### PR TITLE
feat: jb-swap theme toggle + Connect Wallet, move worker dev ports to 33xxx

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -48,6 +48,7 @@
         "@radix-ui/react-slot": "^1.2.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "framer-motion": "^12.23.30",
         "geist": "^1.5.1",
         "lucide-react": "^0.562.0",
         "next": "15.5.9",

--- a/workers/jb-gear/wrangler.jsonc
+++ b/workers/jb-gear/wrangler.jsonc
@@ -22,8 +22,8 @@
 		}
 	],
 	"dev": {
-		"port": 6002,
-		"inspector_port": 6502
+		"port": 33002,
+		"inspector_port": 33502
 	},
 	"observability": {
 		"enabled": true

--- a/workers/jb-swap/package.json
+++ b/workers/jb-swap/package.json
@@ -18,6 +18,7 @@
 		"@radix-ui/react-slot": "^1.2.4",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
+		"framer-motion": "^12.23.30",
 		"geist": "^1.5.1",
 		"lucide-react": "^0.562.0",
 		"next": "15.5.9",

--- a/workers/jb-swap/src/app/globals.css
+++ b/workers/jb-swap/src/app/globals.css
@@ -4,6 +4,10 @@
 
 @layer base {
   :root {
+    /* Easings used by the skiper26 theme-toggle view transitions */
+    --expo-out: cubic-bezier(0.16, 1, 0.3, 1);
+    --expo-in: cubic-bezier(0.7, 0, 0.84, 0);
+
     --background: 0 0% 100%;
     --foreground: 0 0% 3.9%;
 

--- a/workers/jb-swap/src/app/layout.tsx
+++ b/workers/jb-swap/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
 import "./globals.css";
 import { ThemeProvider } from "@/components/theme-provider";
+import { SiteHeader } from "@/components/site-header";
 
 export const metadata: Metadata = {
 	title: "Swap — Joe Blau",
@@ -25,6 +26,7 @@ export default function RootLayout({
 		<html lang="en" suppressHydrationWarning>
 			<body className={`${GeistSans.variable} ${GeistMono.variable} antialiased`}>
 				<ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+					<SiteHeader />
 					{children}
 				</ThemeProvider>
 			</body>

--- a/workers/jb-swap/src/components/site-header.tsx
+++ b/workers/jb-swap/src/components/site-header.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { Wallet } from "lucide-react";
+
+import { ThemeToggleButton } from "@/components/skiper26";
+
+export function SiteHeader() {
+	return (
+		<header className="absolute inset-x-0 top-0 z-50 flex items-center justify-end gap-3 p-4 sm:p-6">
+			<button
+				type="button"
+				className="inline-flex h-10 cursor-pointer items-center justify-center gap-2 rounded-full bg-primary px-5 text-sm font-medium text-primary-foreground shadow-sm transition-all hover:bg-primary/90 active:scale-95"
+			>
+				<Wallet className="size-4" />
+				Connect Wallet
+			</button>
+			<ThemeToggleButton variant="circle" start="center" />
+		</header>
+	);
+}

--- a/workers/jb-swap/src/components/skiper26.tsx
+++ b/workers/jb-swap/src/components/skiper26.tsx
@@ -1,0 +1,778 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { useTheme } from "next-themes";
+import React, { useCallback, useEffect, useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+// ///////////////////////////////////////////////////////////////////////////
+// Custom hook for theme toggle functionality
+export const useThemeToggle = ({
+  variant = "circle",
+  start = "center",
+  blur = false,
+  gifUrl = "",
+}: {
+  variant?: AnimationVariant;
+  start?: AnimationStart;
+  blur?: boolean;
+  gifUrl?: string;
+} = {}) => {
+  const { theme, setTheme, resolvedTheme } = useTheme();
+
+  const [isDark, setIsDark] = useState(false);
+
+  // Sync isDark state with resolved theme after hydration
+  useEffect(() => {
+    setIsDark(resolvedTheme === "dark");
+  }, [resolvedTheme]);
+
+  const styleId = "theme-transition-styles";
+
+  const updateStyles = useCallback((css: string, name: string) => {
+    if (typeof window === "undefined") return;
+
+    let styleElement = document.getElementById(styleId) as HTMLStyleElement;
+
+    if (!styleElement) {
+      styleElement = document.createElement("style");
+      styleElement.id = styleId;
+      document.head.appendChild(styleElement);
+    }
+
+    styleElement.textContent = css;
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setIsDark(!isDark);
+
+    const animation = createAnimation(variant, start, blur, gifUrl);
+
+    updateStyles(animation.css, animation.name);
+
+    if (typeof window === "undefined") return;
+
+    const switchTheme = () => {
+      setTheme(theme === "light" ? "dark" : "light");
+    };
+
+    if (!document.startViewTransition) {
+      switchTheme();
+      return;
+    }
+
+    document.startViewTransition(switchTheme);
+  }, [
+    theme,
+    setTheme,
+    variant,
+    start,
+    blur,
+    gifUrl,
+    updateStyles,
+    isDark,
+    setIsDark,
+  ]);
+
+  const setCrazyLightTheme = useCallback(() => {
+    setIsDark(false);
+
+    const animation = createAnimation(variant, start, blur, gifUrl);
+
+    updateStyles(animation.css, animation.name);
+
+    if (typeof window === "undefined") return;
+
+    const switchTheme = () => {
+      setTheme("light");
+    };
+
+    if (!document.startViewTransition) {
+      switchTheme();
+      return;
+    }
+
+    document.startViewTransition(switchTheme);
+  }, [setTheme, variant, start, blur, gifUrl, updateStyles, setIsDark]);
+
+  const setCrazyDarkTheme = useCallback(() => {
+    setIsDark(true);
+
+    const animation = createAnimation(variant, start, blur, gifUrl);
+
+    updateStyles(animation.css, animation.name);
+
+    if (typeof window === "undefined") return;
+
+    const switchTheme = () => {
+      setTheme("dark");
+    };
+
+    if (!document.startViewTransition) {
+      switchTheme();
+      return;
+    }
+
+    document.startViewTransition(switchTheme);
+  }, [setTheme, variant, start, blur, gifUrl, updateStyles, setIsDark]);
+
+  const setCrazySystemTheme = useCallback(() => {
+    if (typeof window === "undefined") return;
+
+    // Check system preference for dark mode
+    const prefersDark = window.matchMedia(
+      "(prefers-color-scheme: dark)",
+    ).matches;
+    setIsDark(prefersDark);
+
+    const animation = createAnimation(variant, start, blur, gifUrl);
+
+    updateStyles(animation.css, animation.name);
+
+    const switchTheme = () => {
+      setTheme("system");
+    };
+
+    if (!document.startViewTransition) {
+      switchTheme();
+      return;
+    }
+
+    document.startViewTransition(switchTheme);
+  }, [setTheme, variant, start, blur, gifUrl, updateStyles, setIsDark]);
+
+  return {
+    isDark,
+    setIsDark,
+    toggleTheme,
+    setCrazyLightTheme,
+    setCrazyDarkTheme,
+    setCrazySystemTheme,
+  };
+};
+
+// ///////////////////////////////////////////////////////////////////////////
+
+export const ThemeToggleButton = ({
+  className = "",
+  variant = "circle",
+  start = "center",
+  blur = false,
+  gifUrl = "",
+}: {
+  className?: string;
+  variant?: AnimationVariant;
+  start?: AnimationStart;
+  blur?: boolean;
+  gifUrl?: string;
+}) => {
+  const { isDark, toggleTheme } = useThemeToggle({
+    variant,
+    start,
+    blur,
+    gifUrl,
+  });
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        "size-10 cursor-pointer rounded-full bg-black p-0 transition-all duration-300 active:scale-95",
+        className,
+      )}
+      onClick={toggleTheme}
+      aria-label="Toggle theme"
+    >
+      <span className="sr-only">Toggle theme</span>
+      <svg viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <motion.g
+          animate={{ rotate: isDark ? -180 : 0 }}
+          transition={{ ease: "easeInOut", duration: 0.5 }}
+        >
+          <path
+            d="M120 67.5C149.25 67.5 172.5 90.75 172.5 120C172.5 149.25 149.25 172.5 120 172.5"
+            fill="white"
+          />
+          <path
+            d="M120 67.5C90.75 67.5 67.5 90.75 67.5 120C67.5 149.25 90.75 172.5 120 172.5"
+            fill="black"
+          />
+        </motion.g>
+        <motion.path
+          animate={{ rotate: isDark ? 180 : 0 }}
+          transition={{ ease: "easeInOut", duration: 0.5 }}
+          d="M120 3.75C55.5 3.75 3.75 55.5 3.75 120C3.75 184.5 55.5 236.25 120 236.25C184.5 236.25 236.25 184.5 236.25 120C236.25 55.5 184.5 3.75 120 3.75ZM120 214.5V172.5C90.75 172.5 67.5 149.25 67.5 120C67.5 90.75 90.75 67.5 120 67.5V25.5C172.5 25.5 214.5 67.5 214.5 120C214.5 172.5 172.5 214.5 120 214.5Z"
+          fill="white"
+        />
+      </svg>
+    </button>
+  );
+};
+
+// ///////////////////////////////////////////////////////////////////////////
+
+export type AnimationVariant =
+  | "circle"
+  | "rectangle"
+  | "gif"
+  | "polygon"
+  | "circle-blur";
+export type AnimationStart =
+  | "top-left"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-right"
+  | "center"
+  | "top-center"
+  | "bottom-center"
+  | "bottom-up"
+  | "top-down"
+  | "left-right"
+  | "right-left";
+
+interface Animation {
+  name: string;
+  css: string;
+}
+
+const getPositionCoords = (position: AnimationStart) => {
+  switch (position) {
+    case "top-left":
+      return { cx: "0", cy: "0" };
+    case "top-right":
+      return { cx: "40", cy: "0" };
+    case "bottom-left":
+      return { cx: "0", cy: "40" };
+    case "bottom-right":
+      return { cx: "40", cy: "40" };
+    case "top-center":
+      return { cx: "20", cy: "0" };
+    case "bottom-center":
+      return { cx: "20", cy: "40" };
+    // For directional positions, default to center (these are used for rectangle variant)
+    case "bottom-up":
+    case "top-down":
+    case "left-right":
+    case "right-left":
+      return { cx: "20", cy: "20" };
+  }
+};
+
+const generateSVG = (variant: AnimationVariant, start: AnimationStart) => {
+  // circle-blur variant handles center case differently, so check it first
+  if (variant === "circle-blur") {
+    if (start === "center") {
+      return `data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><defs><filter id="blur"><feGaussianBlur stdDeviation="2"/></filter></defs><circle cx="20" cy="20" r="18" fill="white" filter="url(%23blur)"/></svg>`;
+    }
+    const positionCoords = getPositionCoords(start);
+    if (!positionCoords) {
+      throw new Error(`Invalid start position: ${start}`);
+    }
+    const { cx, cy } = positionCoords;
+    return `data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><defs><filter id="blur"><feGaussianBlur stdDeviation="2"/></filter></defs><circle cx="${cx}" cy="${cy}" r="18" fill="white" filter="url(%23blur)"/></svg>`;
+  }
+
+  if (start === "center") return;
+
+  // Rectangle variant doesn't use SVG masks, so return early
+  if (variant === "rectangle") return "";
+
+  const positionCoords = getPositionCoords(start);
+  if (!positionCoords) {
+    throw new Error(`Invalid start position: ${start}`);
+  }
+  const { cx, cy } = positionCoords;
+
+  if (variant === "circle") {
+    return `data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><circle cx="${cx}" cy="${cy}" r="20" fill="white"/></svg>`;
+  }
+
+  return "";
+};
+
+const getTransformOrigin = (start: AnimationStart) => {
+  switch (start) {
+    case "top-left":
+      return "top left";
+    case "top-right":
+      return "top right";
+    case "bottom-left":
+      return "bottom left";
+    case "bottom-right":
+      return "bottom right";
+    case "top-center":
+      return "top center";
+    case "bottom-center":
+      return "bottom center";
+    // For directional positions, default to center
+    case "bottom-up":
+    case "top-down":
+    case "left-right":
+    case "right-left":
+      return "center";
+  }
+};
+
+export const createAnimation = (
+  variant: AnimationVariant,
+  start: AnimationStart = "center",
+  blur = false,
+  url?: string,
+): Animation => {
+  const svg = generateSVG(variant, start);
+  const transformOrigin = getTransformOrigin(start);
+
+  if (variant === "rectangle") {
+    const getClipPath = (direction: AnimationStart) => {
+      switch (direction) {
+        case "bottom-up":
+          return {
+            from: "polygon(0% 100%, 100% 100%, 100% 100%, 0% 100%)",
+            to: "polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%)",
+          };
+        case "top-down":
+          return {
+            from: "polygon(0% 0%, 100% 0%, 100% 0%, 0% 0%)",
+            to: "polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%)",
+          };
+        case "left-right":
+          return {
+            from: "polygon(0% 0%, 0% 0%, 0% 100%, 0% 100%)",
+            to: "polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%)",
+          };
+        case "right-left":
+          return {
+            from: "polygon(100% 0%, 100% 0%, 100% 100%, 100% 100%)",
+            to: "polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%)",
+          };
+        case "top-left":
+          return {
+            from: "polygon(0% 0%, 0% 0%, 0% 0%, 0% 0%)",
+            to: "polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%)",
+          };
+        case "top-right":
+          return {
+            from: "polygon(100% 0%, 100% 0%, 100% 0%, 100% 0%)",
+            to: "polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%)",
+          };
+        case "bottom-left":
+          return {
+            from: "polygon(0% 100%, 0% 100%, 0% 100%, 0% 100%)",
+            to: "polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%)",
+          };
+        case "bottom-right":
+          return {
+            from: "polygon(100% 100%, 100% 100%, 100% 100%, 100% 100%)",
+            to: "polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%)",
+          };
+        default:
+          return {
+            from: "polygon(0% 100%, 100% 100%, 100% 100%, 0% 100%)",
+            to: "polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%)",
+          };
+      }
+    };
+
+    const clipPath = getClipPath(start);
+
+    return {
+      name: `${variant}-${start}${blur ? "-blur" : ""}`,
+      css: `
+       ::view-transition-group(root) {
+        animation-duration: 0.7s;
+        animation-timing-function: var(--expo-out);
+      }
+
+      ::view-transition-new(root) {
+        animation-name: reveal-light-${start}${blur ? "-blur" : ""};
+        ${blur ? "filter: blur(2px);" : ""}
+      }
+
+      ::view-transition-old(root),
+      .dark::view-transition-old(root) {
+        animation: none;
+        z-index: -1;
+      }
+      .dark::view-transition-new(root) {
+        animation-name: reveal-dark-${start}${blur ? "-blur" : ""};
+        ${blur ? "filter: blur(2px);" : ""}
+      }
+
+      @keyframes reveal-dark-${start}${blur ? "-blur" : ""} {
+        from {
+          clip-path: ${clipPath.from};
+          ${blur ? "filter: blur(8px);" : ""}
+        }
+        ${blur ? "50% { filter: blur(4px); }" : ""}
+        to {
+          clip-path: ${clipPath.to};
+          ${blur ? "filter: blur(0px);" : ""}
+        }
+      }
+
+      @keyframes reveal-light-${start}${blur ? "-blur" : ""} {
+        from {
+          clip-path: ${clipPath.from};
+          ${blur ? "filter: blur(8px);" : ""}
+        }
+        ${blur ? "50% { filter: blur(4px); }" : ""}
+        to {
+          clip-path: ${clipPath.to};
+          ${blur ? "filter: blur(0px);" : ""}
+        }
+      }
+      `,
+    };
+  }
+  if (variant === "circle" && start == "center") {
+    return {
+      name: `${variant}-${start}${blur ? "-blur" : ""}`,
+      css: `
+       ::view-transition-group(root) {
+        animation-duration: 0.7s;
+        animation-timing-function: var(--expo-out);
+      }
+
+      ::view-transition-new(root) {
+        animation-name: reveal-light${blur ? "-blur" : ""};
+        ${blur ? "filter: blur(2px);" : ""}
+      }
+
+      ::view-transition-old(root),
+      .dark::view-transition-old(root) {
+        animation: none;
+        z-index: -1;
+      }
+      .dark::view-transition-new(root) {
+        animation-name: reveal-dark${blur ? "-blur" : ""};
+        ${blur ? "filter: blur(2px);" : ""}
+      }
+
+      @keyframes reveal-dark${blur ? "-blur" : ""} {
+        from {
+          clip-path: circle(0% at 50% 50%);
+          ${blur ? "filter: blur(8px);" : ""}
+        }
+        ${blur ? "50% { filter: blur(4px); }" : ""}
+        to {
+          clip-path: circle(100.0% at 50% 50%);
+          ${blur ? "filter: blur(0px);" : ""}
+        }
+      }
+
+      @keyframes reveal-light${blur ? "-blur" : ""} {
+        from {
+           clip-path: circle(0% at 50% 50%);
+           ${blur ? "filter: blur(8px);" : ""}
+        }
+        ${blur ? "50% { filter: blur(4px); }" : ""}
+        to {
+          clip-path: circle(100.0% at 50% 50%);
+          ${blur ? "filter: blur(0px);" : ""}
+        }
+      }
+      `,
+    };
+  }
+  if (variant === "gif") {
+    return {
+      name: `${variant}-${start}`,
+      css: `
+      ::view-transition-group(root) {
+  animation-timing-function: var(--expo-in);
+}
+
+::view-transition-new(root) {
+  mask: url('${url}') center / 0 no-repeat;
+  animation: scale 3s;
+}
+
+::view-transition-old(root),
+.dark::view-transition-old(root) {
+  animation: scale 3s;
+}
+
+@keyframes scale {
+  0% {
+    mask-size: 0;
+  }
+  10% {
+    mask-size: 50vmax;
+  }
+  90% {
+    mask-size: 50vmax;
+  }
+  100% {
+    mask-size: 2000vmax;
+  }
+}`,
+    };
+  }
+
+  if (variant === "circle-blur") {
+    if (start === "center") {
+      return {
+        name: `${variant}-${start}`,
+        css: `
+        ::view-transition-group(root) {
+          animation-timing-function: var(--expo-out);
+        }
+
+        ::view-transition-new(root) {
+          mask: url('${svg}') center / 0 no-repeat;
+          mask-origin: content-box;
+          animation: scale 1s;
+          transform-origin: center;
+        }
+
+        ::view-transition-old(root),
+        .dark::view-transition-old(root) {
+          animation: scale 1s;
+          transform-origin: center;
+          z-index: -1;
+        }
+
+        @keyframes scale {
+          to {
+            mask-size: 350vmax;
+          }
+        }
+        `,
+      };
+    }
+
+    return {
+      name: `${variant}-${start}`,
+      css: `
+      ::view-transition-group(root) {
+        animation-timing-function: var(--expo-out);
+      }
+
+      ::view-transition-new(root) {
+        mask: url('${svg}') ${start.replace("-", " ")} / 0 no-repeat;
+        mask-origin: content-box;
+        animation: scale 1s;
+        transform-origin: ${transformOrigin};
+      }
+
+      ::view-transition-old(root),
+      .dark::view-transition-old(root) {
+        animation: scale 1s;
+        transform-origin: ${transformOrigin};
+        z-index: -1;
+      }
+
+      @keyframes scale {
+        to {
+          mask-size: 350vmax;
+        }
+      }
+      `,
+    };
+  }
+
+  if (variant === "polygon") {
+    const getPolygonClipPaths = (position: AnimationStart) => {
+      switch (position) {
+        case "top-left":
+          return {
+            darkFrom: "polygon(50% -71%, -50% 71%, -50% 71%, 50% -71%)",
+            darkTo: "polygon(50% -71%, -50% 71%, 50% 171%, 171% 50%)",
+            lightFrom: "polygon(171% 50%, 50% 171%, 50% 171%, 171% 50%)",
+            lightTo: "polygon(171% 50%, 50% 171%, -50% 71%, 50% -71%)",
+          };
+        case "top-right":
+          return {
+            darkFrom: "polygon(150% -71%, 250% 71%, 250% 71%, 150% -71%)",
+            darkTo: "polygon(150% -71%, 250% 71%, 50% 171%, -71% 50%)",
+            lightFrom: "polygon(-71% 50%, 50% 171%, 50% 171%, -71% 50%)",
+            lightTo: "polygon(-71% 50%, 50% 171%, 250% 71%, 150% -71%)",
+          };
+        default:
+          // Default to top-left behavior
+          return {
+            darkFrom: "polygon(50% -71%, -50% 71%, -50% 71%, 50% -71%)",
+            darkTo: "polygon(50% -71%, -50% 71%, 50% 171%, 171% 50%)",
+            lightFrom: "polygon(171% 50%, 50% 171%, 50% 171%, 171% 50%)",
+            lightTo: "polygon(171% 50%, 50% 171%, -50% 71%, 50% -71%)",
+          };
+      }
+    };
+
+    const clipPaths = getPolygonClipPaths(start);
+
+    return {
+      name: `${variant}-${start}${blur ? "-blur" : ""}`,
+      css: `
+      ::view-transition-group(root) {
+        animation-duration: 0.7s;
+        animation-timing-function: var(--expo-out);
+      }
+
+      ::view-transition-new(root) {
+        animation-name: reveal-light-${start}${blur ? "-blur" : ""};
+        ${blur ? "filter: blur(2px);" : ""}
+      }
+
+      ::view-transition-old(root),
+      .dark::view-transition-old(root) {
+        animation: none;
+        z-index: -1;
+      }
+      .dark::view-transition-new(root) {
+        animation-name: reveal-dark-${start}${blur ? "-blur" : ""};
+        ${blur ? "filter: blur(2px);" : ""}
+      }
+
+      @keyframes reveal-dark-${start}${blur ? "-blur" : ""} {
+        from {
+          clip-path: ${clipPaths.darkFrom};
+          ${blur ? "filter: blur(8px);" : ""}
+        }
+        ${blur ? "50% { filter: blur(4px); }" : ""}
+        to {
+          clip-path: ${clipPaths.darkTo};
+          ${blur ? "filter: blur(0px);" : ""}
+        }
+      }
+
+      @keyframes reveal-light-${start}${blur ? "-blur" : ""} {
+        from {
+          clip-path: ${clipPaths.lightFrom};
+          ${blur ? "filter: blur(8px);" : ""}
+        }
+        ${blur ? "50% { filter: blur(4px); }" : ""}
+        to {
+          clip-path: ${clipPaths.lightTo};
+          ${blur ? "filter: blur(0px);" : ""}
+        }
+      }
+      `,
+    };
+  }
+
+  // Handle circle variants with start positions using clip-path
+  if (variant === "circle" && start !== "center") {
+    const getClipPathPosition = (position: AnimationStart) => {
+      switch (position) {
+        case "top-left":
+          return "0% 0%";
+        case "top-right":
+          return "100% 0%";
+        case "bottom-left":
+          return "0% 100%";
+        case "bottom-right":
+          return "100% 100%";
+        case "top-center":
+          return "50% 0%";
+        case "bottom-center":
+          return "50% 100%";
+        default:
+          return "50% 50%";
+      }
+    };
+
+    const clipPosition = getClipPathPosition(start);
+
+    return {
+      name: `${variant}-${start}${blur ? "-blur" : ""}`,
+      css: `
+       ::view-transition-group(root) {
+        animation-duration: 1s;
+        animation-timing-function: var(--expo-out);
+      }
+
+      ::view-transition-new(root) {
+        animation-name: reveal-light-${start}${blur ? "-blur" : ""};
+        ${blur ? "filter: blur(2px);" : ""}
+      }
+
+      ::view-transition-old(root),
+      .dark::view-transition-old(root) {
+        animation: none;
+        z-index: -1;
+      }
+      .dark::view-transition-new(root) {
+        animation-name: reveal-dark-${start}${blur ? "-blur" : ""};
+        ${blur ? "filter: blur(2px);" : ""}
+      }
+
+      @keyframes reveal-dark-${start}${blur ? "-blur" : ""} {
+        from {
+          clip-path: circle(0% at ${clipPosition});
+          ${blur ? "filter: blur(8px);" : ""}
+        }
+        ${blur ? "50% { filter: blur(4px); }" : ""}
+        to {
+          clip-path: circle(150.0% at ${clipPosition});
+          ${blur ? "filter: blur(0px);" : ""}
+        }
+      }
+
+      @keyframes reveal-light-${start}${blur ? "-blur" : ""} {
+        from {
+           clip-path: circle(0% at ${clipPosition});
+           ${blur ? "filter: blur(8px);" : ""}
+        }
+        ${blur ? "50% { filter: blur(4px); }" : ""}
+        to {
+          clip-path: circle(150.0% at ${clipPosition});
+          ${blur ? "filter: blur(0px);" : ""}
+        }
+      }
+      `,
+    };
+  }
+
+  return {
+    name: `${variant}-${start}${blur ? "-blur" : ""}`,
+    css: `
+      ::view-transition-group(root) {
+        animation-timing-function: var(--expo-in);
+      }
+      ::view-transition-new(root) {
+        mask: url('${svg}') ${start.replace("-", " ")} / 0 no-repeat;
+        mask-origin: content-box;
+        animation: scale-${start}${blur ? "-blur" : ""} 1s;
+        transform-origin: ${transformOrigin};
+        ${blur ? "filter: blur(2px);" : ""}
+      }
+      ::view-transition-old(root),
+      .dark::view-transition-old(root) {
+        animation: scale-${start}${blur ? "-blur" : ""} 1s;
+        transform-origin: ${transformOrigin};
+        z-index: -1;
+      }
+      @keyframes scale-${start}${blur ? "-blur" : ""} {
+        from {
+          ${blur ? "filter: blur(8px);" : ""}
+        }
+        ${blur ? "50% { filter: blur(4px); }" : ""}
+        to {
+          mask-size: 2000vmax;
+          ${blur ? "filter: blur(0px);" : ""}
+        }
+      }
+    `,
+  };
+};
+
+/**
+ * Skiper 26 Theme_buttons_002 — React + CSS + transition view api  https://developer.chrome.com/docs/web-platform/view-transitions/
+ * Orignal concept from rudrodip
+ * Inspired by from https://github.com/rudrodip/theme-toggle-effect
+ * We respect the original creators. This is an inspired rebuild with our own taste and does not claim any ownership.
+ * These animations aren't associated with the rudrodip . They're independent recreations meant to study interaction design
+ *
+ * License & Usage:
+ * - Free to use and modify in both personal and commercial projects.
+ * - Attribution to Skiper UI is required when using the free version.
+ * - No attribution required with Skiper UI Pro.
+ *
+ * Feedback and contributions are welcome.
+ *
+ * Author: @gurvinder-singh02
+ * Website: https://gxuri.in
+ * Twitter: https://x.com/Gur__vi
+ */

--- a/workers/jb-swap/wrangler.jsonc
+++ b/workers/jb-swap/wrangler.jsonc
@@ -22,8 +22,8 @@
 		}
 	],
 	"dev": {
-		"port": 6003,
-		"inspector_port": 6503
+		"port": 33003,
+		"inspector_port": 33503
 	},
 	"observability": {
 		"enabled": true

--- a/workers/jb-travel/wrangler.jsonc
+++ b/workers/jb-travel/wrangler.jsonc
@@ -22,8 +22,8 @@
 		}
 	],
 	"dev": {
-		"port": 6001,
-		"inspector_port": 6501
+		"port": 33001,
+		"inspector_port": 33501
 	},
 	"observability": {
 		"enabled": true

--- a/workers/jb-www/wrangler.jsonc
+++ b/workers/jb-www/wrangler.jsonc
@@ -22,8 +22,8 @@
 		}
 	],
 	"dev": {
-		"port": 6000,
-		"inspector_port": 6500
+		"port": 33000,
+		"inspector_port": 33500
 	},
 	"observability": {
 		"enabled": true


### PR DESCRIPTION
## Summary

Two changes to the **jb-swap** worker plus a repo-wide dev-port tidy:

1. Adds a top-right header with the [Skiper UI skiper26](https://skiper-ui.com/v1/skiper26) theme-toggle button next to a full-capsule **Connect Wallet** button.
2. Moves every worker's local dev ports from `600x`/`650x` into the `33xxx` range.

## Theme toggle + Connect Wallet (jb-swap)

- **`skiper26.tsx`** — the skiper26 component: `ThemeToggleButton` (animated yin-yang circle), the `useThemeToggle` hook, and the `createAnimation` engine driving the View Transition API circle-reveal. Faithful to the registry source, including the required Skiper UI attribution header.
- **`site-header.tsx`** — top-right header (`absolute inset-x-0 top-0 justify-end`) with a `rounded-full` Connect Wallet capsule (wallet icon) and the theme toggle, wired into the root layout.
- **`globals.css`** — adds the `--expo-out` / `--expo-in` easings the transitions reference.
- **`framer-motion`** dependency (required by skiper26).

## Dev ports → 33xxx (all workers)

Rebased the wrangler `dev` block ports, preserving the per-worker index and +500 inspector offset:

| worker | port | inspector_port |
|---|---|---|
| jb-www | 33000 | 33500 |
| jb-travel | 33001 | 33501 |
| jb-gear | 33002 | 33502 |
| jb-swap | 33003 | 33503 |

Dev-only config; does not affect production deploys.

## Verification

- `bun run cf-build` (OpenNext) succeeds; both controls render in the prerendered HTML and the easings are present in the compiled CSS.
- Verified live in Chrome: the capsule + toggle sit top-right; clicking the toggle switches dark↔light and the Connect Wallet capsule inverts with the theme.

## Note

Under headless/background automation the console logs `InvalidStateError: Transition was aborted because of invalid state` — this is Chrome intentionally skipping view transitions when `document.visibilityState === "hidden"`; the theme switch still completes (`finished` resolves). A focused tab gets the full animation and no error, so the component is left faithful to source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)