### PR TITLE
feat: To-side token selector, subtle scrollbar, 48px flip button

### DIFF
--- a/workers/jb-swap/src/app/globals.css
+++ b/workers/jb-swap/src/app/globals.css
@@ -80,3 +80,22 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* Subtle, theme-aware scrollbar (shadcn-style) */
+.scrollbar-subtle {
+  scrollbar-width: thin;
+  scrollbar-color: hsl(var(--muted-foreground) / 0.25) transparent;
+}
+.scrollbar-subtle::-webkit-scrollbar {
+  width: 6px;
+}
+.scrollbar-subtle::-webkit-scrollbar-track {
+  background: transparent;
+}
+.scrollbar-subtle::-webkit-scrollbar-thumb {
+  border-radius: 9999px;
+  background-color: hsl(var(--muted-foreground) / 0.25);
+}
+.scrollbar-subtle::-webkit-scrollbar-thumb:hover {
+  background-color: hsl(var(--muted-foreground) / 0.4);
+}

--- a/workers/jb-swap/src/components/swap-card.tsx
+++ b/workers/jb-swap/src/components/swap-card.tsx
@@ -1,70 +1,12 @@
-import { ArrowUpDown, SlidersHorizontal } from "lucide-react";
+import { ArrowUpDown } from "lucide-react";
 
-import { FromBox } from "@/components/token-drawer";
+import { TokenBox } from "@/components/token-drawer";
 
-/**
- * Visual scaffold for the swap interface. Static, non-functional —
- * placeholder values only, no wiring to wallets, quotes, or routing.
- */
-
-const WALLET_ADDRESS = "0x71C7656EC7ab88b098defB751B7401B5f6d8976F";
-
-function shortenAddress(address: string) {
-	return `${address.slice(0, 4)}•••${address.slice(-4)}`;
-}
-
-function TokenStack({ variant }: { variant: "eth" | "usdc" }) {
+function Pill({ children }: { children: React.ReactNode }) {
 	return (
-		<div className="relative h-[68px] w-9 shrink-0">
-			<div className="absolute left-1/2 top-0 size-9 -translate-x-1/2 rounded-full bg-gradient-to-b from-sky-400 to-blue-600 ring-2 ring-background" />
-			<div className="absolute left-1/2 top-4 flex size-9 -translate-x-1/2 items-center justify-center rounded-full bg-blue-500 text-[10px] text-white ring-2 ring-background">
-				▲
-			</div>
-			<div
-				className={`absolute left-1/2 top-8 flex size-9 -translate-x-1/2 items-center justify-center rounded-full text-sm font-semibold text-white ring-2 ring-background ${
-					variant === "eth" ? "bg-[#131a2a]" : "bg-[#2775ca]"
-				}`}
-			>
-				{variant === "eth" ? "◆" : "$"}
-			</div>
-		</div>
-	);
-}
-
-function Pill({
-	children,
-	className = "",
-}: {
-	children: React.ReactNode;
-	className?: string;
-}) {
-	return (
-		<span
-			className={`inline-flex items-center gap-1.5 rounded-full bg-foreground/[0.07] px-3 py-1.5 text-sm text-muted-foreground ${className}`}
-		>
+		<span className="inline-flex items-center gap-1.5 rounded-full bg-foreground/[0.07] px-3 py-1.5 text-sm text-muted-foreground">
 			{children}
 		</span>
-	);
-}
-
-function TokenInfo({
-	variant,
-	name,
-}: {
-	variant: "eth" | "usdc";
-	name: string;
-}) {
-	return (
-		<div className="flex gap-3">
-			<TokenStack variant={variant} />
-			<div className="flex flex-col leading-none -space-y-0.5">
-				<span className="text-sm text-muted-foreground">
-					{shortenAddress(WALLET_ADDRESS)}
-				</span>
-				<span className="text-sm text-muted-foreground">Ethereum</span>
-				<span className="text-xl font-semibold text-foreground">{name}</span>
-			</div>
-		</div>
 	);
 }
 
@@ -73,7 +15,10 @@ export function SwapCard() {
 		<div className="w-full max-w-md">
 			{/* You pay */}
 			<section className="rounded-3xl bg-card px-5 pb-8 pt-5">
-				<FromBox />
+				<TokenBox
+					variant="from"
+					triggerClassName="-mx-5 -mt-5 w-[calc(100%+2.5rem)] rounded-t-3xl px-5 pb-5 pt-5 hover:bg-foreground/[0.03]"
+				/>
 				<div className="-mx-5 mb-2 border-t-2 border-background" />
 				<div className="flex flex-col items-center gap-3">
 					<span className="text-6xl font-bold tracking-tight text-foreground">
@@ -87,10 +32,10 @@ export function SwapCard() {
 			</section>
 
 			{/* Swap direction */}
-			<div className="relative z-10 mx-auto -my-5 flex w-fit">
+			<div className="relative z-10 mx-auto -my-4 flex w-fit">
 				<button
 					type="button"
-					className="flex size-14 items-center justify-center rounded-full bg-blue-500 text-white ring-4 ring-card transition-colors hover:bg-blue-600"
+					className="flex size-12 items-center justify-center rounded-full bg-blue-500 text-white ring-4 ring-card transition-colors hover:bg-blue-600"
 					aria-label="Swap direction"
 				>
 					<ArrowUpDown className="size-5" />
@@ -99,17 +44,11 @@ export function SwapCard() {
 
 			{/* You receive */}
 			<section className="rounded-3xl bg-card px-5 pb-5 pt-8">
-				<div className="flex items-start justify-between">
-					<TokenInfo variant="usdc" name="USD Coin" />
-					<div className="flex flex-col items-end gap-2">
-						<Pill>
-							<SlidersHorizontal className="size-3.5" />
-							Slippage 0.5%
-						</Pill>
-						<span className="text-sm text-muted-foreground">Fee $0.25</span>
-					</div>
-				</div>
-				<div className="-mx-5 mt-5 mb-2 border-t-2 border-background" />
+				<TokenBox
+					variant="to"
+					triggerClassName="-mx-5 -mt-8 w-[calc(100%+2.5rem)] rounded-t-3xl px-5 pb-5 pt-8 hover:bg-foreground/[0.03]"
+				/>
+				<div className="-mx-5 mb-2 border-t-2 border-background" />
 				<div className="flex flex-col items-center gap-3">
 					<span className="text-6xl font-bold tracking-tight text-muted-foreground">
 						81.9534

--- a/workers/jb-swap/src/components/token-drawer.tsx
+++ b/workers/jb-swap/src/components/token-drawer.tsx
@@ -1,20 +1,23 @@
 "use client";
 
 import Avatar from "boring-avatars";
-import { FlaskConical, Lock, Search, X } from "lucide-react";
+import { FlaskConical, Lock, Scan, Search, SlidersHorizontal, X } from "lucide-react";
 import { useState } from "react";
 import { Drawer } from "vaul";
 
 import { cn } from "@/lib/utils";
 
 /**
- * Stateful "From" token selector. Before a token is picked it shows a
- * "From..." placeholder; picking a token swaps it for a stacked icon
- * (Boring Avatar + chain + asset) alongside the address / chain / name,
- * plus Test/Max and holdings. Static data — no real search or balances.
- * Asset and chain icons come from Relay's icon CDN; the address avatar
- * is generated with boring-avatars.
+ * Stateful token selector used for both the "From" and "To" sides. Before a
+ * token is picked it shows a "From..." / "To..." placeholder; picking a token
+ * swaps in a stacked icon (Boring Avatar + chain + asset) with the address /
+ * chain / name plus side-specific meta (Test/Max + holdings for From,
+ * Slippage/Fee for To). The "To" drawer adds an enter/paste address field with
+ * a QR scanner. Static data — asset/chain icons come from Relay's icon CDN and
+ * the address avatar is generated with boring-avatars.
  */
+
+type Variant = "from" | "to";
 
 interface TokenRow {
 	name: string;
@@ -64,8 +67,8 @@ function tokenKey(t: TokenRow) {
 }
 
 function ChainBadge({ chainId, className }: { chainId: number; className?: string }) {
-	// eslint-disable-next-line @next/next/no-img-element
 	return (
+		// eslint-disable-next-line @next/next/no-img-element
 		<img
 			src={chainIcon(chainId)}
 			alt=""
@@ -118,7 +121,35 @@ function Pill({ children }: { children: React.ReactNode }) {
 	);
 }
 
-function SelectedHeader({ token }: { token: TokenRow }) {
+function SelectedMeta({ variant, token }: { variant: Variant; token: TokenRow }) {
+	if (variant === "to") {
+		return (
+			<div className="flex flex-col items-end gap-2">
+				<Pill>
+					<SlidersHorizontal className="size-3.5" />
+					Slippage 0.5%
+				</Pill>
+				<span className="text-sm text-muted-foreground">Fee $0.25</span>
+			</div>
+		);
+	}
+	return (
+		<div className="flex flex-col items-end gap-2">
+			<div className="flex gap-2">
+				<Pill>
+					<FlaskConical className="size-3.5" />
+					Test
+				</Pill>
+				<Pill>Max</Pill>
+			</div>
+			<span className="text-sm text-muted-foreground">
+				{token.amount} {token.symbol}
+			</span>
+		</div>
+	);
+}
+
+function SelectedHeader({ variant, token }: { variant: Variant; token: TokenRow }) {
 	return (
 		<div className="flex items-start justify-between">
 			<div className="flex items-center gap-3">
@@ -129,38 +160,37 @@ function SelectedHeader({ token }: { token: TokenRow }) {
 					<span className="text-xl font-semibold text-foreground">{token.name}</span>
 				</div>
 			</div>
-			<div className="flex flex-col items-end gap-2">
-				<div className="flex gap-2">
-					<Pill>
-						<FlaskConical className="size-3.5" />
-						Test
-					</Pill>
-					<Pill>Max</Pill>
-				</div>
-				<span className="text-sm text-muted-foreground">
-					{token.amount} {token.symbol}
-				</span>
-			</div>
+			<SelectedMeta variant={variant} token={token} />
 		</div>
 	);
 }
 
-export function FromBox() {
+export function TokenBox({
+	variant,
+	triggerClassName,
+}: {
+	variant: Variant;
+	triggerClassName?: string;
+}) {
 	const [open, setOpen] = useState(false);
 	const [selected, setSelected] = useState<TokenRow | null>(null);
+	const label = variant === "from" ? "From" : "To";
 
 	return (
 		<Drawer.Root open={open} onOpenChange={setOpen}>
 			<button
 				type="button"
 				onClick={() => setOpen(true)}
-				className="-mx-5 -mt-5 block w-[calc(100%+2.5rem)] cursor-pointer rounded-t-3xl px-5 pb-5 pt-5 text-left transition-colors hover:bg-foreground/[0.03]"
+				className={cn(
+					"block cursor-pointer text-left transition-colors",
+					triggerClassName,
+				)}
 			>
 				{selected ? (
-					<SelectedHeader token={selected} />
+					<SelectedHeader variant={variant} token={selected} />
 				) : (
 					<span className="block text-5xl font-semibold text-muted-foreground">
-						From...
+						{label}...
 					</span>
 				)}
 			</button>
@@ -176,22 +206,39 @@ export function FromBox() {
 					<div className="flex flex-col gap-4 px-5 pt-4">
 						<div className="flex items-center justify-between">
 							<Drawer.Title className="text-2xl font-bold text-foreground">
-								From
+								{label}
 							</Drawer.Title>
 							<Drawer.Close className="flex size-9 cursor-pointer items-center justify-center rounded-full bg-foreground/10 text-muted-foreground transition-colors hover:bg-foreground/15">
 								<X className="size-5" />
 							</Drawer.Close>
 						</div>
 
-						<div className="flex items-center gap-3 rounded-2xl bg-foreground/[0.06] px-4 py-3.5">
-							<div className="size-7 shrink-0 overflow-hidden rounded-full">
-								<Avatar size={28} name={ADDRESS} variant="marble" colors={AVATAR_COLORS} />
+						{variant === "from" ? (
+							<div className="flex items-center gap-3 rounded-2xl bg-foreground/[0.06] px-4 py-3.5">
+								<div className="size-7 shrink-0 overflow-hidden rounded-full">
+									<Avatar size={28} name={ADDRESS} variant="marble" colors={AVATAR_COLORS} />
+								</div>
+								<span className="flex-1 text-lg font-semibold text-foreground">
+									0x71C7...976F
+								</span>
+								<Lock className="size-4 text-muted-foreground" />
 							</div>
-							<span className="flex-1 text-lg font-semibold text-foreground">
-								0x71C7...976F
-							</span>
-							<Lock className="size-4 text-muted-foreground" />
-						</div>
+						) : (
+							<div className="flex items-stretch gap-2">
+								<input
+									type="text"
+									placeholder="Enter or paste address"
+									className="flex-1 rounded-2xl bg-foreground/[0.06] px-4 py-3.5 text-base text-foreground placeholder:text-muted-foreground focus:outline-none"
+								/>
+								<button
+									type="button"
+									aria-label="Scan QR code"
+									className="flex aspect-square shrink-0 cursor-pointer items-center justify-center rounded-2xl bg-foreground/[0.06] text-muted-foreground transition-colors hover:bg-foreground/10"
+								>
+									<Scan className="size-5" />
+								</button>
+							</div>
+						)}
 
 						<div className="flex items-center gap-3 rounded-2xl bg-foreground/[0.06] px-4 py-3">
 							<Search className="size-5 shrink-0 text-muted-foreground" />
@@ -230,7 +277,7 @@ export function FromBox() {
 						</div>
 					</div>
 
-					<div className="mt-2 flex-1 overflow-y-auto px-5 pb-8">
+					<div className="scrollbar-subtle mt-2 flex-1 overflow-y-auto px-5 pb-8">
 						{TOKENS.map((t) => {
 							const isSelected = selected !== null && tokenKey(selected) === tokenKey(t);
 							return (


### PR DESCRIPTION
## Summary

Extends the from-side token selector to the **To** side, restyles the drawer scrollbar, and shrinks the swap-direction button.

## What's included

- **`TokenBox` (token-drawer.tsx)** — generalized `FromBox` into one component with `from`/`to` variants:
  - The **To** box shows a "To..." placeholder; clicking its top opens a drawer with an **"Enter or paste address" field + QR-scanner button**, then search, chain filter chips, and the token list.
  - Selecting a token swaps in the `AssetStack` (Boring Avatar + chain + asset) + address/chain/name, with **Slippage/Fee** as the To-side meta (vs Test/Max + holdings on From). From and To hold independent state.
- **Subtle scrollbar (globals.css)** — added a shadcn-style `.scrollbar-subtle` utility (thin, rounded, theme-aware via `--muted-foreground`) applied to the drawer token list, replacing the thick OS scrollbar.
- **Flip button → 48px (swap-card.tsx)** — the swap-direction circle is now `size-12` (matching the Send button height), recentered on the seam (`-my-4`).

## Verification

- `bun run cf-build` (OpenNext) succeeds.
- Verified live in Chrome: From + To placeholders render; To drawer shows the address input + QR scanner with the subtle scrollbar; selecting a To token shows the AssetStack + Slippage/Fee; flip button renders at 48px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)