### PR TITLE
feat: swap quote engine, denomination toggle, keypad, and haptics

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -44,6 +44,7 @@
       "name": "jb-swap",
       "version": "0.1.0",
       "dependencies": {
+        "@number-flow/react": "^0.6.0",
         "@opennextjs/cloudflare": "^1.14.4",
         "@radix-ui/react-slot": "^1.2.4",
         "@relayprotocol/relay-sdk": "^5.2.7",
@@ -652,7 +653,7 @@
 
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
 
-    "@number-flow/react": ["@number-flow/react@0.5.14", "", { "dependencies": { "esm-env": "^1.1.4", "number-flow": "0.5.12" }, "peerDependencies": { "react": "^18 || ^19", "react-dom": "^18 || ^19" } }, "sha512-FGUqjh/P5/ukr0U0ySwb987M0SbRkrnZq70f0wQFncDbXa3SIib4L+FTr5ngvWwGAW8S6b391eTXcfhErZsw4w=="],
+    "@number-flow/react": ["@number-flow/react@0.6.0", "", { "dependencies": { "esm-env": "^1.1.4", "number-flow": "0.6.0" }, "peerDependencies": { "react": "^18 || ^19", "react-dom": "^18 || ^19" } }, "sha512-77Yfc9+zkV2UDSP8phhZzxJGuwxi/Tt1TikmipL+1r3e9GFKEYDZ1XwInj67NoSt3OnOB0KLvvcl3lfPZgBHVQ=="],
 
     "@opennextjs/aws": ["@opennextjs/aws@3.9.16", "", { "dependencies": { "@ast-grep/napi": "^0.40.5", "@aws-sdk/client-cloudfront": "3.984.0", "@aws-sdk/client-dynamodb": "3.984.0", "@aws-sdk/client-lambda": "3.984.0", "@aws-sdk/client-s3": "3.984.0", "@aws-sdk/client-sqs": "3.984.0", "@node-minify/core": "^8.0.6", "@node-minify/terser": "^8.0.6", "@tsconfig/node18": "^1.0.3", "aws4fetch": "^1.0.20", "chalk": "^5.6.2", "cookie": "^1.0.2", "esbuild": "0.25.4", "express": "^5.1.0", "path-to-regexp": "^6.3.0", "urlpattern-polyfill": "^10.1.0", "yaml": "^2.8.1" }, "peerDependencies": { "next": "~15.0.8 || ~15.1.12 || ~15.2.9 || ~15.3.9 || ~15.4.11 || ~15.5.10 || ~16.0.11 || ^16.1.5" }, "bin": { "open-next": "dist/index.js" } }, "sha512-jQQStCysIllNCPqz5W2KSguXpr+ETlOcD8SyNu+h9zwpRVYk4uEPQge+ErG3avI5xsT8vKA7EGLYG59dhj/B6Q=="],
 
@@ -2158,7 +2159,7 @@
 
     "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
 
-    "number-flow": ["number-flow@0.5.12", "", { "dependencies": { "esm-env": "^1.1.4" } }, "sha512-CIs21h2JkfYG4rfgERaUNAk0Cz+Ef14fNJfSCbGGhgRgconQc9b7rcCQfi9SZ36kNjVXmsl2BrzDbjGtEgumAA=="],
+    "number-flow": ["number-flow@0.6.0", "", { "dependencies": { "esm-env": "^1.1.4" } }, "sha512-K8flNq2Wqus53vjp/btVo3qXFkagF8dIdYavreBfE7hlvFFG/b1HMGEH6nZL+mlrJ+4lbLP9OmPv3t2rmRkpSQ=="],
 
     "nypm": ["nypm@0.6.5", "", { "dependencies": { "citty": "^0.2.0", "pathe": "^2.0.3", "tinyexec": "^1.0.2" }, "bin": { "nypm": "dist/cli.mjs" } }, "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ=="],
 
@@ -2870,6 +2871,8 @@
 
     "is-bun-module/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "jb-travel/@number-flow/react": ["@number-flow/react@0.5.14", "", { "dependencies": { "esm-env": "^1.1.4", "number-flow": "0.5.12" }, "peerDependencies": { "react": "^18 || ^19", "react-dom": "^18 || ^19" } }, "sha512-FGUqjh/P5/ukr0U0ySwb987M0SbRkrnZq70f0wQFncDbXa3SIib4L+FTr5ngvWwGAW8S6b391eTXcfhErZsw4w=="],
+
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
     "libsql/detect-libc": ["detect-libc@2.0.2", "", {}, "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw=="],
@@ -3045,6 +3048,8 @@
     "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "glob/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
+
+    "jb-travel/@number-flow/react/number-flow": ["number-flow@0.5.12", "", { "dependencies": { "esm-env": "^1.1.4" } }, "sha512-CIs21h2JkfYG4rfgERaUNAk0Cz+Ef14fNJfSCbGGhgRgconQc9b7rcCQfi9SZ36kNjVXmsl2BrzDbjGtEgumAA=="],
 
     "mongodb-connection-string-url/whatwg-url/tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
 

--- a/workers/jb-swap/package.json
+++ b/workers/jb-swap/package.json
@@ -14,6 +14,7 @@
 		"preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview"
 	},
 	"dependencies": {
+		"@number-flow/react": "^0.6.0",
 		"@opennextjs/cloudflare": "^1.14.4",
 		"@radix-ui/react-slot": "^1.2.4",
 		"@relayprotocol/relay-sdk": "^5.2.7",

--- a/workers/jb-swap/src/app/page.tsx
+++ b/workers/jb-swap/src/app/page.tsx
@@ -2,7 +2,7 @@ import { SwapCard } from "@/components/swap-card";
 
 export default function Home() {
 	return (
-		<main className="flex min-h-screen items-center justify-center p-6">
+		<main className="flex min-h-screen flex-col items-center px-6 pb-6 pt-18">
 			<SwapCard />
 		</main>
 	);

--- a/workers/jb-swap/src/components/haptic-button.tsx
+++ b/workers/jb-swap/src/components/haptic-button.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import type { ComponentProps } from "react";
+import { useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * A button that plays a native iOS haptic tick on tap, using the Project Fathom
+ * technique (https://github.com/m1ckc3s/project-fathom): an invisible WebKit
+ * `<input type="checkbox" switch>` is overlaid on the button. Tapping the switch
+ * makes iOS (Safari 17.4+ / iOS 18+) play a system haptic, and its change
+ * handler forwards the tap to the real button so existing behavior is kept.
+ * On non-WebKit browsers the switch is an ordinary (invisible) checkbox and the
+ * click-forwarding still works, so it's a no-op visually/behaviorally elsewhere.
+ *
+ * The button and the switch share a single CSS grid cell so the switch always
+ * matches the button's size without changing layout. `wrapperClassName` controls
+ * the wrapper's display/width (e.g. "grid w-full" for full-width buttons).
+ */
+export function HapticButton({
+	className,
+	children,
+	wrapperClassName = "inline-grid",
+	disabled,
+	...props
+}: ComponentProps<"button"> & { wrapperClassName?: string }) {
+	const ref = useRef<HTMLButtonElement>(null);
+	return (
+		<span className={cn("relative [&>*]:[grid-area:1/1]", wrapperClassName)}>
+			<button ref={ref} className={className} disabled={disabled} {...props}>
+				{children}
+			</button>
+			<input
+				type="checkbox"
+				aria-hidden="true"
+				tabIndex={-1}
+				ref={(el) => el?.setAttribute("switch", "")}
+				onChange={() => ref.current?.click()}
+				className={cn(
+					"m-0 size-full opacity-0 [clip-path:inset(0_round_999px)] [-webkit-tap-highlight-color:transparent]",
+					disabled ? "pointer-events-none" : "cursor-pointer",
+				)}
+				style={{ touchAction: "manipulation" }}
+			/>
+		</span>
+	);
+}

--- a/workers/jb-swap/src/components/keypad.tsx
+++ b/workers/jb-swap/src/components/keypad.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import { Delete } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { HapticButton } from "@/components/haptic-button";
+
+/**
+ * Numeric keypad shown only in mobile-width viewports (below md). It animates
+ * in when the viewport compresses to mobile and out when it widens. Keys emit
+ * "0"-"9", ".", or "back" to the parent.
+ */
+
+const KEYS = ["1", "2", "3", "4", "5", "6", "7", "8", "9", ".", "0", "back"];
+
+export function MobileKeypad({ onKey }: { onKey: (key: string) => void }) {
+	const [isMobile, setIsMobile] = useState(false);
+
+	useEffect(() => {
+		const mq = window.matchMedia("(max-width: 767px)");
+		const update = () => setIsMobile(mq.matches);
+		update();
+		mq.addEventListener("change", update);
+		return () => mq.removeEventListener("change", update);
+	}, []);
+
+	return (
+		<AnimatePresence initial={false}>
+			{isMobile && (
+				<motion.div
+					initial={{ opacity: 0, height: 0, y: 16 }}
+					animate={{ opacity: 1, height: "auto", y: 0 }}
+					exit={{ opacity: 0, height: 0, y: 16 }}
+					transition={{ duration: 0.12, ease: "easeOut" }}
+					className="overflow-hidden"
+				>
+					<div className="grid grid-cols-3 pt-3">
+						{KEYS.map((k) => (
+							<HapticButton
+								key={k}
+								wrapperClassName="grid"
+								type="button"
+								onClick={() => onKey(k)}
+								aria-label={k === "back" ? "Delete" : k}
+								className="flex h-16 items-center justify-center rounded-2xl text-2xl font-semibold text-foreground transition-colors active:bg-foreground/10"
+							>
+								{k === "back" ? <Delete className="size-6" /> : k}
+							</HapticButton>
+						))}
+					</div>
+				</motion.div>
+			)}
+		</AnimatePresence>
+	);
+}

--- a/workers/jb-swap/src/components/site-header.tsx
+++ b/workers/jb-swap/src/components/site-header.tsx
@@ -2,19 +2,20 @@
 
 import { Wallet } from "lucide-react";
 
+import { HapticButton } from "@/components/haptic-button";
 import { ThemeToggleButton } from "@/components/skiper26";
 
 export function SiteHeader() {
 	return (
-		<header className="absolute inset-x-0 top-0 z-50 flex items-center justify-between gap-3 p-4 sm:p-6">
+		<header className="absolute inset-x-0 top-0 z-50 flex items-center justify-between gap-3 p-4 sm:px-6">
 			<ThemeToggleButton variant="circle" start="center" blur />
-			<button
+			<HapticButton
 				type="button"
 				className="inline-flex h-10 cursor-pointer items-center justify-center gap-2 rounded-full bg-primary px-5 text-sm font-medium text-primary-foreground shadow-sm transition-all hover:bg-primary/90 active:scale-95"
 			>
 				<Wallet className="size-4" />
 				Connect Wallet
-			</button>
+			</HapticButton>
 		</header>
 	);
 }

--- a/workers/jb-swap/src/components/slippage-drawer.tsx
+++ b/workers/jb-swap/src/components/slippage-drawer.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { X } from "lucide-react";
+import { Drawer } from "vaul";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Controlled slippage picker drawer. Styled like the token drawer (bg-card
+ * content, drag handle, Drawer.Title, Drawer.Close X). Exposes preset chips
+ * (0.1% / 0.5% / 1.0%) plus a custom "%" input. All values flow in/out as a
+ * FRACTION (0.5% = 0.005); the UI converts to/from percent for display.
+ */
+
+const PRESETS = [0.001, 0.005, 0.01]; // 0.1% / 0.5% / 1.0% as fractions
+
+/** Format a fraction as a percent string with trailing zeros trimmed. */
+function formatPct(fraction: number) {
+	return `${Number((fraction * 100).toFixed(4))}%`;
+}
+
+export function SlippageDrawer({
+	open,
+	onOpenChange,
+	value,
+	onChange,
+}: {
+	open: boolean;
+	onOpenChange: (o: boolean) => void;
+	value: number;
+	onChange: (v: number) => void;
+}) {
+	const handleCustom = (raw: string) => {
+		const pct = Number.parseFloat(raw);
+		if (Number.isFinite(pct) && pct >= 0) onChange(pct / 100);
+	};
+
+	return (
+		<Drawer.Root open={open} onOpenChange={onOpenChange}>
+			<Drawer.Portal>
+				<Drawer.Overlay className="fixed inset-0 z-50 bg-black/60" />
+				<Drawer.Content
+					aria-describedby={undefined}
+					className="fixed inset-x-0 bottom-0 z-50 mx-auto flex max-w-md flex-col rounded-t-3xl bg-card outline-none"
+				>
+					<div className="mx-auto mt-3 h-1.5 w-12 shrink-0 rounded-full bg-foreground/20" />
+
+					<div className="flex flex-col gap-5 px-5 pb-8 pt-4">
+						<div className="flex items-center justify-between">
+							<Drawer.Title className="text-2xl font-bold text-foreground">
+								Slippage
+							</Drawer.Title>
+							<Drawer.Close className="flex size-9 cursor-pointer items-center justify-center rounded-full bg-foreground/10 text-muted-foreground transition-colors hover:bg-foreground/15">
+								<X className="size-5" />
+							</Drawer.Close>
+						</div>
+
+						<div className="flex gap-2">
+							{PRESETS.map((preset) => {
+								const active = Math.abs(value - preset) < 1e-9;
+								return (
+									<button
+										key={preset}
+										type="button"
+										onClick={() => onChange(preset)}
+										className={cn(
+											"flex flex-1 cursor-pointer items-center justify-center rounded-full px-4 py-2.5 text-sm font-semibold transition-colors",
+											active
+												? "bg-foreground text-background"
+												: "bg-foreground/[0.06] text-foreground hover:bg-foreground/10",
+										)}
+									>
+										{formatPct(preset)}
+									</button>
+								);
+							})}
+						</div>
+
+						<div className="flex items-center gap-3 rounded-2xl bg-foreground/[0.06] px-4 py-3.5">
+							<input
+								type="number"
+								inputMode="decimal"
+								min={0}
+								step="0.1"
+								value={Number((value * 100).toFixed(4))}
+								onChange={(e) => handleCustom(e.target.value)}
+								placeholder="Custom"
+								className="flex-1 bg-transparent text-base text-foreground placeholder:text-muted-foreground focus:outline-none"
+							/>
+							<span className="shrink-0 text-base font-semibold text-muted-foreground">
+								%
+							</span>
+						</div>
+					</div>
+				</Drawer.Content>
+			</Drawer.Portal>
+		</Drawer.Root>
+	);
+}

--- a/workers/jb-swap/src/components/swap-card.tsx
+++ b/workers/jb-swap/src/components/swap-card.tsx
@@ -1,31 +1,239 @@
+"use client";
+
+import NumberFlow from "@number-flow/react";
 import { ArrowUpDown } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 
-import { TokenBox } from "@/components/token-drawer";
+import { HapticButton } from "@/components/haptic-button";
+import { MobileKeypad } from "@/components/keypad";
+import { SlippageDrawer } from "@/components/slippage-drawer";
+import { price, TokenBox, type TokenRow } from "@/components/token-drawer";
+import { cn } from "@/lib/utils";
 
-function Pill({ children }: { children: React.ReactNode }) {
+/** Same asset + chain → Send; different asset, same chain → Swap; different asset + chain → Bridge. */
+function getActionLabel(from: TokenRow | null, to: TokenRow | null) {
+	if (!from || !to) return "Send";
+	const differentAsset = from.symbol !== to.symbol;
+	const sameChain = from.chainId === to.chainId;
+	if (differentAsset && sameChain) return "Swap";
+	if (differentAsset && !sameChain) return "Bridge";
+	return "Send";
+}
+
+/** Quote constant — must match the "Fee $0.25" shown in SelectedMeta. */
+const FEE_USD = 0.25;
+
+function formatUsd(n: number) {
+	return `$${n.toLocaleString("en-US", {
+		minimumFractionDigits: 2,
+		maximumFractionDigits: 2,
+	})}`;
+}
+
+/** Trim a number to a clean string (drops trailing zeros, caps at 8 decimals). */
+function trim(n: number) {
+	return String(Number(n.toFixed(8)));
+}
+
+function Pill({
+	onClick,
+	children,
+}: {
+	onClick?: () => void;
+	children: React.ReactNode;
+}) {
 	return (
-		<span className="inline-flex items-center gap-1.5 rounded-full bg-foreground/[0.07] px-3 py-1.5 text-sm text-muted-foreground">
+		<button
+			type="button"
+			onClick={onClick}
+			className="inline-flex cursor-pointer items-center gap-1.5 rounded-full bg-foreground/[0.07] px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-foreground/[0.12]"
+		>
 			{children}
-		</span>
+		</button>
+	);
+}
+
+/** Keep only digits and a single decimal point; strip leading zeros. */
+function sanitizeAmount(raw: string) {
+	let v = raw.replace(/[^0-9.]/g, "");
+	const dot = v.indexOf(".");
+	if (dot !== -1) {
+		v = v.slice(0, dot + 1) + v.slice(dot + 1).replace(/\./g, "");
+	}
+	v = v.replace(/^0+(\d)/, "$1");
+	return v === "" || v === "." ? "0" : v;
+}
+
+/**
+ * Animated amount display. Typing, the keypad, and paste are handled globally
+ * by SwapCard and always drive the "from" amount.
+ */
+function AmountInput({
+	value,
+	prefix,
+	muted,
+}: {
+	value: string;
+	prefix?: string;
+	muted?: boolean;
+}) {
+	const dot = value.indexOf(".");
+	const fractionDigits = dot === -1 ? 0 : Math.min(value.length - dot - 1, 8);
+	return (
+		<div
+			role="textbox"
+			aria-label="Amount"
+			tabIndex={0}
+			className="cursor-text rounded-lg outline-none"
+		>
+			<NumberFlow
+				value={Number(value) || 0}
+				prefix={prefix}
+				suffix={value.endsWith(".") ? "." : ""}
+				format={{
+					minimumFractionDigits: fractionDigits,
+					maximumFractionDigits: 8,
+					useGrouping: false,
+				}}
+				className={cn(
+					"text-5xl font-bold tracking-tight",
+					muted ? "text-muted-foreground" : "text-foreground",
+				)}
+			/>
+		</div>
 	);
 }
 
 export function SwapCard() {
+	const [fromAmount, setFromAmount] = useState("0");
+	const [fromToken, setFromToken] = useState<TokenRow | null>(null);
+	const [toToken, setToToken] = useState<TokenRow | null>(null);
+	const [fromMode, setFromMode] = useState<"token" | "usd">("token");
+	const [toMode, setToMode] = useState<"token" | "usd">("token");
+	const [slippage, setSlippage] = useState(0.005);
+	const [slippageOpen, setSlippageOpen] = useState(false);
+	const action = getActionLabel(fromToken, toToken);
+
+	// Quote is always driven by the FROM token units, regardless of display mode.
+	const fromPrice = fromToken ? price(fromToken) : 0;
+	const fromInput = Number(fromAmount) || 0;
+	const fromUnits =
+		fromMode === "token" ? fromInput : fromPrice > 0 ? fromInput / fromPrice : 0;
+	const fromUsd = fromUnits * fromPrice;
+	const toUsd =
+		fromToken && toToken ? Math.max(0, fromUsd - FEE_USD) * (1 - slippage) : 0;
+	const toPrice = toToken ? price(toToken) : 0;
+	const toAmount = toToken && toPrice > 0 ? toUsd / toPrice : 0;
+
+	// Requirements to enable the action: both tokens chosen, a positive amount,
+	// and enough from-balance to cover it. Otherwise disable and show the reason.
+	const fromBalance = fromToken ? Number(fromToken.amount) || 0 : 0;
+	const insufficient = fromToken !== null && fromUnits > fromBalance;
+	const canSwap =
+		fromToken !== null && toToken !== null && fromUnits > 0 && !insufficient;
+	const actionLabel =
+		fromToken === null || toToken === null
+			? "Select a token"
+			: fromUnits <= 0
+				? "Enter an amount"
+				: insufficient
+					? `Insufficient ${fromToken.symbol} balance`
+					: action;
+
+	// Flip a field's denomination. For FROM, convert the editable string so the
+	// displayed value stays equal across the toggle.
+	const toggleFromMode = () => {
+		if (fromMode === "token") {
+			setFromAmount(trim(fromUsd));
+			setFromMode("usd");
+		} else {
+			setFromAmount(trim(fromUnits));
+			setFromMode("token");
+		}
+	};
+	const toggleToMode = () =>
+		setToMode((m) => (m === "token" ? "usd" : "token"));
+
+	// Latest from amount for the global keyboard handler (avoids stale closures).
+	const stateRef = useRef(fromAmount);
+	stateRef.current = fromAmount;
+
+	const handleKey = (key: string) => {
+		const current = stateRef.current;
+		if (key === "back") {
+			setFromAmount(current.length <= 1 ? "0" : current.slice(0, -1));
+		} else if (key === ".") {
+			if (!current.includes(".")) setFromAmount(`${current}.`);
+		} else {
+			setFromAmount(sanitizeAmount(current === "0" ? key : current + key));
+		}
+	};
+
+	// The physical keyboard / paste drive the active amount unless another
+	// field (e.g. the drawer search) is focused.
+	useEffect(() => {
+		const inField = () => {
+			const el = document.activeElement;
+			return (
+				!!el &&
+				(el.tagName === "INPUT" ||
+					el.tagName === "TEXTAREA" ||
+					(el as HTMLElement).isContentEditable)
+			);
+		};
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (e.metaKey || e.ctrlKey || e.altKey || inField()) return;
+			if (/^[0-9]$/.test(e.key)) {
+				handleKey(e.key);
+				e.preventDefault();
+			} else if (e.key === ".") {
+				handleKey(".");
+				e.preventDefault();
+			} else if (e.key === "Backspace") {
+				handleKey("back");
+				e.preventDefault();
+			}
+		};
+		const onPaste = (e: ClipboardEvent) => {
+			if (inField()) return;
+			const text = (e.clipboardData?.getData("text") ?? "")
+				.trim()
+				.replace(/,/g, "");
+			if (text !== "" && /^[0-9]*\.?[0-9]*$/.test(text)) {
+				setFromAmount(sanitizeAmount(text));
+				e.preventDefault();
+			}
+		};
+		document.addEventListener("keydown", onKeyDown);
+		document.addEventListener("paste", onPaste);
+		return () => {
+			document.removeEventListener("keydown", onKeyDown);
+			document.removeEventListener("paste", onPaste);
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
 	return (
 		<div className="w-full max-w-md">
 			{/* You pay */}
 			<section className="rounded-3xl bg-card px-5 pb-8 pt-5">
 				<TokenBox
 					variant="from"
+					onSelect={setFromToken}
+					onSetAmount={setFromAmount}
 					triggerClassName="-mx-5 -mt-5 w-[calc(100%+2.5rem)] rounded-t-3xl px-5 pb-5 pt-5 hover:bg-foreground/[0.03]"
 				/>
-				<div className="-mx-5 mb-2 border-t-2 border-background" />
-				<div className="flex flex-col items-center gap-3">
-					<span className="text-6xl font-bold tracking-tight text-foreground">
-						0.05
-					</span>
-					<Pill>
-						<span className="opacity-50">=</span> $82.20
+				<div className="-mx-5 mb-0.5 border-t-2 border-background" />
+				<div className="flex flex-col items-center gap-0">
+					<AmountInput
+						value={fromAmount}
+						prefix={fromMode === "usd" ? "$" : undefined}
+					/>
+					<Pill onClick={toggleFromMode}>
+						<span className="opacity-50">=</span>{" "}
+						{fromMode === "token"
+							? formatUsd(fromUsd)
+							: `${trim(fromUnits)} ${fromToken?.symbol ?? ""}`}
 						<ArrowUpDown className="size-3.5" />
 					</Pill>
 				</div>
@@ -33,39 +241,58 @@ export function SwapCard() {
 
 			{/* Swap direction */}
 			<div className="relative z-10 mx-auto -my-4 flex w-fit">
-				<button
+				<HapticButton
 					type="button"
-					className="flex size-12 items-center justify-center rounded-full bg-blue-500 text-white ring-4 ring-card transition-colors hover:bg-blue-600"
+					className="flex size-12 items-center justify-center rounded-full bg-primary text-primary-foreground ring-4 ring-background transition-colors hover:bg-primary/90"
 					aria-label="Swap direction"
 				>
 					<ArrowUpDown className="size-5" />
-				</button>
+				</HapticButton>
 			</div>
 
 			{/* You receive */}
 			<section className="rounded-3xl bg-card px-5 pb-5 pt-8">
 				<TokenBox
 					variant="to"
+					onSelect={setToToken}
+					slippage={slippage}
+					onOpenSlippage={() => setSlippageOpen(true)}
 					triggerClassName="-mx-5 -mt-8 w-[calc(100%+2.5rem)] rounded-t-3xl px-5 pb-5 pt-8 hover:bg-foreground/[0.03]"
 				/>
-				<div className="-mx-5 mb-2 border-t-2 border-background" />
-				<div className="flex flex-col items-center gap-3">
-					<span className="text-6xl font-bold tracking-tight text-muted-foreground">
-						81.9534
-					</span>
-					<Pill>
-						<span className="opacity-50">=</span> $81.95
+				<div className="-mx-5 mb-0.5 border-t-2 border-background" />
+				<div className="flex flex-col items-center gap-0">
+					<AmountInput
+						value={trim(toMode === "token" ? toAmount : toUsd)}
+						prefix={toMode === "usd" ? "$" : undefined}
+						muted
+					/>
+					<Pill onClick={toggleToMode}>
+						<span className="opacity-50">=</span>{" "}
+						{toMode === "token"
+							? formatUsd(toUsd)
+							: `${trim(toAmount)} ${toToken?.symbol ?? ""}`}
 						<ArrowUpDown className="size-3.5" />
 					</Pill>
 				</div>
 			</section>
 
-			<button
+			<MobileKeypad onKey={handleKey} />
+
+			<HapticButton
+				wrapperClassName="mt-4 grid w-full"
 				type="button"
-				className="mt-4 h-12 w-full rounded-full bg-primary text-base font-semibold text-primary-foreground transition-colors hover:bg-primary/90 active:scale-[0.99]"
+				disabled={!canSwap}
+				className="h-12 w-full rounded-full bg-primary text-base font-semibold text-primary-foreground transition-colors hover:bg-primary/90 active:scale-[0.99] disabled:cursor-not-allowed disabled:bg-foreground/[0.08] disabled:text-muted-foreground disabled:hover:bg-foreground/[0.08] disabled:active:scale-100"
 			>
-				Send
-			</button>
+				{actionLabel}
+			</HapticButton>
+
+			<SlippageDrawer
+				open={slippageOpen}
+				onOpenChange={setSlippageOpen}
+				value={slippage}
+				onChange={setSlippage}
+			/>
 		</div>
 	);
 }

--- a/workers/jb-swap/src/components/token-drawer.tsx
+++ b/workers/jb-swap/src/components/token-drawer.tsx
@@ -19,14 +19,23 @@ import { cn } from "@/lib/utils";
 
 type Variant = "from" | "to";
 
-interface TokenRow {
+export interface TokenRow {
 	name: string;
 	symbol: string;
 	chain: string;
 	chainId: number;
+	address: string;
 	logo: string;
 	amount: string;
 	usd: string;
+}
+
+/** USD price per unit of a token: total usd ÷ holdings. 0 if NaN / divide-by-zero. */
+export function price(token: TokenRow) {
+	const usd = Number.parseFloat(token.usd.replace(/[^0-9.]/g, "")) || 0;
+	const amount = Number.parseFloat(token.amount) || 0;
+	if (!(usd > 0) || !(amount > 0)) return 0;
+	return usd / amount;
 }
 
 const ADDRESS = "0x71•••976F";
@@ -45,14 +54,14 @@ const chainIcon = (chainId: number) =>
 	`https://assets.relay.link/icons/${chainId}/light.png`;
 
 const TOKENS: TokenRow[] = [
-	{ name: "Solana", symbol: "SOL", chain: "Solana", chainId: 792703809, logo: LOGO.sol, amount: "12.41", usd: "$1,767.18" },
-	{ name: "USD Coin", symbol: "USDC", chain: "Ethereum", chainId: 1, logo: LOGO.usdc, amount: "1240.5", usd: "$1,240.50" },
-	{ name: "Wrapped BTC", symbol: "WBTC", chain: "Ethereum", chainId: 1, logo: LOGO.wbtc, amount: "0.0154", usd: "$956.96" },
-	{ name: "Ethereum", symbol: "ETH", chain: "Ethereum", chainId: 1, logo: LOGO.eth, amount: "0.4218", usd: "$693.44" },
-	{ name: "Tether", symbol: "USDT", chain: "Ethereum", chainId: 1, logo: LOGO.usdt, amount: "540", usd: "$540.00" },
-	{ name: "USD Coin", symbol: "USDC", chain: "Solana", chainId: 792703809, logo: LOGO.usdc, amount: "320.75", usd: "$320.75" },
-	{ name: "Ethereum", symbol: "ETH", chain: "Base", chainId: 8453, logo: LOGO.eth, amount: "0.083", usd: "$136.45" },
-	{ name: "Coinbase ETH", symbol: "cbETH", chain: "Base", chainId: 8453, logo: LOGO.cbeth, amount: "0.061", usd: "$104.43" },
+	{ name: "Solana", symbol: "SOL", chain: "Solana", chainId: 792703809, address: "So11111111111111111111111111111111111111112", logo: LOGO.sol, amount: "12.41", usd: "$1,767.18" },
+	{ name: "USD Coin", symbol: "USDC", chain: "Ethereum", chainId: 1, address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", logo: LOGO.usdc, amount: "1240.5", usd: "$1,240.50" },
+	{ name: "Wrapped BTC", symbol: "WBTC", chain: "Ethereum", chainId: 1, address: "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599", logo: LOGO.wbtc, amount: "0.0154", usd: "$956.96" },
+	{ name: "Ethereum", symbol: "ETH", chain: "Ethereum", chainId: 1, address: "0x0000000000000000000000000000000000000000", logo: LOGO.eth, amount: "0.4218", usd: "$693.44" },
+	{ name: "Tether", symbol: "USDT", chain: "Ethereum", chainId: 1, address: "0xdac17f958d2ee523a2206206994597c13d831ec7", logo: LOGO.usdt, amount: "540", usd: "$540.00" },
+	{ name: "USD Coin", symbol: "USDC", chain: "Solana", chainId: 792703809, address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", logo: LOGO.usdc, amount: "320.75", usd: "$320.75" },
+	{ name: "Ethereum", symbol: "ETH", chain: "Base", chainId: 8453, address: "0x4200000000000000000000000000000000000006", logo: LOGO.eth, amount: "0.083", usd: "$136.45" },
+	{ name: "Coinbase ETH", symbol: "cbETH", chain: "Base", chainId: 8453, address: "0x2ae3f1ec7f1f5012cfeab0185bfc7aa3cf0dec22", logo: LOGO.cbeth, amount: "0.061", usd: "$104.43" },
 ];
 
 const FILTERS: { label: string; chainId?: number; active?: boolean }[] = [
@@ -64,6 +73,32 @@ const FILTERS: { label: string; chainId?: number; active?: boolean }[] = [
 
 function tokenKey(t: TokenRow) {
 	return `${t.name}-${t.chain}`;
+}
+
+/** Fuzzy match: case-insensitive substring or in-order subsequence. */
+function fuzzyMatch(query: string, text: string) {
+	const q = query.toLowerCase().replace(/\s+/g, "");
+	const t = text.toLowerCase();
+	if (t.includes(q)) return true;
+	let qi = 0;
+	for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+		if (t[ti] === q[qi]) qi++;
+	}
+	return qi === q.length;
+}
+
+/** Format a slippage fraction as a percent string with trailing zeros trimmed. */
+function formatPct(fraction: number) {
+	return `${Number((fraction * 100).toFixed(4))}%`;
+}
+
+/** Test amount: 1% of holdings, capped at ~$1 worth of the asset. */
+function computeTest(token: TokenRow) {
+	const usd = Number.parseFloat(token.usd.replace(/[^0-9.]/g, "")) || 0;
+	const amount = Number.parseFloat(token.amount) || 0;
+	if (usd <= 0 || amount <= 0) return "0";
+	const test = Math.min(0.01 * amount, amount / usd);
+	return String(Number(test.toFixed(8)));
 }
 
 function ChainBadge({ chainId, className }: { chainId: number; className?: string }) {
@@ -93,54 +128,86 @@ function TokenIcon({ token }: { token: TokenRow }) {
 
 function AssetStack({ token }: { token: TokenRow }) {
 	return (
-		<div className="relative h-[68px] w-9 shrink-0">
-			<div className="absolute left-1/2 top-0 size-9 -translate-x-1/2 overflow-hidden rounded-full ring-2 ring-card">
-				<Avatar size={36} name={ADDRESS} variant="marble" colors={AVATAR_COLORS} />
+		<div className="relative h-14 w-7 shrink-0">
+			<div className="absolute left-1/2 top-0 size-7 -translate-x-1/2 overflow-hidden rounded-full ring-2 ring-card">
+				<Avatar size={28} name={ADDRESS} variant="marble" colors={AVATAR_COLORS} />
 			</div>
 			{/* eslint-disable-next-line @next/next/no-img-element */}
 			<img
 				src={chainIcon(token.chainId)}
 				alt={token.chain}
-				className="absolute left-1/2 top-4 size-9 -translate-x-1/2 rounded-full bg-card object-cover ring-2 ring-card"
+				className="absolute left-1/2 top-3.5 size-7 -translate-x-1/2 rounded-full bg-card object-cover ring-2 ring-card"
 			/>
 			{/* eslint-disable-next-line @next/next/no-img-element */}
 			<img
 				src={token.logo}
 				alt={token.name}
-				className="absolute left-1/2 top-8 size-9 -translate-x-1/2 rounded-full bg-card object-cover ring-2 ring-card"
+				className="absolute left-1/2 top-7 size-7 -translate-x-1/2 rounded-full bg-card object-cover ring-2 ring-card"
 			/>
 		</div>
 	);
 }
 
-function Pill({ children }: { children: React.ReactNode }) {
+function ClickablePill({
+	onClick,
+	children,
+}: {
+	onClick: (e: React.MouseEvent) => void;
+	children: React.ReactNode;
+}) {
 	return (
-		<span className="inline-flex items-center gap-1.5 rounded-full bg-foreground/[0.07] px-3 py-1.5 text-sm text-muted-foreground">
+		<span
+			role="button"
+			tabIndex={0}
+			onClick={onClick}
+			className="inline-flex cursor-pointer items-center gap-1.5 rounded-full bg-foreground/[0.07] px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-foreground/[0.12]"
+		>
 			{children}
 		</span>
 	);
 }
 
-function SelectedMeta({ variant, token }: { variant: Variant; token: TokenRow }) {
+function SelectedMeta({
+	variant,
+	token,
+	onSetAmount,
+	slippage,
+	onOpenSlippage,
+}: {
+	variant: Variant;
+	token: TokenRow;
+	onSetAmount?: (amount: string) => void;
+	slippage?: number;
+	onOpenSlippage?: () => void;
+}) {
 	if (variant === "to") {
 		return (
 			<div className="flex flex-col items-end gap-2">
-				<Pill>
+				<ClickablePill
+					onClick={(e) => {
+						e.stopPropagation();
+						onOpenSlippage?.();
+					}}
+				>
 					<SlidersHorizontal className="size-3.5" />
-					Slippage 0.5%
-				</Pill>
+					Slippage {formatPct(slippage ?? 0.005)}
+				</ClickablePill>
 				<span className="text-sm text-muted-foreground">Fee $0.25</span>
 			</div>
 		);
 	}
+	const set = (amount: string) => (e: React.MouseEvent) => {
+		e.stopPropagation();
+		onSetAmount?.(amount);
+	};
 	return (
 		<div className="flex flex-col items-end gap-2">
 			<div className="flex gap-2">
-				<Pill>
+				<ClickablePill onClick={set(computeTest(token))}>
 					<FlaskConical className="size-3.5" />
 					Test
-				</Pill>
-				<Pill>Max</Pill>
+				</ClickablePill>
+				<ClickablePill onClick={set(token.amount)}>Max</ClickablePill>
 			</div>
 			<span className="text-sm text-muted-foreground">
 				{token.amount} {token.symbol}
@@ -149,7 +216,19 @@ function SelectedMeta({ variant, token }: { variant: Variant; token: TokenRow })
 	);
 }
 
-function SelectedHeader({ variant, token }: { variant: Variant; token: TokenRow }) {
+function SelectedHeader({
+	variant,
+	token,
+	onSetAmount,
+	slippage,
+	onOpenSlippage,
+}: {
+	variant: Variant;
+	token: TokenRow;
+	onSetAmount?: (amount: string) => void;
+	slippage?: number;
+	onOpenSlippage?: () => void;
+}) {
 	return (
 		<div className="flex items-start justify-between">
 			<div className="flex items-center gap-3">
@@ -157,10 +236,16 @@ function SelectedHeader({ variant, token }: { variant: Variant; token: TokenRow 
 				<div className="flex flex-col leading-none -space-y-0.5">
 					<span className="text-sm text-muted-foreground">{ADDRESS}</span>
 					<span className="text-sm text-muted-foreground">{token.chain}</span>
-					<span className="text-xl font-semibold text-foreground">{token.name}</span>
+					<span className="text-base font-semibold text-foreground">{token.name}</span>
 				</div>
 			</div>
-			<SelectedMeta variant={variant} token={token} />
+			<SelectedMeta
+				variant={variant}
+				token={token}
+				onSetAmount={onSetAmount}
+				slippage={slippage}
+				onOpenSlippage={onOpenSlippage}
+			/>
 		</div>
 	);
 }
@@ -168,13 +253,29 @@ function SelectedHeader({ variant, token }: { variant: Variant; token: TokenRow 
 export function TokenBox({
 	variant,
 	triggerClassName,
+	onSelect,
+	onSetAmount,
+	slippage,
+	onOpenSlippage,
 }: {
 	variant: Variant;
 	triggerClassName?: string;
+	onSelect?: (token: TokenRow) => void;
+	onSetAmount?: (amount: string) => void;
+	slippage?: number;
+	onOpenSlippage?: () => void;
 }) {
 	const [open, setOpen] = useState(false);
 	const [selected, setSelected] = useState<TokenRow | null>(null);
+	const [query, setQuery] = useState("");
 	const label = variant === "from" ? "From" : "To";
+
+	const filtered =
+		query.trim() === ""
+			? TOKENS
+			: TOKENS.filter((t) =>
+					fuzzyMatch(query, `${t.name} ${t.symbol} ${t.chain} ${t.address}`),
+				);
 
 	return (
 		<Drawer.Root open={open} onOpenChange={setOpen}>
@@ -187,7 +288,13 @@ export function TokenBox({
 				)}
 			>
 				{selected ? (
-					<SelectedHeader variant={variant} token={selected} />
+					<SelectedHeader
+						variant={variant}
+						token={selected}
+						onSetAmount={onSetAmount}
+						slippage={slippage}
+						onOpenSlippage={onOpenSlippage}
+					/>
 				) : (
 					<span className="block text-5xl font-semibold text-muted-foreground">
 						{label}...
@@ -244,6 +351,8 @@ export function TokenBox({
 							<Search className="size-5 shrink-0 text-muted-foreground" />
 							<input
 								type="text"
+								value={query}
+								onChange={(e) => setQuery(e.target.value)}
 								placeholder="Search name or paste address"
 								className="flex-1 bg-transparent text-base text-foreground placeholder:text-muted-foreground focus:outline-none"
 							/>
@@ -278,7 +387,12 @@ export function TokenBox({
 					</div>
 
 					<div className="scrollbar-subtle mt-2 flex-1 overflow-y-auto px-5 pb-8">
-						{TOKENS.map((t) => {
+						{filtered.length === 0 && (
+							<p className="py-8 text-center text-sm text-muted-foreground">
+								No tokens found
+							</p>
+						)}
+						{filtered.map((t) => {
 							const isSelected = selected !== null && tokenKey(selected) === tokenKey(t);
 							return (
 								<button
@@ -287,6 +401,7 @@ export function TokenBox({
 									onClick={() => {
 										setSelected(t);
 										setOpen(false);
+										onSelect?.(t);
 									}}
 									className={cn(
 										"flex w-full cursor-pointer items-center gap-3 rounded-xl py-3 text-left transition-colors hover:bg-foreground/[0.04]",


### PR DESCRIPTION
## Summary
Turns the jb-swap card from a static scaffold into a working quote UI on `swap.joeblau.com`.

- **Quote engine** — price-derived amounts with a $0.25 fee and slippage: `toUsd = max(0, fromUsd - fee) * (1 - slippage)`, always driven by the FROM units regardless of display mode.
- **Denomination toggle** — tap the `=` pill on either field to switch between token and USD; the editable FROM string converts so the on-screen value stays equal across the toggle.
- **Slippage drawer** — Vaul bottom sheet with 0.1% / 0.5% / 1.0% presets plus a custom input, opened from the To card's "Slippage" pill (with "Fee $0.25" shown alongside).
- **Animated input** — NumberFlow amounts driven by the physical keyboard, paste, and a mobile keypad; a global keydown/paste handler edits the FROM amount, with trailing-decimal handling.
- **Mobile keypad** — framer-motion 3-column pad shown under 768px.
- **Haptics** — Project Fathom technique: `HapticButton` overlays an invisible WebKit `<input switch>` so every tap plays a native iOS haptic, while preserving layout and `onClick`.
- **Action gating** — `Select a token` → `Enter an amount` → `Insufficient balance`, otherwise `Send` / `Swap` / `Bridge` chosen by asset + chain.
- **Spacing** — page-top→buttons and buttons→From-card gaps are both 16px, matching the card's internal rhythm.

## Test plan
- [x] `bun run cf-build` compiles clean (OpenNext build complete)
- [x] Quote math reconciles live (e.g. 5 SOL → $711.99 → 708.19 USDC @0.5%, 704.63 @1%)
- [x] Denomination toggle keeps values equal across token/USD
- [x] Gating transitions verified (Select a token → Bridge)
- [x] Header/card spacing measured at 16px / 16px

🤖 Generated with [Claude Code](https://claude.com/claude-code)