### PR TITLE
fix: let the token list scroll inside the drawer instead of dragging it

### DIFF
--- a/workers/jb-swap/src/components/token-drawer.tsx
+++ b/workers/jb-swap/src/components/token-drawer.tsx
@@ -499,7 +499,8 @@ export function TokenBox({
 
 					<div
 						ref={listRef}
-						className="scrollbar-subtle mt-2 flex-1 overflow-y-auto px-5 pb-8"
+						data-vaul-no-drag
+						className="scrollbar-subtle mt-2 min-h-0 flex-1 touch-pan-y overscroll-contain overflow-y-auto px-5 pb-8"
 					>
 						{filtered.length === 0 && (
 							<p className="py-8 text-center text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
Adds `data-vaul-no-drag` plus `min-h-0`, `touch-pan-y`, and `overscroll-contain` to the scrollable token list in the From/To drawer. Touch scrolling now moves the list rather than dragging the Vaul drawer down, and the flex child can shrink so the list scrolls correctly.

## Test plan
- [x] `bun run cf-build` compiles clean
- [ ] On a touch device: scrolling the token list scrolls the list (doesn't drag the drawer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)