### PR TITLE
fix: label-driven haptic overlay so mobile can scroll the token list

### DIFF
--- a/workers/jb-swap/src/app/globals.css
+++ b/workers/jb-swap/src/app/globals.css
@@ -99,3 +99,33 @@
 .scrollbar-subtle::-webkit-scrollbar-thumb:hover {
   background-color: hsl(var(--muted-foreground) / 0.4);
 }
+
+/* Project Fathom haptic overlay (iOS only). The visible host stays a normal
+   button; an invisible <label> linked to a native <input switch> fills it.
+   The label is an ordinary gesture target, so browser scrolling and Vaul
+   drawer dragging pass through untouched — only a completed tap toggles the
+   switch and fires the WebKit system haptic; a swipe never buzzes or blocks
+   the scroll. */
+.haptic-clip {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+.haptic-label {
+  position: absolute;
+  inset: 0;
+  pointer-events: auto;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+.haptic-switch {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  margin: 0;
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, -50%);
+}

--- a/workers/jb-swap/src/components/haptic-button.tsx
+++ b/workers/jb-swap/src/components/haptic-button.tsx
@@ -1,24 +1,25 @@
 "use client";
 
 import type { ComponentProps } from "react";
-import { useRef } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 
+import { shouldUseHapticOverlay } from "@/lib/platform";
 import { cn } from "@/lib/utils";
 
 /**
  * A button that plays a native iOS haptic tick on tap, using the Project Fathom
- * technique (https://github.com/m1ckc3s/project-fathom): an invisible WebKit
- * `<input type="checkbox" switch>` is overlaid on the button. Tapping the switch
- * makes iOS (Safari 17.4+ / iOS 18+) play a system haptic, and its change
- * handler forwards the tap to the real button so existing behavior is kept.
- * On non-WebKit browsers the switch is an ordinary (invisible) checkbox and the
- * click-forwarding still works, so it's a no-op visually/behaviorally elsewhere.
+ * technique (https://github.com/m1ckc3s/project-fathom).
  *
- * The switch is absolutely positioned over the whole button (inset-0), so a tap
- * anywhere on the button — including its padding and corners — triggers the
- * haptic, without changing layout. `wrapperClassName` controls the wrapper's
- * display/width (e.g. "grid w-full" for full-width buttons, "absolute inset-0"
- * to fill a positioned parent).
+ * On iOS WebKit it appends an invisible `<label>` (filling the button) linked to
+ * a native `<input switch>` via `htmlFor`/`id`. A `<label>` is an ordinary
+ * gesture target, so finger scrolling and Vaul drawer dragging pass straight
+ * through it — only a *completed tap* toggles the switch, which fires the WebKit
+ * system haptic and forwards a click to the real button; a swipe never toggles
+ * it, so it neither buzzes nor blocks the scroll. (An absolute `<input>` overlay
+ * captures the touch and breaks scrolling, which is why this uses a label.)
+ *
+ * The overlay renders only on iOS WebKit, so on desktop/Android the button is a
+ * plain button with no overlay (hover and clicks behave natively).
  */
 export function HapticButton({
 	className,
@@ -28,23 +29,37 @@ export function HapticButton({
 	...props
 }: ComponentProps<"button"> & { wrapperClassName?: string }) {
 	const ref = useRef<HTMLButtonElement>(null);
+	const switchId = useId();
+	// Resolve out of render so SSR and the first client paint agree; flips true
+	// one tick after mount on iOS.
+	const [overlay, setOverlay] = useState(false);
+	useEffect(() => setOverlay(shouldUseHapticOverlay()), []);
+
 	return (
 		<span className={cn("relative", wrapperClassName)}>
 			<button ref={ref} className={className} disabled={disabled} {...props}>
 				{children}
 			</button>
-			<input
-				type="checkbox"
-				aria-hidden="true"
-				tabIndex={-1}
-				ref={(el) => el?.setAttribute("switch", "")}
-				onChange={() => ref.current?.click()}
-				className={cn(
-					"absolute inset-0 m-0 size-full opacity-0 [-webkit-tap-highlight-color:transparent]",
-					disabled ? "pointer-events-none" : "cursor-pointer",
-				)}
-				style={{ touchAction: "manipulation" }}
-			/>
+			{overlay && !disabled && (
+				<span aria-hidden="true" className="haptic-clip">
+					<input
+						className="haptic-switch"
+						id={switchId}
+						type="checkbox"
+						tabIndex={-1}
+						aria-hidden="true"
+						// `switch` isn't a valid JSX/TS attr; set it imperatively.
+						ref={(el) => el?.setAttribute("switch", "")}
+						onChange={() => ref.current?.click()}
+					/>
+					<label
+						className="haptic-label"
+						htmlFor={switchId}
+						aria-hidden="true"
+						onClick={(e) => e.stopPropagation()}
+					/>
+				</span>
+			)}
 		</span>
 	);
 }

--- a/workers/jb-swap/src/components/token-drawer.tsx
+++ b/workers/jb-swap/src/components/token-drawer.tsx
@@ -499,8 +499,7 @@ export function TokenBox({
 
 					<div
 						ref={listRef}
-						data-vaul-no-drag
-						className="scrollbar-subtle mt-2 min-h-0 flex-1 touch-pan-y overscroll-contain overflow-y-auto px-5 pb-8"
+						className="scrollbar-subtle mt-2 min-h-0 flex-1 overflow-y-auto px-5 pb-8"
 					>
 						{filtered.length === 0 && (
 							<p className="py-8 text-center text-sm text-muted-foreground">

--- a/workers/jb-swap/src/lib/platform.ts
+++ b/workers/jb-swap/src/lib/platform.ts
@@ -1,0 +1,24 @@
+let _hapticOverlay: boolean | null = null;
+
+/**
+ * True only on iOS WebKit, where the Project Fathom `<input switch>` haptic
+ * works. Used to gate the invisible haptic overlay so it never renders on
+ * desktop/Android (where it would only add a transparent layer and could
+ * swallow `:hover`). Memoized and SSR-safe (returns false when `navigator`
+ * is undefined). NEVER call at module load — call it from an effect so the
+ * server and first client paint agree.
+ */
+export function shouldUseHapticOverlay(): boolean {
+	if (_hapticOverlay !== null) return _hapticOverlay;
+	if (typeof navigator === "undefined") return false; // SSR
+	const platform = navigator.platform ?? "";
+	const isIOS =
+		/iP(hone|ad|od)/.test(platform) ||
+		// iPadOS 13+ reports "MacIntel" with touch points.
+		(platform === "MacIntel" && navigator.maxTouchPoints > 1);
+	// The Vibration API is absent on every iOS browser; that absence is the
+	// canonical "no script haptic" tell, so require iOS AND no-vibrate.
+	const noVibration = typeof navigator.vibrate !== "function";
+	_hapticOverlay = isIOS && noVibration;
+	return _hapticOverlay;
+}


### PR DESCRIPTION
## Summary
The Project Fathom haptic used an absolutely-positioned `<input switch>` overlay that **captured the touch**, so on iOS the token list couldn't be scrolled with a finger and selection/swipe were flaky.

Ported the `bloxwap/www` approach: the overlay is now an invisible **`<label>` linked to the native `<input switch>` via `htmlFor`/`id`**. A `<label>` is an ordinary gesture target, so finger scrolling and Vaul dragging pass straight through — only a *completed tap* toggles the switch (firing the WebKit haptic and forwarding the click); a swipe never toggles it, so it neither buzzes nor blocks the scroll.

- **New `src/lib/platform.ts`** → `shouldUseHapticOverlay()` (iOS WebKit only), so the overlay never renders on desktop/Android (hover/clicks stay native).
- **`globals.css`** → `.haptic-clip` / `.haptic-label` / `.haptic-switch`.
- **`HapticButton`** rewritten to the label-driven, iOS-gated overlay.
- **Reverted earlier workarounds** (`handleOnly`, `Drawer.Handle`, `data-vaul-no-drag` + `touch-pan-y` + `overscroll-contain`) — the label fix alone makes Vaul **scroll *and* swipe-to-dismiss** work, so body-swipe dismissal is back.

## Test plan
- [x] `bun run cf-build` compiles clean
- [x] Desktop: overlay not rendered (0 switches/labels); drawer opens, list scrolls, rows select, buttons work natively
- [x] iOS path (temporarily forced on): label→switch→onClick fires (pill toggle + row select), list scrolls with overlays present
- [ ] On a physical iPhone: scroll the token list with a finger; tap to select buzzes; swipe handle/body dismisses

🤖 Generated with [Claude Code](https://claude.com/claude-code)