### PR TITLE
feat: Apple Intelligence submit effect, menu drawer, and swap polish

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2871,6 +2871,8 @@
 
     "is-bun-module/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "jb-swap/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.5", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg=="],
+
     "jb-swap/lucide-react": ["lucide-react@1.18.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-LZDb7H/0YfM+RJncD0hDQRCAu+vSGODqpe35TuVI8EuXaRjkczbsx7p8dY4J87F/MUSj6bpYqeI8nw8qXaAdmA=="],
 
     "jb-travel/@number-flow/react": ["@number-flow/react@0.5.14", "", { "dependencies": { "esm-env": "^1.1.4", "number-flow": "0.5.12" }, "peerDependencies": { "react": "^18 || ^19", "react-dom": "^18 || ^19" } }, "sha512-FGUqjh/P5/ukr0U0ySwb987M0SbRkrnZq70f0wQFncDbXa3SIib4L+FTr5ngvWwGAW8S6b391eTXcfhErZsw4w=="],
@@ -3054,6 +3056,8 @@
     "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "glob/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
+
+    "jb-swap/@radix-ui/react-slot/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
 
     "jb-travel/@number-flow/react/number-flow": ["number-flow@0.5.12", "", { "dependencies": { "esm-env": "^1.1.4" } }, "sha512-CIs21h2JkfYG4rfgERaUNAk0Cz+Ef14fNJfSCbGGhgRgconQc9b7rcCQfi9SZ36kNjVXmsl2BrzDbjGtEgumAA=="],
 

--- a/workers/jb-swap/src/app/globals.css
+++ b/workers/jb-swap/src/app/globals.css
@@ -129,3 +129,145 @@
   pointer-events: none;
   transform: translate(-50%, -50%);
 }
+
+/* Apple-Intelligence edge glow (skiper86). The element is painted with the
+   animated linear-gradient (set inline by the component); here we (1) round the
+   outer corners so the glow follows a rounded frame and (2) feather the
+   gradient inward to transparent so the centre stays clear and the page shows
+   through. Four additive mask layers (one per edge) union under the DEFAULT
+   `add` compositing — no mask-composite needed, so it's robust across browsers.
+   Each layer uses a smooth ease-out alpha falloff (not a linear ramp) so the
+   thin band fades softly; `--feather` (set by the component's `intensity`)
+   controls the band thickness. Corners read brighter where two layers overlap,
+   matching the Apple look. */
+.apple-edge-glow {
+  --feather: 32px;
+  border-radius: 26px;
+  -webkit-mask-image: linear-gradient(
+      to top,
+      rgb(0 0 0 / 1) 0,
+      rgb(0 0 0 / 0.82) calc(var(--feather) * 0.18),
+      rgb(0 0 0 / 0.58) calc(var(--feather) * 0.36),
+      rgb(0 0 0 / 0.36) calc(var(--feather) * 0.55),
+      rgb(0 0 0 / 0.16) calc(var(--feather) * 0.75),
+      transparent var(--feather)
+    ),
+    linear-gradient(
+      to bottom,
+      rgb(0 0 0 / 1) 0,
+      rgb(0 0 0 / 0.82) calc(var(--feather) * 0.18),
+      rgb(0 0 0 / 0.58) calc(var(--feather) * 0.36),
+      rgb(0 0 0 / 0.36) calc(var(--feather) * 0.55),
+      rgb(0 0 0 / 0.16) calc(var(--feather) * 0.75),
+      transparent var(--feather)
+    ),
+    linear-gradient(
+      to left,
+      rgb(0 0 0 / 1) 0,
+      rgb(0 0 0 / 0.82) calc(var(--feather) * 0.18),
+      rgb(0 0 0 / 0.58) calc(var(--feather) * 0.36),
+      rgb(0 0 0 / 0.36) calc(var(--feather) * 0.55),
+      rgb(0 0 0 / 0.16) calc(var(--feather) * 0.75),
+      transparent var(--feather)
+    ),
+    linear-gradient(
+      to right,
+      rgb(0 0 0 / 1) 0,
+      rgb(0 0 0 / 0.82) calc(var(--feather) * 0.18),
+      rgb(0 0 0 / 0.58) calc(var(--feather) * 0.36),
+      rgb(0 0 0 / 0.36) calc(var(--feather) * 0.55),
+      rgb(0 0 0 / 0.16) calc(var(--feather) * 0.75),
+      transparent var(--feather)
+    );
+  mask-image: linear-gradient(
+      to top,
+      rgb(0 0 0 / 1) 0,
+      rgb(0 0 0 / 0.82) calc(var(--feather) * 0.18),
+      rgb(0 0 0 / 0.58) calc(var(--feather) * 0.36),
+      rgb(0 0 0 / 0.36) calc(var(--feather) * 0.55),
+      rgb(0 0 0 / 0.16) calc(var(--feather) * 0.75),
+      transparent var(--feather)
+    ),
+    linear-gradient(
+      to bottom,
+      rgb(0 0 0 / 1) 0,
+      rgb(0 0 0 / 0.82) calc(var(--feather) * 0.18),
+      rgb(0 0 0 / 0.58) calc(var(--feather) * 0.36),
+      rgb(0 0 0 / 0.36) calc(var(--feather) * 0.55),
+      rgb(0 0 0 / 0.16) calc(var(--feather) * 0.75),
+      transparent var(--feather)
+    ),
+    linear-gradient(
+      to left,
+      rgb(0 0 0 / 1) 0,
+      rgb(0 0 0 / 0.82) calc(var(--feather) * 0.18),
+      rgb(0 0 0 / 0.58) calc(var(--feather) * 0.36),
+      rgb(0 0 0 / 0.36) calc(var(--feather) * 0.55),
+      rgb(0 0 0 / 0.16) calc(var(--feather) * 0.75),
+      transparent var(--feather)
+    ),
+    linear-gradient(
+      to right,
+      rgb(0 0 0 / 1) 0,
+      rgb(0 0 0 / 0.82) calc(var(--feather) * 0.18),
+      rgb(0 0 0 / 0.58) calc(var(--feather) * 0.36),
+      rgb(0 0 0 / 0.36) calc(var(--feather) * 0.55),
+      rgb(0 0 0 / 0.16) calc(var(--feather) * 0.75),
+      transparent var(--feather)
+    );
+}
+
+/* Skiper87-style scroll fade: a top/bottom mask whose fade bands grow/shrink
+   with scroll position (pure CSS via scroll-driven animation-timeline). The top
+   band is 0 at the very top, the bottom band is 0 at the very bottom — so the
+   first/last rows are never clipped. Degrades to no fade where unsupported. */
+@property --ft {
+  syntax: "<length-percentage>";
+  inherits: false;
+  initial-value: 0%;
+}
+@property --fb {
+  syntax: "<length-percentage>";
+  inherits: false;
+  initial-value: 0%;
+}
+@keyframes scroll-fade-top {
+  0%,
+  6% {
+    --ft: 0%;
+  }
+  14%,
+  100% {
+    --ft: 8%;
+  }
+}
+@keyframes scroll-fade-bottom {
+  0%,
+  86% {
+    --fb: 8%;
+  }
+  94%,
+  100% {
+    --fb: 0%;
+  }
+}
+.scroll-fade {
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    transparent 0,
+    #000 var(--ft),
+    #000 calc(100% - var(--fb)),
+    transparent 100%
+  );
+  mask-image: linear-gradient(
+    to bottom,
+    transparent 0,
+    #000 var(--ft),
+    #000 calc(100% - var(--fb)),
+    transparent 100%
+  );
+  animation-name: scroll-fade-top, scroll-fade-bottom;
+  animation-timeline: scroll(self), scroll(self);
+  animation-timing-function: linear;
+  animation-fill-mode: both;
+}

--- a/workers/jb-swap/src/app/page.tsx
+++ b/workers/jb-swap/src/app/page.tsx
@@ -2,7 +2,7 @@ import { SwapCard } from "@/components/swap-card";
 
 export default function Home() {
 	return (
-		<main className="flex min-h-screen flex-col items-center px-6 py-2 md:justify-center">
+		<main className="flex min-h-screen flex-col items-center justify-center px-6 py-2">
 			<SwapCard />
 		</main>
 	);

--- a/workers/jb-swap/src/components/app-menu.tsx
+++ b/workers/jb-swap/src/components/app-menu.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { ChevronLeft, Menu, X } from "lucide-react";
+import { useRef, useState } from "react";
+import { Drawer } from "vaul";
+
+import { LanguagePanel, LanguageRow } from "@/components/language-drawer";
+import { ResizablePanel } from "@/components/resizable-panel";
+import { ThemeSegmentedControl } from "@/components/theme-segmented-control";
+import { cn } from "@/lib/utils";
+
+type View = "menu" | "language";
+
+/**
+ * Bottom-row menu button. Opens a Vaul bottom-sheet (matching the token /
+ * slippage drawers) that holds the theme control, language picker, and is the
+ * home for future options. Selecting Language pushes a new view into the SAME
+ * sheet; the body springs its height and slides between views — a Family-wallet
+ * style morph rather than a hard snap.
+ */
+export function AppMenu({ className }: { className?: string }) {
+	const [language, setLanguage] = useState("en");
+	const [view, setView] = useState<View>("menu");
+	// +1 = forward push (slide in from the right), -1 = back pop.
+	const [direction, setDirection] = useState(1);
+	const directionRef = useRef(1);
+
+	const go = (next: View) => {
+		const dir = next === "menu" ? -1 : 1;
+		directionRef.current = dir;
+		setDirection(dir);
+		setView(next);
+	};
+
+	return (
+		<Drawer.Root
+			onOpenChange={(open) => {
+				// Reset to the menu view once the sheet finishes closing.
+				if (!open) {
+					directionRef.current = 1;
+					setDirection(1);
+					setView("menu");
+				}
+			}}
+		>
+			<Drawer.Trigger asChild>
+				<button
+					type="button"
+					aria-label="Menu"
+					className={cn(
+						"flex size-12 shrink-0 items-center justify-center rounded-full bg-secondary text-secondary-foreground transition-colors hover:bg-secondary/80 active:scale-95",
+						className,
+					)}
+				>
+					<Menu className="size-5" />
+				</button>
+			</Drawer.Trigger>
+			<Drawer.Portal>
+				<Drawer.Overlay className="fixed inset-0 z-50 bg-black/60" />
+				<Drawer.Content
+					aria-describedby={undefined}
+					className="fixed inset-x-0 bottom-0 z-50 mx-auto flex max-w-md flex-col rounded-t-3xl bg-card outline-none"
+				>
+					<div className="mx-auto mt-3 h-1.5 w-12 shrink-0 rounded-full bg-foreground/20" />
+
+					<div className="flex flex-col gap-4 px-5 pb-8 pt-4">
+						<div className="flex items-center justify-between">
+							<div className="flex items-center gap-1">
+								{view === "language" && (
+									<button
+										type="button"
+										aria-label="Back"
+										onClick={() => go("menu")}
+										className="-ml-2 flex size-9 cursor-pointer items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
+									>
+										<ChevronLeft className="size-6" />
+									</button>
+								)}
+								<Drawer.Title className="text-2xl font-bold text-foreground">
+									{view === "language" ? "Language" : "Menu"}
+								</Drawer.Title>
+							</div>
+							<Drawer.Close className="flex size-9 cursor-pointer items-center justify-center rounded-full bg-foreground/10 text-muted-foreground transition-colors hover:bg-foreground/15">
+								<X className="size-5" />
+							</Drawer.Close>
+						</div>
+
+						<ResizablePanel activeKey={view} direction={direction}>
+							{view === "language" ? (
+								<LanguagePanel
+									value={language}
+									onSelect={(code) => {
+										setLanguage(code);
+										go("menu");
+									}}
+								/>
+							) : (
+								<div className="flex flex-col gap-4">
+									<LanguageRow
+										value={language}
+										onOpen={() => go("language")}
+									/>
+									<ThemeSegmentedControl />
+								</div>
+							)}
+						</ResizablePanel>
+					</div>
+				</Drawer.Content>
+			</Drawer.Portal>
+		</Drawer.Root>
+	);
+}

--- a/workers/jb-swap/src/components/apple-border-gradient.tsx
+++ b/workers/jb-swap/src/components/apple-border-gradient.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import type { CSSProperties } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Recreation of Skiper UI's "Apple AI Gradient" (skiper86, AppleBorderGradient).
+ *
+ * The original is a full-size rectangle painted with an animated
+ * `linear-gradient` (blue → purple → red → orange) whose angle spins
+ * 0deg → 360deg over 5s; a blurred inset fill covers the centre so only a soft
+ * glow bleeds out around the edge. We keep the exact colours and rotation, but
+ * because this overlays the live swap card we leave the centre TRANSPARENT —
+ * the gradient feathers inward to nothing via an eased edge mask instead of
+ * being covered by an opaque fill. The overlay is inset (`inset-1`) so a thin
+ * black margin frames the rounded glow; the band is thin (`--feather`) with a
+ * smooth ease-out falloff, and the whole thing is kept subtle (low opacity).
+ *
+ * NOTE: the original is a paid Skiper UI Pro component; this is an independent
+ * recreation of the same effect.
+ */
+const COLORS = "#3b82f6, #a855f7, #ef4444, #f97316";
+
+export function AppleBorderGradient({
+	preview,
+	intensity = "xl",
+	className,
+}: {
+	preview: boolean;
+	intensity?: "lg" | "xl" | "2xl" | "3xl";
+	className?: string;
+}) {
+	// Band thickness: how far the gradient reaches inward before fading out.
+	const feather = { lg: 22, xl: 32, "2xl": 48, "3xl": 72 }[intensity];
+
+	return (
+		<AnimatePresence>
+			{preview && (
+				<motion.div
+					aria-hidden
+					initial={{ opacity: 0 }}
+					animate={{ opacity: 0.45 }}
+					exit={{ opacity: 0 }}
+					transition={{ duration: 0.5, ease: "easeInOut" }}
+					className={cn("pointer-events-none fixed inset-1 z-[100]", className)}
+				>
+					<motion.div
+						className="apple-edge-glow absolute inset-0"
+						style={{ "--feather": `${feather}px` } as CSSProperties}
+						animate={{
+							background: [
+								`linear-gradient(0deg, ${COLORS})`,
+								`linear-gradient(360deg, ${COLORS})`,
+							],
+						}}
+						transition={{ duration: 5, ease: "linear", repeat: Infinity }}
+					/>
+				</motion.div>
+			)}
+		</AnimatePresence>
+	);
+}

--- a/workers/jb-swap/src/components/language-drawer.tsx
+++ b/workers/jb-swap/src/components/language-drawer.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { Check, ChevronRight, Search } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import { HapticButton } from "@/components/haptic-button";
+import { cn } from "@/lib/utils";
+
+/**
+ * Language picker pieces for the AppMenu sheet. Rather than open a second
+ * drawer, the menu swaps its own content between the menu view and the
+ * `LanguagePanel`; Vaul's dynamic height animates the sheet taller/shorter to
+ * fit. `LanguageRow` is the tappable menu entry (circular flag + current
+ * language) that triggers the swap.
+ *
+ * Flags come from flagcdn.com's SVG CDN — the same pattern the token/chain
+ * icons use. (restcountries.com/flags serves an HTML page, not an image.)
+ */
+
+export interface Language {
+	/** BCP-47 code used as the stable key / persisted value. */
+	code: string;
+	/** Endonym shown to the user. */
+	name: string;
+	/** English name, kept searchable so "Spanish" finds "Español". */
+	englishName: string;
+	/** ISO 3166-1 alpha-2 country code for the flag CDN. */
+	flag: string;
+}
+
+export const LANGUAGES: Language[] = [
+	{ code: "en", name: "English", englishName: "English", flag: "us" },
+	{ code: "es", name: "Español", englishName: "Spanish", flag: "es" },
+	{ code: "zh", name: "中文", englishName: "Chinese", flag: "cn" },
+	{ code: "ko", name: "한국어", englishName: "Korean", flag: "kr" },
+	{ code: "fr", name: "Français", englishName: "French", flag: "fr" },
+];
+
+export const languageFor = (code: string) =>
+	LANGUAGES.find((l) => l.code === code) ?? LANGUAGES[0];
+
+const flagUrl = (code: string) => `https://flagcdn.com/${code}.svg`;
+
+export function FlagCircle({
+	flag,
+	alt,
+	className,
+}: {
+	flag: string;
+	alt: string;
+	className?: string;
+}) {
+	return (
+		// eslint-disable-next-line @next/next/no-img-element
+		<img
+			src={flagUrl(flag)}
+			alt={alt}
+			className={cn(
+				"size-8 shrink-0 rounded-full bg-foreground/[0.06] object-cover",
+				className,
+			)}
+		/>
+	);
+}
+
+/** Case-insensitive substring match across endonym, English name and code. */
+function matches(query: string, lang: Language) {
+	const q = query.trim().toLowerCase();
+	if (q === "") return true;
+	return (
+		lang.name.toLowerCase().includes(q) ||
+		lang.englishName.toLowerCase().includes(q) ||
+		lang.code.toLowerCase().includes(q)
+	);
+}
+
+/** The menu row: circular flag + "Language" + current endonym. Opens the panel. */
+export function LanguageRow({
+	value,
+	onOpen,
+}: {
+	value: string;
+	onOpen: () => void;
+}) {
+	const current = languageFor(value);
+	return (
+		<HapticButton
+			type="button"
+			onClick={onOpen}
+			wrapperClassName="block w-full"
+			className="flex h-12 w-full cursor-pointer items-center gap-3 rounded-full bg-foreground/[0.06] pl-1.5 pr-4 text-left text-base font-medium text-foreground transition-colors hover:bg-foreground/10"
+		>
+			<FlagCircle
+				flag={current.flag}
+				alt={current.englishName}
+				className="size-9"
+			/>
+			<span className="flex-1">Language</span>
+			<span className="text-muted-foreground">{current.name}</span>
+			<ChevronRight className="size-5 shrink-0 text-muted-foreground" />
+		</HapticButton>
+	);
+}
+
+/** The pushed-in view: search field + scrollable list of every language. */
+export function LanguagePanel({
+	value,
+	onSelect,
+}: {
+	value: string;
+	onSelect: (code: string) => void;
+}) {
+	const [query, setQuery] = useState("");
+	const searchRef = useRef<HTMLInputElement>(null);
+	const current = languageFor(value);
+
+	// Focus the search on web only (skip mobile to avoid popping the keyboard).
+	useEffect(() => {
+		if (!window.matchMedia("(min-width: 768px)").matches) return;
+		const t = setTimeout(() => searchRef.current?.focus(), 150);
+		return () => clearTimeout(t);
+	}, []);
+
+	const filtered = LANGUAGES.filter((l) => matches(query, l));
+
+	return (
+		<div className="flex flex-col gap-4">
+			<div className="flex items-center gap-3 rounded-2xl bg-foreground/[0.06] px-4 py-3">
+				<Search className="size-5 shrink-0 text-muted-foreground" />
+				<input
+					ref={searchRef}
+					type="text"
+					value={query}
+					onChange={(e) => setQuery(e.target.value)}
+					placeholder="Search languages"
+					className="flex-1 bg-transparent text-base text-foreground placeholder:text-muted-foreground focus:outline-none"
+				/>
+			</div>
+
+			<div className="scrollbar-subtle -mx-1 max-h-[50vh] overflow-y-auto px-1">
+				{filtered.length === 0 && (
+					<p className="py-8 text-center text-sm text-muted-foreground">
+						No languages found
+					</p>
+				)}
+				{filtered.map((l) => {
+					const isSelected = l.code === current.code;
+					return (
+						<HapticButton
+							key={l.code}
+							type="button"
+							wrapperClassName="block w-full"
+							onClick={() => onSelect(l.code)}
+							className="flex w-full cursor-pointer items-center gap-3 rounded-xl py-3 text-left transition-colors hover:bg-foreground/[0.04]"
+						>
+							<FlagCircle flag={l.flag} alt={l.englishName} />
+							<div className="min-w-0 flex-1">
+								<p className="font-semibold text-foreground">{l.name}</p>
+								<p className="text-sm text-muted-foreground">{l.englishName}</p>
+							</div>
+							{isSelected && (
+								<Check className="size-5 shrink-0 text-foreground" />
+							)}
+						</HapticButton>
+					);
+				})}
+			</div>
+		</div>
+	);
+}

--- a/workers/jb-swap/src/components/resizable-panel.tsx
+++ b/workers/jb-swap/src/components/resizable-panel.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import { useLayoutEffect, useRef, useState, type ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Family-wallet-style resizable container. The outer box springs its height to
+ * whatever the active view measures, while views cross-fade and slide in the
+ * push/pop direction — so navigating between sheet views morphs the sheet
+ * instead of snapping. `activeKey` identifies the current view; `direction`
+ * is +1 for a forward push (slide in from the right) and -1 for a back pop.
+ */
+
+const SPRING = { type: "spring", stiffness: 350, damping: 34 } as const;
+
+const slide = {
+	enter: (dir: number) => ({ x: dir >= 0 ? 28 : -28, opacity: 0 }),
+	center: { x: 0, opacity: 1 },
+	exit: (dir: number) => ({ x: dir >= 0 ? -28 : 28, opacity: 0 }),
+};
+
+export function ResizablePanel({
+	activeKey,
+	direction,
+	children,
+	className,
+}: {
+	activeKey: string;
+	direction: number;
+	children: ReactNode;
+	className?: string;
+}) {
+	const measureRef = useRef<HTMLDivElement>(null);
+	const [height, setHeight] = useState<number | null>(null);
+
+	// Track the measured height of the in-flow view. popLayout pulls the exiting
+	// view out of flow, so this reflects the incoming view immediately and the
+	// wrapper can spring to it.
+	useLayoutEffect(() => {
+		const el = measureRef.current;
+		if (!el) return;
+		const observer = new ResizeObserver(() => setHeight(el.offsetHeight));
+		observer.observe(el);
+		setHeight(el.offsetHeight);
+		return () => observer.disconnect();
+	}, []);
+
+	return (
+		<motion.div
+			initial={false}
+			animate={{ height: height ?? "auto" }}
+			transition={SPRING}
+			className={cn("relative overflow-hidden", className)}
+		>
+			<div ref={measureRef}>
+				<AnimatePresence mode="popLayout" initial={false} custom={direction}>
+					<motion.div
+						key={activeKey}
+						custom={direction}
+						variants={slide}
+						initial="enter"
+						animate="center"
+						exit="exit"
+						transition={SPRING}
+						className="w-full"
+					>
+						{children}
+					</motion.div>
+				</AnimatePresence>
+			</div>
+		</motion.div>
+	);
+}

--- a/workers/jb-swap/src/components/swap-card.tsx
+++ b/workers/jb-swap/src/components/swap-card.tsx
@@ -2,13 +2,14 @@
 
 import NumberFlow from "@number-flow/react";
 import { motion } from "framer-motion";
-import { ArrowUpDown } from "lucide-react";
+import { ArrowUpDown, RotateCcw } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
+import { AppleBorderGradient } from "@/components/apple-border-gradient";
+import { AppMenu } from "@/components/app-menu";
 import { HapticButton } from "@/components/haptic-button";
 import { MobileKeypad } from "@/components/keypad";
 import { SlippageDrawer } from "@/components/slippage-drawer";
-import { ThemeToggleButton2 } from "@/components/ui/skiper-ui/skiper4";
 import { price, TokenBox, type TokenRow } from "@/components/token-drawer";
 import { cn } from "@/lib/utils";
 
@@ -120,6 +121,7 @@ export function SwapCard() {
 	const [slippageOpen, setSlippageOpen] = useState(false);
 	const [connected, setConnected] = useState(false);
 	const [genAddress, setGenAddress] = useState(false);
+	const [submitting, setSubmitting] = useState(false);
 	const action = getActionLabel(fromToken, toToken);
 
 	// Quote is always driven by the FROM token units, regardless of display mode.
@@ -161,6 +163,35 @@ export function SwapCard() {
 	};
 	const toggleToMode = () =>
 		setToMode((m) => (m === "token" ? "usd" : "token"));
+
+	// Flip only swaps the chosen assets/chains; the entered amount stays put and
+	// the quote re-derives. No-op until both sides have a token.
+	const swapTokens = () => {
+		if (fromToken === null || toToken === null) return;
+		setFromToken(toToken);
+		setToToken(fromToken);
+	};
+
+	// Clear tokens, amount, and denomination back to the initial state.
+	const resetForm = () => {
+		setFromAmount("0");
+		setFromToken(null);
+		setToToken(null);
+		setFromMode("token");
+		setToMode("token");
+	};
+	const isPristine =
+		fromToken === null && toToken === null && Number(fromAmount) === 0;
+
+	// Send/Swap/Bridge: play the Apple-gradient effect for 3s, then reset the form.
+	const handleSubmit = () => {
+		if (!canSwap || submitting) return;
+		setSubmitting(true);
+		window.setTimeout(() => {
+			setSubmitting(false);
+			resetForm();
+		}, 3000);
+	};
 
 	// Latest from amount for the global keyboard handler (avoids stale closures).
 	const stateRef = useRef(fromAmount);
@@ -232,6 +263,7 @@ export function SwapCard() {
 			<section className="rounded-3xl bg-card px-4 pb-3 pt-4">
 				<TokenBox
 					variant="from"
+					selected={fromToken}
 					onSelect={setFromToken}
 					onSetAmount={setFromAmount}
 					connected={connected}
@@ -260,12 +292,14 @@ export function SwapCard() {
 			<div className="relative z-10 mx-auto -my-3 flex w-fit">
 				<HapticButton
 					type="button"
+					onClick={swapTokens}
+					disabled={fromToken === null || toToken === null}
 					style={{
 						background:
 							"linear-gradient(hsl(var(--foreground) / 0.07), hsl(var(--foreground) / 0.07)), hsl(var(--card))",
 					}}
-					className="flex size-8 items-center justify-center rounded-full text-muted-foreground ring-2 ring-background"
-					aria-label="Swap direction"
+					className="flex size-8 items-center justify-center rounded-full text-muted-foreground ring-2 ring-background transition-colors disabled:cursor-not-allowed disabled:text-muted-foreground/40"
+					aria-label="Swap assets"
 				>
 					<ArrowUpDown className="size-4" />
 				</HapticButton>
@@ -275,6 +309,7 @@ export function SwapCard() {
 			<section className="rounded-3xl bg-card px-4 pb-0 pt-6">
 				<TokenBox
 					variant="to"
+					selected={toToken}
 					onSelect={setToToken}
 					slippage={slippage}
 					onOpenSlippage={() => setSlippageOpen(true)}
@@ -299,18 +334,26 @@ export function SwapCard() {
 
 			<MobileKeypad onKey={handleKey} />
 
-			{/* Action button with the theme toggle to its left. */}
+			{/* Action button with the menu button to its left. */}
 			<div className="mt-2 flex items-center gap-2">
-				<div className="flex shrink-0">
-					<ThemeToggleButton2 className="size-12 bg-secondary p-2 text-secondary-foreground" />
-				</div>
+				<AppMenu />
 				<HapticButton
 					wrapperClassName="grid flex-1"
 					type="button"
-					disabled={!canSwap}
-					className="h-12 w-full rounded-full bg-primary text-base font-semibold text-primary-foreground transition-colors hover:bg-primary/90 active:scale-[0.99] disabled:cursor-not-allowed disabled:bg-foreground/[0.08] disabled:text-muted-foreground disabled:hover:bg-foreground/[0.08] disabled:active:scale-100"
+					onClick={handleSubmit}
+					disabled={!canSwap || submitting}
+					className="h-12 w-full rounded-full bg-primary text-base font-semibold text-primary-foreground transition-colors hover:bg-primary/90 active:scale-[0.99] disabled:cursor-not-allowed disabled:bg-secondary disabled:text-muted-foreground disabled:hover:bg-secondary disabled:active:scale-100"
 				>
-					{actionLabel}
+					{submitting ? "Confirming…" : actionLabel}
+				</HapticButton>
+				<HapticButton
+					type="button"
+					onClick={resetForm}
+					disabled={isPristine || submitting}
+					aria-label="Reset"
+					className="flex size-12 shrink-0 items-center justify-center rounded-full bg-secondary text-secondary-foreground transition-colors hover:bg-secondary/80 active:scale-95 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-secondary disabled:active:scale-100"
+				>
+					<RotateCcw className="size-5" />
 				</HapticButton>
 			</div>
 
@@ -320,6 +363,8 @@ export function SwapCard() {
 				value={slippage}
 				onChange={setSlippage}
 			/>
+
+			<AppleBorderGradient preview={submitting} intensity="xl" />
 		</motion.div>
 	);
 }

--- a/workers/jb-swap/src/components/theme-segmented-control.tsx
+++ b/workers/jb-swap/src/components/theme-segmented-control.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { Monitor, Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+
+import { HapticButton } from "@/components/haptic-button";
+import { useThemeToggle } from "@/components/skiper26";
+import { cn } from "@/lib/utils";
+
+type ThemeOption = "system" | "light" | "dark";
+
+const OPTIONS: { value: ThemeOption; label: string; icon: typeof Sun }[] = [
+	{ value: "system", label: "System", icon: Monitor },
+	{ value: "light", label: "Light", icon: Sun },
+	{ value: "dark", label: "Dark", icon: Moon },
+];
+
+/**
+ * System / Light / Dark segmented control. A single pill slides between the
+ * three segments via a shared `layoutId`, while each tap runs the skiper26
+ * View-Transition theme swap so the whole page wipes to the chosen theme.
+ */
+export function ThemeSegmentedControl({ className }: { className?: string }) {
+	const { theme } = useTheme();
+	const { setCrazySystemTheme, setCrazyLightTheme, setCrazyDarkTheme } =
+		useThemeToggle({ variant: "circle", start: "center", blur: true });
+
+	// next-themes is undefined until hydration; gate the active pill on mount so
+	// SSR and the first client paint agree.
+	const [mounted, setMounted] = useState(false);
+	useEffect(() => setMounted(true), []);
+
+	const active = (mounted ? theme : "system") as ThemeOption;
+
+	const select = (value: ThemeOption) => {
+		if (value === "system") setCrazySystemTheme();
+		else if (value === "light") setCrazyLightTheme();
+		else setCrazyDarkTheme();
+	};
+
+	return (
+		<div
+			className={cn(
+				"flex items-center gap-1 rounded-full bg-foreground/[0.06] p-1",
+				className,
+			)}
+		>
+			{OPTIONS.map(({ value, label, icon: Icon }) => {
+				const isActive = active === value;
+				return (
+					<HapticButton
+						key={value}
+						type="button"
+						wrapperClassName="grid flex-1"
+						onClick={() => select(value)}
+						aria-pressed={isActive}
+						className={cn(
+							"relative flex items-center justify-center gap-2 rounded-full px-3 py-2.5 text-sm font-medium transition-colors",
+							isActive
+								? "text-foreground"
+								: "text-muted-foreground hover:text-foreground",
+						)}
+					>
+						{isActive && (
+							<motion.span
+								layoutId="theme-segment-pill"
+								className="absolute inset-0 rounded-full bg-background shadow-sm"
+								transition={{ type: "spring", stiffness: 400, damping: 32 }}
+							/>
+						)}
+						<span className="relative flex items-center gap-2">
+							<Icon className="size-4" />
+							{label}
+						</span>
+					</HapticButton>
+				);
+			})}
+		</div>
+	);
+}

--- a/workers/jb-swap/src/components/token-drawer.tsx
+++ b/workers/jb-swap/src/components/token-drawer.tsx
@@ -254,6 +254,7 @@ function SelectedHeader({
 
 export function TokenBox({
 	variant,
+	selected = null,
 	triggerClassName,
 	onSelect,
 	onSetAmount,
@@ -265,6 +266,8 @@ export function TokenBox({
 	onToggleGenAddress,
 }: {
 	variant: Variant;
+	/** Controlled selected token (owned by the parent so the flip can swap them). */
+	selected?: TokenRow | null;
 	triggerClassName?: string;
 	onSelect?: (token: TokenRow) => void;
 	onSetAmount?: (amount: string) => void;
@@ -276,7 +279,6 @@ export function TokenBox({
 	onToggleGenAddress?: () => void;
 }) {
 	const [open, setOpen] = useState(false);
-	const [selected, setSelected] = useState<TokenRow | null>(null);
 	const [query, setQuery] = useState("");
 	const searchRef = useRef<HTMLInputElement>(null);
 	const listRef = useRef<HTMLDivElement>(null);
@@ -319,7 +321,6 @@ export function TokenBox({
 	activeRef.current = activeIndex;
 
 	const selectToken = (t: TokenRow) => {
-		setSelected(t);
 		setOpen(false);
 		onSelect?.(t);
 	};
@@ -499,7 +500,7 @@ export function TokenBox({
 
 					<div
 						ref={listRef}
-						className="scrollbar-subtle mt-2 min-h-0 flex-1 overflow-y-auto px-5 pb-8"
+						className="scroll-fade scrollbar-subtle mt-2 min-h-0 flex-1 overflow-y-auto px-5 pb-8"
 					>
 						{filtered.length === 0 && (
 							<p className="py-8 text-center text-sm text-muted-foreground">


### PR DESCRIPTION
Swap UI batch for **jb-swap** (swap.joeblau.com).

## What's in here
- **Submit effect (`AppleBorderGradient`)** — on Send/Swap/Bridge, a faithful recreation of Skiper UI's Apple AI Gradient (skiper86) plays for 3s, then the fields reset. A thin, eased edge glow inset by a 4px black margin with rounded corners; the 4 brand colours rotate 0°→360° over 5s and the centre stays transparent so the card stays visible.
- **Menu (`AppMenu`)** — the inline theme toggle is replaced by a menu button that opens a Vaul bottom-sheet with the language drawer and a segmented light/dark theme control (smooth height via a resizable panel).
- **Flip button** — disabled until both From and To assets are selected; now swaps the chain/asset between the two sides.
- **Token list** — Skiper87 scroll-driven fade (top/bottom mask).
- **Layout** — content is always vertically centred, including on mobile.

## Verification
- `bun run cf-build` (clean) is green.
- Submit effect verified end-to-end (triggers on submit, resets after 3s); compiled `.apple-edge-glow` rule confirmed in the bundle (rounded 26px, 32px eased band, 4 mask layers).
- Scroll fade, flip swap/disable, and the Vaul menu verified in-browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)