### PR TITLE
style: pill-shaped token list rows

### DIFF
--- a/workers/jb-swap/src/components/token-drawer.tsx
+++ b/workers/jb-swap/src/components/token-drawer.tsx
@@ -125,7 +125,7 @@ function TokenIcon({ token }: { token: TokenRow }) {
 				alt={token.name}
 				className="size-11 rounded-full bg-foreground/[0.06] object-cover"
 			/>
-			<ChainBadge chainId={token.chainId} className="absolute -bottom-0.5 -right-0.5" />
+			<ChainBadge chainId={token.chainId} className="absolute bottom-0 right-0" />
 		</div>
 	);
 }
@@ -568,11 +568,13 @@ export function TokenBox({
 									key={tokenKey(t)}
 									type="button"
 									data-active={i === activeIndex}
-									wrapperClassName="block w-full"
+									wrapperClassName="mb-2 block w-full"
 									onClick={() => selectToken(t)}
 									className={cn(
-										"flex w-full cursor-pointer items-center gap-3 rounded-xl py-3 text-left transition-colors hover:bg-foreground/[0.04]",
-										i === activeIndex && "bg-foreground/[0.06]",
+										"flex w-full cursor-pointer items-center gap-3 rounded-full py-2 pl-2 pr-4 text-left transition-colors",
+										i === activeIndex
+											? "bg-foreground/10"
+											: "bg-foreground/[0.06] hover:bg-foreground/10",
 										isSelected && "opacity-50",
 									)}
 								>


### PR DESCRIPTION
Small visual polish for jb-swap's token list.

- Token list rows are now filled `rounded-full` pills (`bg-foreground/[0.06]`, hover/active `bg-foreground/10`) with `mb-2` spacing between them, replacing the transparent `rounded-xl` rows.
- Nudge the chain badge to `bottom-0`/`right-0` so it sits flush on the token icon.

className-only change; no logic or imports touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)