### PR TITLE
style: use p-3 padding on the swap page main

### DIFF
--- a/workers/jb-swap/src/app/page.tsx
+++ b/workers/jb-swap/src/app/page.tsx
@@ -2,7 +2,7 @@ import { SwapCard } from "@/components/swap-card";
 
 export default function Home() {
 	return (
-		<main className="flex min-h-screen flex-col items-center justify-center px-6 py-2">
+		<main className="flex min-h-screen flex-col items-center justify-center p-3">
 			<SwapCard />
 		</main>
 	);


### PR DESCRIPTION
The swap page `main` was `px-6 py-2`; this makes it an even **`p-3`** on all sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)