### PR TITLE
feat: render receive QR with cuer

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -58,6 +58,7 @@
         "boring-avatars": "^2.0.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cuer": "^0.0.3",
         "framer-motion": "^12.40.0",
         "lucide-react": "^1.18.0",
         "next": "15.5.9",
@@ -1878,6 +1879,8 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "cuer": ["cuer@0.0.3", "", { "dependencies": { "qr": "~0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18", "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-f/UNxRMRCYtfLEGECAViByA3JNflZImOk11G9hwSd+44jvzrc99J35u5l+fbdQ2+ZG441GvOpaeGYBmWquZsbQ=="],
+
     "d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
 
     "d3-color": ["d3-color@2.0.0", "", {}, "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="],
@@ -3011,6 +3014,8 @@
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+
+    "qr": ["qr@0.6.0", "", {}, "sha512-P23VoX7SipHALdiIYG+D+LT/6n22dNKwV92FAb3d+Nlki/5WisSsfLt0UDFz2XEBtuwrECTznvu+chKKFCSYhA=="],
 
     "qrcode": ["qrcode@1.5.4", "", { "dependencies": { "dijkstrajs": "^1.0.1", "pngjs": "^5.0.0", "yargs": "^15.3.1" }, "bin": { "qrcode": "bin/qrcode" } }, "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg=="],
 

--- a/workers/jb-swap/package.json
+++ b/workers/jb-swap/package.json
@@ -32,6 +32,7 @@
 		"boring-avatars": "^2.0.4",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
+		"cuer": "^0.0.3",
 		"framer-motion": "^12.40.0",
 		"lucide-react": "^1.18.0",
 		"next": "15.5.9",

--- a/workers/jb-swap/src/components/receive-qr.tsx
+++ b/workers/jb-swap/src/components/receive-qr.tsx
@@ -1,13 +1,15 @@
 "use client";
 
-import { QrCode } from "@/components/qr-code";
+import { Cuer } from "cuer";
+
 import { buildPaymentPayload, type PaymentRequest } from "@/lib/eip681";
 import { cn } from "@/lib/utils";
 
 /**
  * A scannable receive QR for an address. Encodes an EIP-681 payment URI for EVM
  * addresses (so a scanning wallet pre-fills the transfer) or the bare address
- * for non-EVM chains. Rendered on a white tile so any wallet camera reads it.
+ * for non-EVM chains. Rendered with cuer (https://cuer.dev) on a white tile so
+ * any wallet camera reads it.
  */
 export function ReceiveQr({
 	request,
@@ -22,7 +24,7 @@ export function ReceiveQr({
 	return (
 		<div className={cn("flex flex-col items-center gap-3", className)}>
 			<div className="rounded-2xl bg-white p-3 shadow-sm">
-				<QrCode value={payload} size={size} foreground="#000000" background="#ffffff" />
+				<Cuer value={payload} size={size} color="#000000" />
 			</div>
 			<code className="max-w-[16rem] break-all text-center text-xs text-muted-foreground">
 				{request.address}


### PR DESCRIPTION
## What

Install [`cuer`](https://cuer.dev) (wevm's opinionated React QR component — same ecosystem as our viem/Privy/Relay stack) and use it in `ReceiveQr` instead of the custom `qrcode-generator` SVG renderer.

- `bun add cuer` → `cuer@0.0.3`
- `src/components/receive-qr.tsx`: `<QrCode>` → `<Cuer value … color size />`

## Notes

- cuer's rounded SVG style matches the app's rounded aesthetic and supports a center `arena` logo we can add later.
- `ReceiveQr` isn't mounted in any visible screen yet (built during the Relay "generate QR for addresses" work), so **no rendered UI changes** — this just makes the dependency meaningful for when the receive flow is surfaced.
- `qr-code.tsx` is now unused; left in place as a harmless SSR-safe fallback.

## Verification

- 298/298 unit tests pass
- Changed files typecheck clean; `Cuer` resolves at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)