### PR TITLE
fix: reliable wallet logout + CORS-friendly balance RPCs

### DIFF
--- a/workers/jb-swap/src/lib/relay/balances.ts
+++ b/workers/jb-swap/src/lib/relay/balances.ts
@@ -51,6 +51,32 @@ const CHAINS: Record<number, Chain> = {
 	[zora.id]: zora,
 };
 
+/**
+ * Per-chain RPC URLs that allow browser (cross-origin) requests. viem's default
+ * chain RPCs don't — mainnet's `https://eth.merkle.io` returns no
+ * `Access-Control-Allow-Origin`, so the multicall fails from the browser. These
+ * public endpoints (publicnode, plus official endpoints for zkSync/Zora which
+ * publicnode doesn't host) all respond with `access-control-allow-origin: *` on
+ * both the preflight and the POST. Verified 2026-06.
+ */
+const RPC_URLS: Record<number, string> = {
+	[mainnet.id]: "https://ethereum-rpc.publicnode.com",
+	[base.id]: "https://base-rpc.publicnode.com",
+	[arbitrum.id]: "https://arbitrum-one-rpc.publicnode.com",
+	[optimism.id]: "https://optimism-rpc.publicnode.com",
+	[polygon.id]: "https://polygon-bor-rpc.publicnode.com",
+	[bsc.id]: "https://bsc-rpc.publicnode.com",
+	[avalanche.id]: "https://avalanche-c-chain-rpc.publicnode.com",
+	[zksync.id]: "https://mainnet.era.zksync.io",
+	[linea.id]: "https://linea-rpc.publicnode.com",
+	[scroll.id]: "https://scroll-rpc.publicnode.com",
+	[blast.id]: "https://blast-rpc.publicnode.com",
+	[mantle.id]: "https://mantle-rpc.publicnode.com",
+	[gnosis.id]: "https://gnosis-rpc.publicnode.com",
+	[celo.id]: "https://celo-rpc.publicnode.com",
+	[zora.id]: "https://rpc.zora.energy",
+};
+
 const NATIVE = "0x0000000000000000000000000000000000000000";
 
 /** Chains (with catalog tokens) we can read EVM balances on. */
@@ -72,7 +98,10 @@ async function fetchChainHeld(
 	tokens: TokenRow[],
 	user: `0x${string}`,
 ): Promise<TokenRow[]> {
-	const client = createPublicClient({ chain: CHAINS[chainId], transport: http() });
+	const client = createPublicClient({
+		chain: CHAINS[chainId],
+		transport: http(RPC_URLS[chainId]),
+	});
 	const erc20 = tokens.filter((t) => t.address.toLowerCase() !== NATIVE);
 	const native = tokens.find((t) => t.address.toLowerCase() === NATIVE);
 

--- a/workers/jb-swap/src/lib/use-wallet.ts
+++ b/workers/jb-swap/src/lib/use-wallet.ts
@@ -3,9 +3,14 @@
 import { usePrivy, useWallets } from "@privy-io/react-auth";
 import { useWallets as useSolanaWallets } from "@privy-io/react-auth/solana";
 import type { AdaptedWallet } from "@relayprotocol/relay-sdk";
-import { useCallback } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 
 import { adaptedWalletFromEip1193 } from "@/lib/wallet-adapter";
+import {
+	clearManualDisconnect,
+	setManualDisconnect,
+	walletSessionStore,
+} from "@/lib/wallet-session-store";
 
 /**
  * Connection state for the swap UI, backed by Privy external wallets. Reports
@@ -14,13 +19,23 @@ import { adaptedWalletFromEip1193 } from "@/lib/wallet-adapter";
  * embedded/smart wallets are involved — see {@link WalletProvider}.
  */
 export function useWallet() {
-	const { ready, connectWallet, logout } = usePrivy();
+	const { ready, login, logout } = usePrivy();
 	const { wallets: evmWallets } = useWallets();
 	const { wallets: solanaWallets } = useSolanaWallets();
 
 	const evmWallet = evmWallets[0];
 	const solanaWallet = solanaWallets[0];
-	const address = evmWallet?.address ?? solanaWallet?.address ?? null;
+	const rawAddress = evmWallet?.address ?? solanaWallet?.address ?? null;
+
+	// Whether the user explicitly logged out. Injected wallets can't be told to
+	// disconnect, so we override Privy's (still-connected) view locally. See
+	// {@link walletSessionStore}.
+	const manuallyDisconnected = useSyncExternalStore(
+		walletSessionStore.subscribe,
+		walletSessionStore.getSnapshot,
+		walletSessionStore.getServerSnapshot,
+	);
+	const address = manuallyDisconnected ? null : rawAddress;
 
 	/** Build a Relay AdaptedWallet from the connected EVM wallet (for executeSwap). */
 	const getAdaptedWallet = useCallback(async (): Promise<AdaptedWallet> => {
@@ -40,13 +55,30 @@ export function useWallet() {
 		ready,
 		connected: address !== null,
 		address,
-		evmAddress: evmWallet?.address ?? null,
-		solanaAddress: solanaWallet?.address ?? null,
-		connect: () => connectWallet(),
+		evmAddress: manuallyDisconnected ? null : (evmWallet?.address ?? null),
+		solanaAddress: manuallyDisconnected ? null : (solanaWallet?.address ?? null),
+		// Clear the override first so the wallet re-surfaces, then open Privy's
+		// login modal. `login()` (vs `connectWallet()`) creates an authenticated
+		// session so the eventual `logout()` has something real to destroy
+		// (avoids the connect-only `POST /sessions/logout` 400). If a wallet is
+		// already connected at the provider level, just clearing the override
+		// reconnects instantly with no redundant modal.
+		connect: () => {
+			clearManualDisconnect();
+			if (rawAddress === null) login();
+		},
+		// Injected wallets (MetaMask/Phantom) can't be programmatically
+		// disconnected and Privy's `useWallets()` isn't gated on auth, so neither
+		// `wallet.disconnect()` nor `logout()` clears the list. Flip the local
+		// override first (the UI returns to connect immediately and reliably),
+		// then best-effort tear down the connector + Privy session for any wallet
+		// that *does* support it. The logout 400 on a stale session is harmless —
+		// Privy still clears local tokens — so swallow it.
 		disconnect: () => {
-			evmWallets.forEach((w) => w.disconnect?.());
-			solanaWallets.forEach((w) => w.disconnect?.());
-			logout();
+			setManualDisconnect();
+			void evmWallet?.disconnect?.();
+			void solanaWallet?.disconnect?.();
+			void logout().catch(() => {});
 		},
 		getAdaptedWallet,
 	};

--- a/workers/jb-swap/src/lib/wallet-session-store.test.ts
+++ b/workers/jb-swap/src/lib/wallet-session-store.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+	clearManualDisconnect,
+	setManualDisconnect,
+	walletSessionStore,
+} from "./wallet-session-store";
+
+// The store is a module singleton — reset it after every test so order doesn't
+// matter.
+afterEach(() => clearManualDisconnect());
+
+describe("walletSessionStore", () => {
+	test("starts not-disconnected", () => {
+		expect(walletSessionStore.getSnapshot()).toBe(false);
+	});
+
+	test("server snapshot is always false", () => {
+		setManualDisconnect();
+		expect(walletSessionStore.getServerSnapshot()).toBe(false);
+	});
+
+	test("set/clear flips the snapshot", () => {
+		setManualDisconnect();
+		expect(walletSessionStore.getSnapshot()).toBe(true);
+		clearManualDisconnect();
+		expect(walletSessionStore.getSnapshot()).toBe(false);
+	});
+
+	test("notifies subscribers on change", () => {
+		let calls = 0;
+		const unsub = walletSessionStore.subscribe(() => calls++);
+		setManualDisconnect();
+		clearManualDisconnect();
+		expect(calls).toBe(2);
+		unsub();
+	});
+
+	test("does not notify when the value is unchanged (idempotent)", () => {
+		let calls = 0;
+		const unsub = walletSessionStore.subscribe(() => calls++);
+		setManualDisconnect();
+		setManualDisconnect(); // already true — no emit
+		expect(calls).toBe(1);
+		unsub();
+	});
+
+	test("unsubscribed listeners stop receiving updates", () => {
+		let calls = 0;
+		const unsub = walletSessionStore.subscribe(() => calls++);
+		unsub();
+		setManualDisconnect();
+		expect(calls).toBe(0);
+	});
+});

--- a/workers/jb-swap/src/lib/wallet-session-store.ts
+++ b/workers/jb-swap/src/lib/wallet-session-store.ts
@@ -1,0 +1,53 @@
+/**
+ * A tiny module-level store for an explicit "the user disconnected" override.
+ *
+ * Injected wallets (MetaMask/Phantom) can't be programmatically disconnected:
+ * their connector `disconnect()` is a documented no-op, and Privy's
+ * `useWallets()` is driven by the live connector store (not by auth state), so
+ * neither `wallet.disconnect()` nor `logout()` removes the wallet from the list.
+ * Without this, the UI would never return to the connect screen on "log out".
+ *
+ * This override lets {@link useWallet} treat the wallet as disconnected the
+ * instant the user clicks log out — regardless of what Privy still reports — and
+ * is cleared when they reconnect. State is shared through one subscription set
+ * so every `useWallet()` consumer re-renders consistently. It is intentionally
+ * in-memory (a page refresh re-evaluates the live connection).
+ */
+let manuallyDisconnected = false;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+	for (const listener of listeners) listener();
+}
+
+export const walletSessionStore = {
+	subscribe(listener: () => void): () => void {
+		listeners.add(listener);
+		return () => {
+			listeners.delete(listener);
+		};
+	},
+	getSnapshot(): boolean {
+		return manuallyDisconnected;
+	},
+	/** Server snapshot is always "not disconnected" — no wallet exists on the server. */
+	getServerSnapshot(): boolean {
+		return false;
+	},
+};
+
+/** Mark the wallet as disconnected (called from `useWallet().disconnect`). */
+export function setManualDisconnect(): void {
+	if (!manuallyDisconnected) {
+		manuallyDisconnected = true;
+		emit();
+	}
+}
+
+/** Clear the override so a fresh connect re-surfaces the wallet. */
+export function clearManualDisconnect(): void {
+	if (manuallyDisconnected) {
+		manuallyDisconnected = false;
+		emit();
+	}
+}


### PR DESCRIPTION
Fixes two bugs reported from the running app, both root-caused against the installed sources.

## 1. Logout did nothing

Clicking log out left the wallet on screen. Root cause (verified in `@privy-io/react-auth@3.30.0`):

- Injected wallets (MetaMask/Phantom) **can't be programmatically disconnected** — the connector's `disconnect()` is a documented no-op.
- Privy's `useWallets()` is driven by the **live connector store, not auth state**, so neither `wallet.disconnect()` nor `logout()` removes the wallet from the list. `connected = address !== null` stayed true.
- The `POST /sessions/logout` **400 is a red herring** — Privy clears local tokens in a `catch` regardless.

**Fix:** a tiny module-level "manually disconnected" override (`wallet-session-store.ts`) read via `useSyncExternalStore`:
- `disconnect()` flips the override **first** (UI returns to the connect screen instantly + reliably), then best-effort tears down the connector + Privy session.
- `connect()` clears the override and only opens the login modal when no wallet is already connected (instant reconnect otherwise).
- `connect` uses `login()` (authenticated session) rather than `connectWallet()` so a real logout has a session to destroy.

## 2. Balance multicall blocked by CORS

`balances.ts` called viem `http()` with no URL → each chain's **default** RPC. Mainnet's `https://eth.merkle.io` returns no `Access-Control-Allow-Origin`, so the browser blocked it (`net::ERR_FAILED`).

**Fix:** pin a CORS-verified public RPC per chain — publicnode for 13, official endpoints for zkSync/Zora (publicnode doesn't host them). All respond `access-control-allow-origin: *` on both the preflight and the POST; every returned `chainId` matches.

## Verification

- 304/304 unit tests (added 6 for the override store)
- Changed files typecheck clean
- CORS independently re-confirmed via curl for mainnet, zkSync (`0x144`), Zora (`0x76adf1`)
- ⚠️ Logout end-to-end still needs a real wallet test in-browser (connect MetaMask → log out → confirm it returns to the connect screen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)