### PR TITLE
feat: add Saint Martin pin to travel map

### DIFF
--- a/workers/jb-travel/public/conquer-earth-locations.geojson
+++ b/workers/jb-travel/public/conquer-earth-locations.geojson
@@ -4,7 +4,7 @@
     "source": "Conquer Earth",
     "url": "https://conquer.earth/joeblau/places",
     "api": "1.0",
-    "count": "305",
+    "count": "306",
     "generated_at": "1768454824"
   },
   "features": [
@@ -3971,6 +3971,19 @@
         "type": "Route",
         "description": "",
         "token": "3zZCrASsV4NdkTJtYhoKwe"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-63.0501, 18.0708]
+      },
+      "properties": {
+        "title": "Saint Martin",
+        "type": "Country",
+        "description": null,
+        "token": "AbuegL86NXSGZOGjx265gL"
       }
     }
   ]


### PR DESCRIPTION
## Summary
Adds a **Saint Martin** location pin to the conquer-earth travel map.

- Coordinates: `[-63.0501, 18.0708]` (lng, lat — the Caribbean island)
- Type: `Country` (matches nearby islands like Jamaica & Puerto Rico)
- Generated a unique 22-char token in the existing format
- Bumped `metadata.count` 305 → 306
- Validated: file parses as JSON, 306 features

🤖 Generated with [Claude Code](https://claude.com/claude-code)