### PR TITLE
feat: generate-address receive view (QR + vertical address)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -66,6 +66,7 @@
         "qrcode-generator": "^2.0.4",
         "react": "19.1.4",
         "react-dom": "19.1.4",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
         "vaul": "^1.1.2",
         "viem": "^2.52.2",
@@ -205,6 +206,9 @@
         "wrangler": "^4.54.0",
       },
     },
+  },
+  "patchedDependencies": {
+    "cuer@0.0.3": "patches/cuer@0.0.3.patch",
   },
   "packages": {
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
@@ -927,7 +931,7 @@
 
     "@radix-ui/react-slider": ["@radix-ui/react-slider@1.3.6", "", { "dependencies": { "@radix-ui/number": "1.1.1", "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-use-size": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw=="],
 
-    "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
+    "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.5", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg=="],
 
     "@radix-ui/react-switch": ["@radix-ui/react-switch@1.2.6", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-use-size": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ=="],
 
@@ -3015,7 +3019,7 @@
 
     "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
-    "qr": ["qr@0.6.0", "", {}, "sha512-P23VoX7SipHALdiIYG+D+LT/6n22dNKwV92FAb3d+Nlki/5WisSsfLt0UDFz2XEBtuwrECTznvu+chKKFCSYhA=="],
+    "qr": ["qr@0.5.5", "", {}, "sha512-iQBvKj7MRKO+co+MY0IZpyLO+ezvttxsmV86WywrgPuAmgBkv0pytyi03wourniSoPgzffeBW6cBgIkpqcvjTg=="],
 
     "qrcode": ["qrcode@1.5.4", "", { "dependencies": { "dijkstrajs": "^1.0.1", "pngjs": "^5.0.0", "yargs": "^15.3.1" }, "bin": { "qrcode": "bin/qrcode" } }, "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg=="],
 
@@ -3737,6 +3741,8 @@
 
     "@radix-ui/react-separator/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg=="],
 
+    "@radix-ui/react-slot/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
+
     "@radix-ui/react-toast/@radix-ui/react-visually-hidden": ["@radix-ui/react-visually-hidden@1.2.3", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug=="],
 
     "@radix-ui/react-toolbar/@radix-ui/react-separator": ["@radix-ui/react-separator@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA=="],
@@ -3971,13 +3977,9 @@
 
     "jayson/ws": ["ws@7.5.11", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA=="],
 
-    "jb-swap/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.5", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg=="],
-
     "jb-swap/lucide-react": ["lucide-react@1.18.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-LZDb7H/0YfM+RJncD0hDQRCAu+vSGODqpe35TuVI8EuXaRjkczbsx7p8dY4J87F/MUSj6bpYqeI8nw8qXaAdmA=="],
 
     "jb-travel/@number-flow/react": ["@number-flow/react@0.5.14", "", { "dependencies": { "esm-env": "^1.1.4", "number-flow": "0.5.12" }, "peerDependencies": { "react": "^18 || ^19", "react-dom": "^18 || ^19" } }, "sha512-FGUqjh/P5/ukr0U0ySwb987M0SbRkrnZq70f0wQFncDbXa3SIib4L+FTr5ngvWwGAW8S6b391eTXcfhErZsw4w=="],
-
-    "jb-travel/framer-motion": ["framer-motion@12.34.5", "", { "dependencies": { "motion-dom": "^12.34.5", "motion-utils": "^12.29.2", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-Z2dQ+o7BsfpJI3+u0SQUNCrN+ajCKJen1blC4rCHx1Ta2EOHs+xKJegLT2aaD9iSMbU3OoX+WabQXkloUbZmJQ=="],
 
     "jest-util/ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
 
@@ -4309,6 +4311,12 @@
 
     "@puppeteer/browsers/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
+    "@radix-ui/react-label/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
+
+    "@radix-ui/react-separator/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
+
+    "@radix-ui/react-visually-hidden/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
+
     "@react-native/codegen/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "@react-native/codegen/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
@@ -4501,6 +4509,8 @@
 
     "cloudflare/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
+    "cmdk/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
+
     "connect/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "connect/finalhandler/encodeurl": ["encodeurl@1.0.2", "", {}, "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="],
@@ -4523,13 +4533,7 @@
 
     "jayson/@types/ws/@types/node": ["@types/node@25.3.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ=="],
 
-    "jb-swap/@radix-ui/react-slot/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA=="],
-
     "jb-travel/@number-flow/react/number-flow": ["number-flow@0.5.12", "", { "dependencies": { "esm-env": "^1.1.4" } }, "sha512-CIs21h2JkfYG4rfgERaUNAk0Cz+Ef14fNJfSCbGGhgRgconQc9b7rcCQfi9SZ36kNjVXmsl2BrzDbjGtEgumAA=="],
-
-    "jb-travel/framer-motion/motion-dom": ["motion-dom@12.34.5", "", { "dependencies": { "motion-utils": "^12.29.2" } }, "sha512-k33CsnxO2K3gBRMUZT+vPmc4Utlb5menKdG0RyVNLtlqRaaJPRWlE9fXl8NTtfZ5z3G8TDvqSu0MENLqSTaHZA=="],
-
-    "jb-travel/framer-motion/motion-utils": ["motion-utils@12.29.2", "", {}, "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A=="],
 
     "lighthouse-logger/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
   "packageManager": "bun@1.3.0",
   "devDependencies": {
     "turbo": "^2"
+  },
+  "patchedDependencies": {
+    "cuer@0.0.3": "patches/cuer@0.0.3.patch"
   }
 }

--- a/patches/cuer@0.0.3.patch
+++ b/patches/cuer@0.0.3.patch
@@ -1,0 +1,25 @@
+diff --git a/_dist/QrCode.js b/_dist/QrCode.js
+index b1806526c3d100ca6f1e9259b4dfbcd416a33927..909dac69d8adfbd9c306e5220ca1212eed3e6954 100644
+--- a/_dist/QrCode.js
++++ b/_dist/QrCode.js
+@@ -1,12 +1,18 @@
+ import { encodeQR } from 'qr';
+ export function create(value, options = {}) {
+     const { errorCorrection, version } = options;
+-    const grid = encodeQR(value, 'raw', {
+-        border: 0,
++    // qr >= 0.6.0 rejects border <= 0; request a 2-module quiet zone and strip
++    // it back off so cuer still receives the border-less grid it expects.
++    const border = 2;
++    const bordered = encodeQR(value, 'raw', {
++        border,
+         ecc: errorCorrection,
+         scale: 1,
+         version: version,
+     });
++    const grid = bordered
++        .slice(border, bordered.length - border)
++        .map((row) => row.slice(border, row.length - border));
+     const finderLength = 7;
+     const edgeLength = grid.length;
+     return {

--- a/workers/jb-swap/package.json
+++ b/workers/jb-swap/package.json
@@ -40,6 +40,7 @@
 		"qrcode-generator": "^2.0.4",
 		"react": "19.1.4",
 		"react-dom": "19.1.4",
+		"sonner": "^2.0.7",
 		"tailwind-merge": "^3.4.0",
 		"vaul": "^1.1.2",
 		"viem": "^2.52.2"

--- a/workers/jb-swap/src/app/layout.tsx
+++ b/workers/jb-swap/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Nunito } from "next/font/google";
 import "./globals.css";
 import { ThemeProvider } from "@/components/theme-provider";
+import { Toaster } from "@/components/toaster";
 import { WalletProvider } from "@/components/wallet-provider";
 import { LocaleProvider } from "@/i18n/locale-provider";
 
@@ -47,6 +48,7 @@ export default function RootLayout({
 					<WalletProvider>
 						<LocaleProvider>{children}</LocaleProvider>
 					</WalletProvider>
+					<Toaster />
 				</ThemeProvider>
 			</body>
 		</html>

--- a/workers/jb-swap/src/components/crypto-address.tsx
+++ b/workers/jb-swap/src/components/crypto-address.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { Cuer } from "cuer";
+import { toast } from "sonner";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Tap-to-copy receive view: a scannable Cuer QR on the left, the address laid
+ * out as a multi-row "vertical address" on the right with the anchor characters
+ * (the leading + trailing chars wallets use to eyeball a match) highlighted and
+ * the middle faded. The whole surface copies the address on tap.
+ *
+ * `qrValue` overrides ONLY the QR payload (e.g. an EIP-681 asset-transfer URI so
+ * a scanning wallet pre-fills the right token); the displayed + copied text is
+ * always the bare `address`. `arena` renders a logo (the asset icon) in the QR
+ * center — cuer bumps the error-correction level so it still scans.
+ *
+ * Adapted from the bloxwap `CryptoAddress` / `AddressColumn`.
+ */
+export function CryptoAddress({
+	address,
+	qrValue,
+	arena,
+}: {
+	address: string;
+	qrValue?: string;
+	arena?: string;
+}) {
+	const copy = () => {
+		navigator.clipboard
+			?.writeText(address)
+			.then(() => toast.success("Address copied"))
+			.catch(() => {});
+	};
+	return (
+		<button
+			type="button"
+			onClick={copy}
+			aria-label="Copy address"
+			className="block w-full rounded-2xl p-2 transition-opacity active:opacity-80"
+		>
+			<div className="flex w-full items-center justify-evenly">
+				{/* Square tile; QR is `currentColor` so it flips with the theme:
+				    white tile + black code (light), black tile + white code (dark). */}
+				<div className="grid aspect-square w-[clamp(112px,38vw,196px)] shrink-0 rounded-2xl bg-white p-2 text-black dark:bg-black dark:text-white [&_svg]:block [&_svg]:size-full">
+					<Cuer
+						value={qrValue ?? address}
+						size={196}
+						color="currentColor"
+						arena={arena}
+						errorCorrection={arena ? "high" : undefined}
+					/>
+				</div>
+				<AddressColumn address={address} />
+			</div>
+		</button>
+	);
+}
+
+/**
+ * The address as a column of fixed-width chunks. EVM (`0x` + 40 hex) lays out 6
+ * chars × 7 rows at the larger font; everything else (Solana base58, etc.) uses
+ * a narrower 4-char grid at a smaller font. The leading anchor (6 for EVM, else
+ * 4) and trailing 4 chars are bold; the middle is faded.
+ */
+function AddressColumn({ address }: { address: string }) {
+	const isEvm = address.startsWith("0x");
+	const chunkSize = isEvm ? 6 : 4;
+	const hiStart = isEvm ? 6 : 4;
+	const total = address.length;
+	const hiEnd = total - 4;
+	const chunks: string[] = [];
+	for (let i = 0; i < total; i += chunkSize) {
+		chunks.push(address.slice(i, i + chunkSize));
+	}
+	const fontClass = isEvm
+		? "text-[clamp(15px,5vw,26px)] leading-[1.06]"
+		: "text-[clamp(10px,3.4vw,18px)] leading-[1.1]";
+	return (
+		<div
+			className={cn(
+				"flex min-w-0 flex-col font-mono tracking-wide tabular-nums",
+				fontClass,
+			)}
+		>
+			{chunks.map((chunk, chunkIdx) => (
+				// biome-ignore lint/suspicious/noArrayIndexKey: fixed-order address chunks
+				<span key={chunkIdx}>
+					{Array.from(chunk).map((ch, i) => {
+						const globalIdx = chunkIdx * chunkSize + i;
+						const highlighted = globalIdx < hiStart || globalIdx >= hiEnd;
+						return (
+							<span
+								// biome-ignore lint/suspicious/noArrayIndexKey: fixed-order address chars
+								key={i}
+								className={
+									highlighted
+										? "font-semibold text-foreground"
+										: "font-medium text-foreground/25"
+								}
+							>
+								{ch}
+							</span>
+						);
+					})}
+				</span>
+			))}
+		</div>
+	);
+}

--- a/workers/jb-swap/src/components/swap-card.tsx
+++ b/workers/jb-swap/src/components/swap-card.tsx
@@ -7,10 +7,12 @@ import { useEffect, useRef, useState } from "react";
 
 import { AppleBorderGradient } from "@/components/apple-border-gradient";
 import { AppMenu, type Denomination, DENOMINATION_KEY } from "@/components/app-menu";
+import { CryptoAddress } from "@/components/crypto-address";
 import { HapticButton } from "@/components/haptic-button";
 import { MobileKeypad } from "@/components/keypad";
 import { SlippageDrawer } from "@/components/slippage-drawer";
 import { price, TokenBox, type TokenRow } from "@/components/token-drawer";
+import { buildPaymentPayload } from "@/lib/eip681";
 import { useTranslations } from "@/i18n/locale-provider";
 import { usePersistentState } from "@/lib/use-persistent-state";
 import type { QuoteRequest } from "@/lib/relay";
@@ -34,6 +36,9 @@ function getActionLabel(from: TokenRow | null, to: TokenRow | null) {
 
 /** Quote constant — must match the "Fee $0.25" shown in SelectedMeta. */
 const FEE_USD = 0.25;
+
+/** Placeholder receive address shown before a wallet is connected (a well-known example address). */
+const PREVIEW_ADDRESS = "0x71C7656EC7ab88b098defB751B7401B5f6d8976F";
 
 /** Trim a number to a clean string (drops trailing zeros, caps at 8 decimals). */
 function trim(n: number) {
@@ -159,6 +164,38 @@ function AmountInput({
 	);
 }
 
+/** Shared CSS height transition for the animated amount fields. */
+const AMOUNT_FIELD_TRANSITION =
+	"overflow-hidden transition-[height] duration-[400ms] ease-[cubic-bezier(0.22,1,0.36,1)]";
+
+/**
+ * Measures the natural (content-box) height of an element and keeps it current
+ * across breakpoint/value changes via a ResizeObserver. Returns the ref to put
+ * on the content and its measured height (`null` until first measured). Used to
+ * coordinate the generate-address animation: the "from" amount field grows by
+ * exactly the height the removed "to" amount block gives up, so the card's total
+ * height is unchanged.
+ *
+ * A hook rather than a wrapper component so call sites use inline JSX — a
+ * `children: ReactNode` prop trips the repo's duplicated `@types/react`.
+ */
+function useMeasuredHeight() {
+	const ref = useRef<HTMLDivElement>(null);
+	const [height, setHeight] = useState<number | null>(null);
+
+	useEffect(() => {
+		const el = ref.current;
+		if (!el) return;
+		const measure = () => setHeight(el.offsetHeight);
+		measure();
+		const ro = new ResizeObserver(measure);
+		ro.observe(el);
+		return () => ro.disconnect();
+	}, []);
+
+	return { ref, height };
+}
+
 export function SwapCard() {
 	const t = useTranslations();
 	// Default amount denomination, set in the menu and persisted. It seeds the
@@ -179,6 +216,14 @@ export function SwapCard() {
 	// Real wallet connection via Privy (external EVM/SVM wallets only).
 	const { connected, address, connect, disconnect } = useWallet();
 	const [genAddress, setGenAddress] = useState(false);
+	// Generate-address mode swaps the "from" amount ($0 + units) for a receive
+	// view (QR + vertical address) and removes the "to" amount block entirely.
+	// Each area animates its measured height to fit whatever content it holds.
+	const fromAmountBox = useMeasuredHeight();
+	const toAmountBox = useMeasuredHeight();
+	const fromAmountHeight = fromAmountBox.height ?? undefined;
+	const toAmountHeight =
+		toAmountBox.height == null ? undefined : genAddress ? 0 : toAmountBox.height;
 	const [submitting, setSubmitting] = useState(false);
 	const action = getActionLabel(fromToken, toToken);
 	const canFlip = fromToken !== null && toToken !== null;
@@ -189,6 +234,20 @@ export function SwapCard() {
 	const fromUnits =
 		fromMode === "token" ? fromInput : fromPrice > 0 ? fromInput / fromPrice : 0;
 	const fromUsd = fromUnits * fromPrice;
+
+	// Generate-address receive view: the address (the connected wallet, or a
+	// placeholder before connect) and an asset-formatted EIP-681 QR payload for
+	// the selected FROM token so a scanning wallet pre-fills the right asset.
+	const receiveAddress = address ?? PREVIEW_ADDRESS;
+	const receivePayload = fromToken
+		? buildPaymentPayload({
+				address: receiveAddress,
+				chainId: fromToken.chainId,
+				tokenAddress: fromToken.address,
+				decimals: fromToken.decimals,
+				vmType: fromToken.vmType,
+			})
+		: receiveAddress;
 
 	// Live Relay quote (debounced). Drives the real received amount + fees; while
 	// it loads or if it errors we fall back to a local price estimate so the UI
@@ -431,25 +490,54 @@ export function SwapCard() {
 					onConnect={connect}
 					onDisconnect={disconnect}
 					genAddress={genAddress}
-					onToggleGenAddress={() => setGenAddress((v) => !v)}
+					onToggleGenAddress={() => {
+						const next = !genAddress;
+						setGenAddress(next);
+						// Deselecting generate-address while not connected: the address
+						// shown was only a placeholder, so revert the "from" field to its
+						// empty state instead of leaving a fake selected token.
+						if (!next && !connected) {
+							setFromToken(null);
+							setFromAmount("0");
+						}
+					}}
 					triggerClassName="-mx-4 -mt-4 w-[calc(100%+2rem)] rounded-t-3xl px-4 pb-4 pt-4 hover:bg-foreground/[0.03]"
 				/>
 				<div className="-mx-4 border-t-2 border-background" />
-				<div className="flex flex-col items-center gap-2 p-2">
-					<AmountInput
-						value={fromAmount}
-						prefix={fromMode === "usd" ? "$" : undefined}
-					/>
-					<Pill onClick={toggleFromMode}>
-						<span className="opacity-50">=</span>{" "}
-						<ConversionValue
-							mode={fromMode}
-							usd={fromUsd}
-							units={fromUnits}
-							symbol={fromToken?.symbol ?? ""}
-						/>
-						<ArrowUpDown className="size-3.5" />
-					</Pill>
+				<div
+					className={cn("flex flex-col justify-center", AMOUNT_FIELD_TRANSITION)}
+					style={{ height: fromAmountHeight }}
+				>
+					<div ref={fromAmountBox.ref}>
+						{genAddress ? (
+							// Receive view: QR + vertical address, formatted per asset.
+							// The $0 + units are hidden in this mode. CryptoAddress's own
+							// p-2 matches the normal field's p-2, so the gap below it to the
+							// flip button is identical (no extra wrapper padding).
+							<CryptoAddress
+								address={receiveAddress}
+								qrValue={receivePayload}
+								arena={fromToken?.logo}
+							/>
+						) : (
+							<div className="flex flex-col items-center gap-2 p-2">
+								<AmountInput
+									value={fromAmount}
+									prefix={fromMode === "usd" ? "$" : undefined}
+								/>
+								<Pill onClick={toggleFromMode}>
+									<span className="opacity-50">=</span>{" "}
+									<ConversionValue
+										mode={fromMode}
+										usd={fromUsd}
+										units={fromUnits}
+										symbol={fromToken?.symbol ?? ""}
+									/>
+									<ArrowUpDown className="size-3.5" />
+								</Pill>
+							</div>
+						)}
+					</div>
 				</div>
 			</section>
 
@@ -494,25 +582,35 @@ export function SwapCard() {
 					walletAddress={address}
 					slippage={slippage}
 					onOpenSlippage={() => setSlippageOpen(true)}
-					triggerClassName="-mx-4 -mt-6 w-[calc(100%+2rem)] rounded-t-3xl px-4 pb-4 pt-6 hover:bg-foreground/[0.03]"
+					triggerClassName={cn(
+						"-mx-4 -mt-6 w-[calc(100%+2rem)] px-4 pb-4 pt-6 hover:bg-foreground/[0.03]",
+						genAddress ? "rounded-3xl" : "rounded-t-3xl",
+					)}
 				/>
-				<div className="-mx-4 border-t-2 border-background" />
-				<div className="flex flex-col items-center gap-2 p-2">
-					<AmountInput
-						value={trim(toMode === "token" ? toAmount : toUsd)}
-						prefix={toMode === "usd" ? "$" : undefined}
-						muted
-					/>
-					<Pill onClick={toggleToMode}>
-						<span className="opacity-50">=</span>{" "}
-						<ConversionValue
-							mode={toMode}
-							usd={toUsd}
-							units={toAmount}
-							symbol={toToken?.symbol ?? ""}
-						/>
-						<ArrowUpDown className="size-3.5" />
-					</Pill>
+				{/* The destination amount is removed entirely in generate-address
+				    mode; the "from" field grows by exactly this block's height so
+				    the card's total height never changes. */}
+				<div className={AMOUNT_FIELD_TRANSITION} style={{ height: toAmountHeight }}>
+					<div ref={toAmountBox.ref}>
+						<div className="-mx-4 border-t-2 border-background" />
+						<div className="flex flex-col items-center gap-2 p-2">
+							<AmountInput
+								value={trim(toMode === "token" ? toAmount : toUsd)}
+								prefix={toMode === "usd" ? "$" : undefined}
+								muted
+							/>
+							<Pill onClick={toggleToMode}>
+								<span className="opacity-50">=</span>{" "}
+								<ConversionValue
+									mode={toMode}
+									usd={toUsd}
+									units={toAmount}
+									symbol={toToken?.symbol ?? ""}
+								/>
+								<ArrowUpDown className="size-3.5" />
+							</Pill>
+						</div>
+					</div>
 				</div>
 			</section>
 

--- a/workers/jb-swap/src/components/toaster.tsx
+++ b/workers/jb-swap/src/components/toaster.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { Toaster as SonnerToaster } from "sonner";
+
+/**
+ * App toaster — top-center, following the resolved light/dark theme so toasts
+ * match the surrounding surfaces. Mounted once in the root layout.
+ */
+export function Toaster() {
+	const { resolvedTheme } = useTheme();
+	return (
+		<SonnerToaster
+			position="top-center"
+			theme={resolvedTheme === "dark" ? "dark" : "light"}
+		/>
+	);
+}


### PR DESCRIPTION
In **generate-address** mode the "from" field becomes a receive view: a **Cuer QR** (left) + a **vertical address** (right), with the destination amount removed.

## What
- **`crypto-address.tsx`** (new) — Cuer QR + `AddressColumn` vertical address (anchor chars bold, middle faded), adapted from bloxwap's `CryptoAddress`. Tap-to-copy.
  - QR encodes an **asset-formatted** EIP-681 payload (`buildPaymentPayload`) so a scanning wallet pre-fills the right token.
  - **Theme-aware:** white tile / black code in light, black tile / white code in dark (`currentColor`).
- **`swap-card.tsx`** — measured-height animation swaps `$0`/units ⇄ the receive view; the `to` amount block is removed and its selector rounds off. Spacing matched to the normal field. Deselecting generate-address **while disconnected** reverts `from` to its empty state.
- **`toaster.tsx`** (new) + **`layout.tsx`** — sonner `Toaster`, top-center, theme-aware; copying the address toasts "Address copied".

## cuer patch
`cuer@0.0.3` passes `border: 0` to its `qr` backend, which `qr@0.6.0` now rejects (`invalid border=0`, an ISO-2024 quiet-zone rule). Rather than pin `qr`, a `bun patch` makes cuer request a 2-module border and strip it back off — same border-less grid, latest `qr`. Durable via `patchedDependencies` (applied by `bun install` in CI).

## Verification
- 304/304 unit tests pass; asset-formatted EIP-681 payloads verified (ERC-20 transfer URI, native, non-EVM bare address)
- Patch verified: `border: 2` accepted by qr@0.6.0, strips to a clean square grid
- TS errors present are the pre-existing build-ignored duplicate-`@types/react` (18 + 19) cosmetic noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)