### PR TITLE
style: tighten menu row gaps to a uniform gap-2

### DIFF
--- a/workers/jb-swap/src/components/app-menu.tsx
+++ b/workers/jb-swap/src/components/app-menu.tsx
@@ -164,7 +164,7 @@ export function AppMenu({
 							) : view === "fees" ? (
 								<FeeBreakdownPanel fees={fees} loading={feeLoading} />
 							) : (
-								<div className="flex flex-col gap-4">
+								<div className="flex flex-col gap-2">
 									<LanguageRow
 										value={locale}
 										onOpen={() => go("language")}
@@ -182,8 +182,8 @@ export function AppMenu({
 										onChange={onDenominationChange}
 										layoutId="denomination-segment-pill"
 									/>
-									<div className="flex flex-col gap-4">
-										<h3 className="-mb-2 px-2 text-sm font-semibold text-muted-foreground">
+									<div className="flex flex-col gap-2">
+										<h3 className="px-2 text-sm font-semibold text-muted-foreground">
 											{t("menu.sectionTransaction")}
 										</h3>
 										<OrderRow


### PR DESCRIPTION
All menu rows (general settings + the Transaction section) now use a uniform `gap-2` instead of mixing `gap-4`/`gap-2`. The title-to-content gap is unchanged. 304/304 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)