### PR TITLE
feat: add jb-symbols worker at symbols.joeblau.com

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        worker: [jb-www, jb-travel, jb-gear, jb-swap]
+        worker: [jb-www, jb-travel, jb-gear, jb-swap, jb-symbols]
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        worker: [jb-www, jb-travel, jb-gear, jb-swap]
+        worker: [jb-www, jb-travel, jb-gear, jb-swap, jb-symbols]
     steps:
       - uses: actions/checkout@v6
 

--- a/bun.lock
+++ b/bun.lock
@@ -85,6 +85,36 @@
         "wrangler": "^4.54.0",
       },
     },
+    "workers/jb-symbols": {
+      "name": "jb-symbols",
+      "version": "0.1.0",
+      "dependencies": {
+        "@opennextjs/cloudflare": "^1.14.4",
+        "@radix-ui/react-slot": "^1.2.4",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "geist": "^1.5.1",
+        "lucide-react": "^0.562.0",
+        "next": "15.5.9",
+        "next-themes": "^0.4.6",
+        "react": "19.1.4",
+        "react-dom": "19.1.4",
+        "tailwind-merge": "^3.4.0",
+      },
+      "devDependencies": {
+        "@eslint/eslintrc": "^3",
+        "@tailwindcss/postcss": "^4",
+        "@types/node": "^25.0.3",
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
+        "eslint": "^9",
+        "eslint-config-next": "15.4.6",
+        "tailwindcss": "^4",
+        "tw-animate-css": "^1.4.0",
+        "typescript": "^5",
+        "wrangler": "^4.54.0",
+      },
+    },
     "workers/jb-travel": {
       "name": "jb-travel",
       "version": "0.1.0",
@@ -2492,6 +2522,8 @@
     "jb-gear": ["jb-gear@workspace:workers/jb-gear"],
 
     "jb-swap": ["jb-swap@workspace:workers/jb-swap"],
+
+    "jb-symbols": ["jb-symbols@workspace:workers/jb-symbols"],
 
     "jb-travel": ["jb-travel@workspace:workers/jb-travel"],
 

--- a/workers/jb-symbols/.gitignore
+++ b/workers/jb-symbols/.gitignore
@@ -1,0 +1,53 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# env files (can opt-in for committing if needed)
+.env*
+!.env.example
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts
+
+# OpenNext
+/.open-next
+
+# wrangler files
+.wrangler
+.dev.vars*
+
+
+!.dev.vars.example
+package-lock.json

--- a/workers/jb-symbols/components.json
+++ b/workers/jb-symbols/components.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.js",
+    "css": "src/app/globals.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "iconLibrary": "lucide"
+}

--- a/workers/jb-symbols/eslint.config.mjs
+++ b/workers/jb-symbols/eslint.config.mjs
@@ -1,0 +1,14 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+	baseDirectory: __dirname,
+});
+
+const eslintConfig = [...compat.extends("next/core-web-vitals", "next/typescript")];
+
+export default eslintConfig;

--- a/workers/jb-symbols/next.config.ts
+++ b/workers/jb-symbols/next.config.ts
@@ -1,0 +1,15 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+	eslint: {
+		ignoreDuringBuilds: true,
+	},
+	typescript: {
+		ignoreBuildErrors: true,
+	},
+};
+
+export default nextConfig;
+
+import { initOpenNextCloudflareForDev } from "@opennextjs/cloudflare";
+initOpenNextCloudflareForDev();

--- a/workers/jb-symbols/open-next.config.ts
+++ b/workers/jb-symbols/open-next.config.ts
@@ -1,0 +1,3 @@
+import { defineCloudflareConfig } from "@opennextjs/cloudflare";
+
+export default defineCloudflareConfig({});

--- a/workers/jb-symbols/package.json
+++ b/workers/jb-symbols/package.json
@@ -1,0 +1,42 @@
+{
+	"name": "jb-symbols",
+	"version": "0.1.0",
+	"private": true,
+	"packageManager": "bun@1.3.0",
+	"scripts": {
+		"dev": "wrangler dev",
+		"build": "next build",
+		"start": "next start",
+		"lint": "next lint",
+		"cf-build": "opennextjs-cloudflare build",
+		"deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
+		"upload": "opennextjs-cloudflare build && opennextjs-cloudflare upload",
+		"preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview"
+	},
+	"dependencies": {
+		"@opennextjs/cloudflare": "^1.14.4",
+		"@radix-ui/react-slot": "^1.2.4",
+		"class-variance-authority": "^0.7.1",
+		"clsx": "^2.1.1",
+		"geist": "^1.5.1",
+		"lucide-react": "^0.562.0",
+		"next": "15.5.9",
+		"next-themes": "^0.4.6",
+		"react": "19.1.4",
+		"react-dom": "19.1.4",
+		"tailwind-merge": "^3.4.0"
+	},
+	"devDependencies": {
+		"@eslint/eslintrc": "^3",
+		"@tailwindcss/postcss": "^4",
+		"@types/node": "^25.0.3",
+		"@types/react": "^19",
+		"@types/react-dom": "^19",
+		"eslint": "^9",
+		"eslint-config-next": "15.4.6",
+		"tailwindcss": "^4",
+		"tw-animate-css": "^1.4.0",
+		"typescript": "^5",
+		"wrangler": "^4.54.0"
+	}
+}

--- a/workers/jb-symbols/postcss.config.mjs
+++ b/workers/jb-symbols/postcss.config.mjs
@@ -1,0 +1,5 @@
+const config = {
+	plugins: ["@tailwindcss/postcss"],
+};
+
+export default config;

--- a/workers/jb-symbols/src/app/globals.css
+++ b/workers/jb-symbols/src/app/globals.css
@@ -1,0 +1,78 @@
+@import "tailwindcss";
+@import "tw-animate-css";
+@config "../../tailwind.config.js";
+
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 0 0% 3.9%;
+
+    --muted: 0 0% 96.1%;
+    --muted-foreground: 0 0% 45.1%;
+
+    --popover: 0 0% 100%;
+    --popover-foreground: 0 0% 3.9%;
+
+    --card: 0 0% 100%;
+    --card-foreground: 0 0% 3.9%;
+
+    --border: 0 0% 89.8%;
+    --input: 0 0% 89.8%;
+
+    --primary: 0 0% 9%;
+    --primary-foreground: 0 0% 98%;
+
+    --secondary: 0 0% 96.1%;
+    --secondary-foreground: 0 0% 9%;
+
+    --accent: 0 0% 96.1%;
+    --accent-foreground: 0 0% 9%;
+
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 0 0% 98%;
+
+    --ring: 0 0% 3.9%;
+
+    --radius: 0.5rem;
+  }
+
+  .dark {
+    --background: 0 0% 3.9%;
+    --foreground: 0 0% 98%;
+
+    --muted: 0 0% 14.9%;
+    --muted-foreground: 0 0% 63.9%;
+
+    --popover: 0 0% 3.9%;
+    --popover-foreground: 0 0% 98%;
+
+    --card: 0 0% 3.9%;
+    --card-foreground: 0 0% 98%;
+
+    --border: 0 0% 14.9%;
+    --input: 0 0% 14.9%;
+
+    --primary: 0 0% 98%;
+    --primary-foreground: 0 0% 9%;
+
+    --secondary: 0 0% 14.9%;
+    --secondary-foreground: 0 0% 98%;
+
+    --accent: 0 0% 14.9%;
+    --accent-foreground: 0 0% 98%;
+
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 0 0% 98%;
+
+    --ring: 0 0% 83.1%;
+  }
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/workers/jb-symbols/src/app/layout.tsx
+++ b/workers/jb-symbols/src/app/layout.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from "next";
+import { GeistSans } from "geist/font/sans";
+import { GeistMono } from "geist/font/mono";
+import "./globals.css";
+import { ThemeProvider } from "@/components/theme-provider";
+
+export const metadata: Metadata = {
+	title: "Symbols — Joe Blau",
+	description: "Symbols",
+	openGraph: {
+		type: "website",
+		locale: "en_US",
+		url: "https://symbols.joeblau.com",
+		title: "Symbols — Joe Blau",
+		description: "Symbols",
+	},
+};
+
+export default function RootLayout({
+	children,
+}: Readonly<{
+	children: React.ReactNode;
+}>) {
+	return (
+		<html lang="en" suppressHydrationWarning>
+			<body className={`${GeistSans.variable} ${GeistMono.variable} antialiased`}>
+				<ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+					{children}
+				</ThemeProvider>
+			</body>
+		</html>
+	);
+}

--- a/workers/jb-symbols/src/app/page.tsx
+++ b/workers/jb-symbols/src/app/page.tsx
@@ -1,0 +1,8 @@
+export default function Home() {
+	return (
+		<main className="flex min-h-screen flex-col items-center justify-center gap-2">
+			<h1 className="font-mono text-2xl font-semibold tracking-tight">symbols</h1>
+			<p className="text-sm text-muted-foreground">symbols.joeblau.com</p>
+		</main>
+	);
+}

--- a/workers/jb-symbols/src/components/theme-provider.tsx
+++ b/workers/jb-symbols/src/components/theme-provider.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import * as React from "react";
+import { ThemeProvider as NextThemesProvider, type ThemeProviderProps } from "next-themes";
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+	return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/workers/jb-symbols/src/lib/utils.ts
+++ b/workers/jb-symbols/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/workers/jb-symbols/tailwind.config.js
+++ b/workers/jb-symbols/tailwind.config.js
@@ -1,0 +1,62 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: ["class"],
+  content: [
+    './pages/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+    './app/**/*.{ts,tsx}',
+    './src/**/*.{ts,tsx}',
+	],
+  theme: {
+  	container: {
+  		center: 'true',
+  		padding: '2rem',
+  		screens: {
+  			'2xl': '1400px'
+  		}
+  	},
+  	extend: {
+  		colors: {
+  			border: 'hsl(var(--border))',
+  			input: 'hsl(var(--input))',
+  			ring: 'hsl(var(--ring))',
+  			background: 'hsl(var(--background))',
+  			foreground: 'hsl(var(--foreground))',
+  			primary: {
+  				DEFAULT: 'hsl(var(--primary))',
+  				foreground: 'hsl(var(--primary-foreground))'
+  			},
+  			secondary: {
+  				DEFAULT: 'hsl(var(--secondary))',
+  				foreground: 'hsl(var(--secondary-foreground))'
+  			},
+  			destructive: {
+  				DEFAULT: 'hsl(var(--destructive))',
+  				foreground: 'hsl(var(--destructive-foreground))'
+  			},
+  			muted: {
+  				DEFAULT: 'hsl(var(--muted))',
+  				foreground: 'hsl(var(--muted-foreground))'
+  			},
+  			accent: {
+  				DEFAULT: 'hsl(var(--accent))',
+  				foreground: 'hsl(var(--accent-foreground))'
+  			},
+  			popover: {
+  				DEFAULT: 'hsl(var(--popover))',
+  				foreground: 'hsl(var(--popover-foreground))'
+  			},
+  			card: {
+  				DEFAULT: 'hsl(var(--card))',
+  				foreground: 'hsl(var(--card-foreground))'
+  			},
+  		},
+  		borderRadius: {
+  			lg: 'var(--radius)',
+  			md: 'calc(var(--radius) - 2px)',
+  			sm: 'calc(var(--radius) - 4px)'
+  		},
+  	}
+  },
+  plugins: [],
+}

--- a/workers/jb-symbols/tsconfig.json
+++ b/workers/jb-symbols/tsconfig.json
@@ -1,0 +1,30 @@
+{
+	"compilerOptions": {
+		"target": "es2022",
+		"lib": ["dom", "dom.iterable", "esnext"],
+		"allowJs": true,
+		"skipLibCheck": true,
+		"strict": true,
+		"noEmit": true,
+		"esModuleInterop": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"jsx": "preserve",
+		"incremental": true,
+		"plugins": [
+			{
+				"name": "next"
+			}
+		],
+		"paths": {
+			"@/*": ["./src/*"]
+		},
+		"types": [
+			"node"
+		]
+	},
+	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+	"exclude": ["node_modules"]
+}

--- a/workers/jb-symbols/wrangler.jsonc
+++ b/workers/jb-symbols/wrangler.jsonc
@@ -1,0 +1,37 @@
+{
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "jb-symbols",
+	"main": ".open-next/worker.js",
+	"account_id": "2b04333c55d653550f69d1c732b92d98",
+	"compatibility_date": "2025-12-01",
+	"compatibility_flags": [
+		"nodejs_compat",
+		"global_fetch_strictly_public"
+	],
+	"assets": {
+		"binding": "ASSETS",
+		"directory": ".open-next/assets"
+	},
+	"images": {
+		"binding": "IMAGES"
+	},
+	"services": [
+		{
+			"binding": "WORKER_SELF_REFERENCE",
+			"service": "jb-symbols"
+		}
+	],
+	"dev": {
+		"port": 33004,
+		"inspector_port": 33504
+	},
+	"observability": {
+		"enabled": true
+	},
+	"routes": [
+		{
+			"pattern": "symbols.joeblau.com",
+			"custom_domain": true
+		}
+	]
+}


### PR DESCRIPTION
## Summary
Scaffolds a new Cloudflare Worker, **jb-symbols**, served at **symbols.joeblau.com**.

Built with the same stack as the other workers — Next.js 15 (App Router, React 19) compiled to a Worker via OpenNext.

## Details
- New `workers/jb-symbols/` package mirroring `jb-gear` config (Tailwind v4, shadcn/ui, next-themes, Geist).
- `wrangler.jsonc`: custom domain `symbols.joeblau.com`, dev port `33004` / inspector `33504` (next free in sequence).
- Added `jb-symbols` to the `preview.yml` and `production.yml` deploy matrices.
- Placeholder landing page — real content TBD.

## Test plan
- `bun install` — no conflicts, worker linked into workspace.
- `bun run build` — compiles and prerenders cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)