### PR TITLE
feat: add @joeblau/unified-ui shared package + swap wallet logout fix

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,34 @@
         "turbo": "^2",
       },
     },
+    "packages/unified-ui": {
+      "name": "@joeblau/unified-ui",
+      "version": "0.1.0",
+      "dependencies": {
+        "@number-flow/react": "^0.6.0",
+        "boring-avatars": "^2.0.4",
+        "clsx": "^2.1.1",
+        "lucide-react": "^1.18.0",
+        "qrcode-generator": "^2.0.4",
+        "tailwind-merge": "^3.4.0",
+      },
+      "devDependencies": {
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
+        "tsup": "^8",
+        "typescript": "^5",
+      },
+      "peerDependencies": {
+        "cuer": "^0.0.3",
+        "framer-motion": "^12.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "vaul": "^1.1.0",
+      },
+      "optionalPeers": [
+        "cuer",
+      ],
+    },
     "workers/jb-gear": {
       "name": "jb-gear",
       "version": "0.1.0",
@@ -668,6 +696,8 @@
 
     "@jest/types": ["@jest/types@29.6.3", "", { "dependencies": { "@jest/schemas": "^29.6.3", "@types/istanbul-lib-coverage": "^2.0.0", "@types/istanbul-reports": "^3.0.0", "@types/node": "*", "@types/yargs": "^17.0.8", "chalk": "^4.0.0" } }, "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw=="],
 
+    "@joeblau/unified-ui": ["@joeblau/unified-ui@workspace:packages/unified-ui"],
+
     "@joeblau/www": ["@joeblau/www@workspace:workers/jb-www"],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
@@ -1055,6 +1085,56 @@
     "@reown/appkit-wallet": ["@reown/appkit-wallet@1.8.9", "", { "dependencies": { "@reown/appkit-common": "1.8.9", "@reown/appkit-polyfills": "1.8.9", "@walletconnect/logger": "2.1.2", "zod": "3.22.4" } }, "sha512-rcAXvkzOVG4941eZVCGtr2dSJAMOclzZGSe+8hnOUnhK4zxa5svxiP6K9O5SMBp3MrAS3WNsRj5hqx6+JHb7iA=="],
 
     "@resvg/resvg-wasm": ["@resvg/resvg-wasm@2.4.0", "", {}, "sha512-C7c51Nn4yTxXFKvgh2txJFNweaVcfUPQxwEUFw4aWsCmfiBDJsTSwviIF8EcwjQ6k8bPyMWCl1vw4BdxE569Cg=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.62.0", "", { "os": "android", "cpu": "arm" }, "sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.62.0", "", { "os": "android", "cpu": "arm64" }, "sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.62.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.62.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.62.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.62.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.62.0", "", { "os": "linux", "cpu": "arm" }, "sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.62.0", "", { "os": "linux", "cpu": "arm" }, "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.62.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.62.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.62.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.62.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.62.0", "", { "os": "linux", "cpu": "none" }, "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.62.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.62.0", "", { "os": "linux", "cpu": "x64" }, "sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.62.0", "", { "os": "linux", "cpu": "x64" }, "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.62.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.62.0", "", { "os": "none", "cpu": "arm64" }, "sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.62.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.62.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.62.0", "", { "os": "win32", "cpu": "x64" }, "sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.62.0", "", { "os": "win32", "cpu": "x64" }, "sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA=="],
 
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
 
@@ -1660,6 +1740,8 @@
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
+    "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
+
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
@@ -1784,9 +1866,13 @@
 
     "bufferutil": ["bufferutil@4.1.0", "", { "dependencies": { "node-gyp-build": "^4.3.0" } }, "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw=="],
 
+    "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
+
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
     "c12": ["c12@3.1.0", "", { "dependencies": { "chokidar": "^4.0.3", "confbox": "^0.2.2", "defu": "^6.1.4", "dotenv": "^16.6.1", "exsolve": "^1.0.7", "giget": "^2.0.0", "jiti": "^2.4.2", "ohash": "^2.0.11", "pathe": "^2.0.3", "perfect-debounce": "^1.0.0", "pkg-types": "^2.2.0", "rc9": "^2.1.2" }, "peerDependencies": { "magicast": "^0.3.5" }, "optionalPeers": ["magicast"] }, "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 
     "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
 
@@ -1824,7 +1910,7 @@
 
     "chevrotain": ["chevrotain@10.5.0", "", { "dependencies": { "@chevrotain/cst-dts-gen": "10.5.0", "@chevrotain/gast": "10.5.0", "@chevrotain/types": "10.5.0", "@chevrotain/utils": "10.5.0", "lodash": "4.17.21", "regexp-to-ast": "0.5.0" } }, "sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A=="],
 
-    "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "chrome-launcher": ["chrome-launcher@0.15.2", "", { "dependencies": { "@types/node": "*", "escape-string-regexp": "^4.0.0", "is-wsl": "^2.2.0", "lighthouse-logger": "^1.0.0" }, "bin": { "print-chrome-path": "bin/print-chrome-path.js" } }, "sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ=="],
 
@@ -1862,13 +1948,13 @@
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
-    "commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
+    "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
     "comment-json": ["comment-json@4.6.2", "", { "dependencies": { "array-timsort": "^1.0.3", "esprima": "^4.0.1" } }, "sha512-R2rze/hDX30uul4NZoIZ76ImSJLFxn/1/ZxtKC1L77y2X1k+yYu1joKbAtMA2Fg3hZrTOiw0I5mwVMo0cf250w=="],
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
-    "confbox": ["confbox@0.2.4", "", {}, "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ=="],
+    "confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
 
     "connect": ["connect@3.7.0", "", { "dependencies": { "debug": "2.6.9", "finalhandler": "1.1.2", "parseurl": "~1.3.3", "utils-merge": "1.0.1" } }, "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ=="],
 
@@ -2250,6 +2336,8 @@
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
+    "fix-dts-default-cjs-exports": ["fix-dts-default-cjs-exports@1.0.1", "", { "dependencies": { "magic-string": "^0.30.17", "mlly": "^1.7.4", "rollup": "^4.34.8" } }, "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg=="],
+
     "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
 
     "flatted": ["flatted@3.3.4", "", {}, "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA=="],
@@ -2626,15 +2714,19 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.31.1", "", { "os": "win32", "cpu": "x64" }, "sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw=="],
 
-    "lilconfig": ["lilconfig@2.1.0", "", {}, "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ=="],
+    "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
 
     "linebreak": ["linebreak@1.1.0", "", { "dependencies": { "base64-js": "0.0.8", "unicode-trie": "^2.0.0" } }, "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ=="],
+
+    "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
     "lit": ["lit@3.3.0", "", { "dependencies": { "@lit/reactive-element": "^2.1.0", "lit-element": "^4.2.0", "lit-html": "^3.3.0" } }, "sha512-DGVsqsOIHBww2DqnuZzW7QsuCdahp50ojuDaBPC7jUDRpYoH0z7kHBBYZewRzer75FwtrkmkKk7iOAwSaWdBmw=="],
 
     "lit-element": ["lit-element@4.2.2", "", { "dependencies": { "@lit-labs/ssr-dom-shim": "^1.5.0", "@lit/reactive-element": "^2.1.0", "lit-html": "^3.3.0" } }, "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w=="],
 
     "lit-html": ["lit-html@3.3.3", "", { "dependencies": { "@types/trusted-types": "^2.0.2" } }, "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA=="],
+
+    "load-tsconfig": ["load-tsconfig@0.2.5", "", {}, "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg=="],
 
     "loader-runner": ["loader-runner@4.3.1", "", {}, "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q=="],
 
@@ -2658,7 +2750,7 @@
 
     "lru.min": ["lru.min@1.1.4", "", {}, "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA=="],
 
-    "lucide-react": ["lucide-react@0.562.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw=="],
+    "lucide-react": ["lucide-react@1.18.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-LZDb7H/0YfM+RJncD0hDQRCAu+vSGODqpe35TuVI8EuXaRjkczbsx7p8dY4J87F/MUSj6bpYqeI8nw8qXaAdmA=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -2818,6 +2910,8 @@
 
     "mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
 
+    "mlly": ["mlly@1.8.2", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA=="],
+
     "mnemonist": ["mnemonist@0.38.3", "", { "dependencies": { "obliterator": "^1.6.1" } }, "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw=="],
 
     "mongodb": ["mongodb@7.1.0", "", { "dependencies": { "@mongodb-js/saslprep": "^1.3.0", "bson": "^7.1.1", "mongodb-connection-string-url": "^7.0.0" }, "peerDependencies": { "@aws-sdk/credential-providers": "^3.806.0", "@mongodb-js/zstd": "^7.0.0", "gcp-metadata": "^7.0.1", "kerberos": "^7.0.0", "mongodb-client-encryption": ">=7.0.0 <7.1.0", "snappy": "^7.3.2", "socks": "^2.8.6" }, "optionalPeers": ["@aws-sdk/credential-providers", "@mongodb-js/zstd", "gcp-metadata", "kerberos", "mongodb-client-encryption", "snappy", "socks"] }, "sha512-kMfnKunbolQYwCIyrkxNJFB4Ypy91pYqua5NargS/f8ODNSJxT03ZU3n1JqL4mCzbSih8tvmMEMLpKTT7x5gCg=="],
@@ -2837,6 +2931,8 @@
     "murmurhash-js": ["murmurhash-js@1.0.0", "", {}, "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw=="],
 
     "mysql2": ["mysql2@3.15.3", "", { "dependencies": { "aws-ssl-profiles": "^1.1.1", "denque": "^2.1.0", "generate-function": "^2.3.1", "iconv-lite": "^0.7.0", "long": "^5.2.1", "lru.min": "^1.0.0", "named-placeholders": "^1.1.3", "seq-queue": "^0.0.5", "sqlstring": "^2.3.2" } }, "sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg=="],
+
+    "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
     "named-placeholders": ["named-placeholders@1.1.6", "", { "dependencies": { "lru.min": "^1.1.0" } }, "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w=="],
 
@@ -2988,7 +3084,9 @@
 
     "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
 
-    "pkg-types": ["pkg-types@2.3.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig=="],
+    "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
+
+    "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
     "pngjs": ["pngjs@5.0.0", "", {}, "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="],
 
@@ -3003,6 +3101,8 @@
     "postal-mime": ["postal-mime@2.7.3", "", {}, "sha512-MjhXadAJaWgYzevi46+3kLak8y6gbg0ku14O1gO/LNOuay8dO+1PtcSGvAdgDR0DoIsSaiIA8y/Ddw6MnrO0Tw=="],
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
+
+    "postcss-load-config": ["postcss-load-config@6.0.1", "", { "dependencies": { "lilconfig": "^3.1.1" }, "peerDependencies": { "jiti": ">=1.21.0", "postcss": ">=8.0.9", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["jiti", "postcss", "tsx", "yaml"] }, "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g=="],
 
     "postcss-selector-parser": ["postcss-selector-parser@6.0.10", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w=="],
 
@@ -3118,7 +3218,7 @@
 
     "readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 
-    "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
@@ -3166,7 +3266,7 @@
 
     "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
-    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+    "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
@@ -3177,6 +3277,8 @@
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
     "robust-predicates": ["robust-predicates@2.0.4", "", {}, "sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg=="],
+
+    "rollup": ["rollup@4.62.0", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.62.0", "@rollup/rollup-android-arm64": "4.62.0", "@rollup/rollup-darwin-arm64": "4.62.0", "@rollup/rollup-darwin-x64": "4.62.0", "@rollup/rollup-freebsd-arm64": "4.62.0", "@rollup/rollup-freebsd-x64": "4.62.0", "@rollup/rollup-linux-arm-gnueabihf": "4.62.0", "@rollup/rollup-linux-arm-musleabihf": "4.62.0", "@rollup/rollup-linux-arm64-gnu": "4.62.0", "@rollup/rollup-linux-arm64-musl": "4.62.0", "@rollup/rollup-linux-loong64-gnu": "4.62.0", "@rollup/rollup-linux-loong64-musl": "4.62.0", "@rollup/rollup-linux-ppc64-gnu": "4.62.0", "@rollup/rollup-linux-ppc64-musl": "4.62.0", "@rollup/rollup-linux-riscv64-gnu": "4.62.0", "@rollup/rollup-linux-riscv64-musl": "4.62.0", "@rollup/rollup-linux-s390x-gnu": "4.62.0", "@rollup/rollup-linux-x64-gnu": "4.62.0", "@rollup/rollup-linux-x64-musl": "4.62.0", "@rollup/rollup-openbsd-x64": "4.62.0", "@rollup/rollup-openharmony-arm64": "4.62.0", "@rollup/rollup-win32-arm64-msvc": "4.62.0", "@rollup/rollup-win32-ia32-msvc": "4.62.0", "@rollup/rollup-win32-x64-gnu": "4.62.0", "@rollup/rollup-win32-x64-msvc": "4.62.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA=="],
 
     "rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
 
@@ -3348,6 +3450,8 @@
 
     "stylis": ["stylis@4.4.0", "", {}, "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="],
 
+    "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
+
     "suncalc": ["suncalc@1.9.0", "", {}, "sha512-vMJ8Byp1uIPoj+wb9c1AdK4jpkSKVAywgHX0lqY7zt6+EWRRC3Z+0Ucfjy/0yxTVO1hwwchZe4uoFNqrIC24+A=="],
 
     "supercluster": ["supercluster@8.0.1", "", { "dependencies": { "kdbush": "^4.0.2" } }, "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ=="],
@@ -3382,6 +3486,10 @@
 
     "text-encoding-utf-8": ["text-encoding-utf-8@1.0.2", "", {}, "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="],
 
+    "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
+
+    "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
+
     "thread-stream": ["thread-stream@3.2.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw=="],
 
     "throat": ["throat@5.0.0", "", {}, "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA=="],
@@ -3394,7 +3502,7 @@
 
     "tinycolor2": ["tinycolor2@1.6.0", "", {}, "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="],
 
-    "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
+    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
@@ -3412,17 +3520,23 @@
 
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
+    "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
+
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
 
     "ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
 
+    "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
+
     "ts-tqdm": ["ts-tqdm@0.8.6", "", {}, "sha512-3X3M1PZcHtgQbnwizL+xU8CAgbYbeLHrrDwL9xxcZZrV5J+e7loJm1XrXozHjSkl44J0Zg0SgA8rXbh83kCkcQ=="],
 
     "tsconfig-paths": ["tsconfig-paths@3.15.0", "", { "dependencies": { "@types/json5": "^0.0.29", "json5": "^1.0.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tsup": ["tsup@8.5.1", "", { "dependencies": { "bundle-require": "^5.1.0", "cac": "^6.7.14", "chokidar": "^4.0.3", "consola": "^3.4.0", "debug": "^4.4.0", "esbuild": "^0.27.0", "fix-dts-default-cjs-exports": "^1.0.0", "joycon": "^3.1.1", "picocolors": "^1.1.1", "postcss-load-config": "^6.0.1", "resolve-from": "^5.0.0", "rollup": "^4.34.8", "source-map": "^0.7.6", "sucrase": "^3.35.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.11", "tree-kill": "^1.2.2" }, "peerDependencies": { "@microsoft/api-extractor": "^7.36.0", "@swc/core": "^1", "postcss": "^8.4.12", "typescript": ">=4.5.0" }, "optionalPeers": ["@microsoft/api-extractor", "@swc/core", "postcss", "typescript"], "bin": { "tsup": "dist/cli-default.js", "tsup-node": "dist/cli-node.js" } }, "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing=="],
 
     "turbo": ["turbo@2.8.13", "", { "optionalDependencies": { "turbo-darwin-64": "2.8.13", "turbo-darwin-arm64": "2.8.13", "turbo-linux-64": "2.8.13", "turbo-linux-arm64": "2.8.13", "turbo-windows-64": "2.8.13", "turbo-windows-arm64": "2.8.13" }, "bin": { "turbo": "bin/turbo" } }, "sha512-nyM99hwFB9/DHaFyKEqatdayGjsMNYsQ/XBNO6MITc7roncZetKb97MpHxWf3uiU+LB9c9HUlU3Jp2Ixei2k1A=="],
 
@@ -3664,6 +3778,8 @@
 
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
+    "@dotenvx/dotenvx/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
+
     "@dotenvx/dotenvx/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
 
     "@ecies/ciphers/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
@@ -3675,6 +3791,8 @@
     "@farcaster/quick-auth/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@gemini-wallet/core/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
+
+    "@joeblau/www/lucide-react": ["lucide-react@0.562.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw=="],
 
     "@libsql/hrana-client/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
@@ -3719,6 +3837,8 @@
     "@metamask/utils/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@metamask/utils/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+
+    "@mrleebo/prisma-ast/lilconfig": ["lilconfig@2.1.0", "", {}, "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ=="],
 
     "@node-minify/core/glob": ["glob@9.3.5", "", { "dependencies": { "fs.realpath": "^1.0.0", "minimatch": "^8.0.2", "minipass": "^4.2.4", "path-scurry": "^1.6.1" } }, "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q=="],
 
@@ -3926,7 +4046,9 @@
 
     "better-call/set-cookie-parser": ["set-cookie-parser@3.0.1", "", {}, "sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q=="],
 
-    "c12/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
+    "c12/confbox": ["confbox@0.2.4", "", {}, "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ=="],
+
+    "c12/pkg-types": ["pkg-types@2.3.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig=="],
 
     "cbw-sdk/clsx": ["clsx@1.2.1", "", {}, "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="],
 
@@ -4000,6 +4122,8 @@
 
     "http-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
+    "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
     "is-bun-module/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "jayson/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
@@ -4012,9 +4136,13 @@
 
     "jayson/ws": ["ws@7.5.11", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA=="],
 
-    "jb-swap/lucide-react": ["lucide-react@1.18.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-LZDb7H/0YfM+RJncD0hDQRCAu+vSGODqpe35TuVI8EuXaRjkczbsx7p8dY4J87F/MUSj6bpYqeI8nw8qXaAdmA=="],
+    "jb-gear/lucide-react": ["lucide-react@0.562.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw=="],
+
+    "jb-symbols/lucide-react": ["lucide-react@0.562.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw=="],
 
     "jb-travel/@number-flow/react": ["@number-flow/react@0.5.14", "", { "dependencies": { "esm-env": "^1.1.4", "number-flow": "0.5.12" }, "peerDependencies": { "react": "^18 || ^19", "react-dom": "^18 || ^19" } }, "sha512-FGUqjh/P5/ukr0U0ySwb987M0SbRkrnZq70f0wQFncDbXa3SIib4L+FTr5ngvWwGAW8S6b391eTXcfhErZsw4w=="],
+
+    "jb-travel/lucide-react": ["lucide-react@0.562.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw=="],
 
     "jest-util/ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
 
@@ -4072,6 +4200,8 @@
 
     "nypm/citty": ["citty@0.2.1", "", {}, "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg=="],
 
+    "nypm/tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
+
     "obj-multiplex/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "ox/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
@@ -4126,6 +4256,8 @@
 
     "react-native/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
+    "rollup/@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
     "router/path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
     "rpc-websockets/utf-8-validate": ["utf-8-validate@6.0.6", "", { "dependencies": { "node-gyp-build": "^4.3.0" } }, "sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA=="],
@@ -4157,6 +4289,8 @@
     "type-is/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "unbzip2-stream/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+
+    "unstorage/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
     "unstorage/lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
 
@@ -4538,8 +4672,6 @@
 
     "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
-    "c12/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
-
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "cloudflare/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
@@ -4637,6 +4769,8 @@
     "terser-webpack-plugin/terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "victory-vendor/@types/d3-interpolate/@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
 

--- a/packages/unified-ui/.gitignore
+++ b/packages/unified-ui/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+*.tsbuildinfo

--- a/packages/unified-ui/README.md
+++ b/packages/unified-ui/README.md
@@ -1,0 +1,219 @@
+# @joeblau/unified-ui
+
+Presentational, fully-controlled React components for a unified **send / swap / bridge** card. Pixel-faithful layout and spacing extracted from the production card, with every data concern (Relay quoting, wallet SDK, i18n) removed — you own the state and inject the data-heavy surfaces through slots.
+
+- **Presentational** — every value and callback is a prop. No Relay, no Privy, no i18n.
+- **One card, both wallet states** — pass `generateAddress` for a disconnected wallet (receive/generate-address view available) or omit it for a connected wallet (no generate-address affordance anywhere).
+- **Layout preserved exactly** — the `-my-3` swap-button overlap, the `border-t-2 border-background` seams, the height-conservation animation between the two fields, the `h-12` / `size-12` action row, the mobile keypad, and the Apple edge-glow.
+- **Slots for the data-heavy bits** — the token search/list drawer and the settings menu are render props.
+
+## Install
+
+```bash
+bun add @joeblau/unified-ui
+# peers (you almost certainly already have react/react-dom):
+bun add react react-dom framer-motion vaul
+# optional, only for the center-logo QR adapter:
+bun add cuer
+```
+
+Dependencies bundled for you: `@number-flow/react`, `boring-avatars`, `clsx`, `tailwind-merge`, `lucide-react`, `qrcode-generator`.
+
+## Styles
+
+The components are Tailwind-class based and read a small set of CSS variables. Two things to wire up:
+
+**1. Import the style contract once** (defines the tokens + the non-utility CSS — `.apple-edge-glow`, `.haptic-*`, `.scrollbar-subtle`, `.scroll-fade`):
+
+```ts
+import "@joeblau/unified-ui/styles.css";
+```
+
+**2. Map the semantic color scale** so utilities like `bg-card`, `text-foreground`, and the `foreground/<opacity>` overlays resolve.
+
+Tailwind **v3** — use the preset, and add the package to `content` so its classes are scanned:
+
+```js
+// tailwind.config.js
+module.exports = {
+  presets: [require("@joeblau/unified-ui/tailwind-preset")],
+  content: [
+    "./src/**/*.{ts,tsx}",
+    "./node_modules/@joeblau/unified-ui/src/**/*.{ts,tsx}",
+  ],
+};
+```
+
+Tailwind **v4** — add an `@theme inline` mapping and scan the package source:
+
+```css
+@import "tailwindcss";
+@import "@joeblau/unified-ui/styles.css";
+@source "../node_modules/@joeblau/unified-ui/src";
+
+@theme inline {
+  --color-background: hsl(var(--background));
+  --color-foreground: hsl(var(--foreground));
+  --color-card: hsl(var(--card));
+  --color-card-foreground: hsl(var(--card-foreground));
+  --color-primary: hsl(var(--primary));
+  --color-primary-foreground: hsl(var(--primary-foreground));
+  --color-secondary: hsl(var(--secondary));
+  --color-secondary-foreground: hsl(var(--secondary-foreground));
+  --color-muted: hsl(var(--muted));
+  --color-muted-foreground: hsl(var(--muted-foreground));
+  --color-border: hsl(var(--border));
+}
+```
+
+Dark mode: add `class="dark"` to a parent (the contract ships `:root` + `.dark`).
+
+### Token contract
+
+`styles.css` ships these (light / dark). Override any in your own `:root`/`.dark` to re-theme.
+
+| Variable | Light | Dark | Used by |
+| --- | --- | --- | --- |
+| `--background` | `0 0% 100%` | `0 0% 3.9%` | page bg; swap-disc; seam color |
+| `--foreground` | `0 0% 3.9%` | `0 0% 98%` | text + every `foreground/<n>` overlay |
+| `--card` | `0 0% 96%` | `0 0% 7.5%` | the two card sections + sheets |
+| `--muted` / `--muted-foreground` | `0 0% 96.1%` / `0 0% 45.1%` | `0 0% 14.9%` / `0 0% 63.9%` | kbd hint / secondary text |
+| `--primary` / `--primary-foreground` | `0 0% 9%` / `0 0% 98%` | `0 0% 98%` / `0 0% 9%` | primary CTA |
+| `--secondary` / `--secondary-foreground` | `0 0% 96.1%` / `0 0% 9%` | `0 0% 14.9%` / `0 0% 98%` | menu + reset buttons |
+| `--border` | `0 0% 89.8%` | `0 0% 14.9%` | bare `border` utilities |
+| `--radius` | `0.5rem` | `0.5rem` | `rounded-lg/md/sm` only (card geometry uses Tailwind defaults) |
+
+> The `*` border reset is scoped to `.unified-ui-root` in `styles.css`. If you don't already have a global `* { border-color: hsl(var(--border)) }` reset, wrap the card in a `<div className="unified-ui-root">` so the `border-t-2 border-background` seams paint.
+
+## Wallet states
+
+The generate-address (receive) affordance is governed by a single optional prop:
+
+- **Disconnected** — pass `generateAddress={{ enabled, onToggle, receiveAddress, … }}`. The From field can flip to a QR + address receive view, the To amount collapses to keep the card height constant, and the From picker slot receives the toggle config so your drawer can render the switch.
+- **Connected** — **omit** `generateAddress`. Internally `genAddress` is forced `false`; there is no receive view and no toggle anywhere. The same `<SwapCard/>` renders both — the affordance is removed by absence of one prop, not a flag you must remember to also hide.
+
+## Slots
+
+Three data-heavy surfaces are injected:
+
+- `renderFromPicker(api)` / `renderToPicker(api)` — return the drawer body (search, list, connect, generate-address switch …), typically wrapped in `<BottomSheet trigger={<TokenTrigger …/>}>`. The package owns the presentational `<TokenTrigger/>` and hands you a `PickerSlotApi` (`variant`, `selected`, `onSelect`, `triggerClassName`, `open`, `onOpenChange`, `onActivate`, `walletAddress`, `generateAddress?`, To-side `slippage`/`fee`/`feeLoading`/`onOpenSlippage`, From-side `onSetAmount`, `labels`). Omit a render prop and a bare static trigger is rendered.
+- `renderMenu(api)` — return the settings views (slippage, order type, language, fees …) for the shared sheet. `<AppMenuShell/>` owns the trigger, sheet chrome, header, and the morphing `ResizablePanel` host; `api` is `{ view, setView, close }`. Compose your rows from the exported `SettingsRow`, `SegmentedControl`, `Keypad`.
+
+## Usage — disconnected (generate-address available)
+
+```tsx
+import { SwapCard, BottomSheet, TokenTrigger, type PickerSlotApi } from "@joeblau/unified-ui";
+import "@joeblau/unified-ui/styles.css";
+
+function Pay() {
+  const [fromToken, setFromToken] = useState(null);
+  const [toToken, setToToken] = useState(null);
+  const [fromAmount, setFromAmount] = useState("0");
+  const [fromMode, setFromMode] = useState<"token" | "usd">("usd");
+  const [toMode, setToMode] = useState<"token" | "usd">("usd");
+  const [slippage, setSlippage] = useState(0.005);
+  const [genAddr, setGenAddr] = useState(false);
+
+  // your data layer (Relay quote, prices, …)
+  const { fromUsd, fromUnits, toAmount, toUsd, feeUsd, quoteLoading } = useMyQuote(/* … */);
+
+  const renderPicker = (api: PickerSlotApi) => (
+    <BottomSheet
+      open={api.open}
+      onOpenChange={api.onOpenChange}
+      contentClassName="h-[88vh]"
+      trigger={
+        <TokenTrigger
+          variant={api.variant}
+          selected={api.selected}
+          triggerClassName={api.triggerClassName}
+          walletAddress={api.walletAddress}
+          onActivate={api.onActivate}
+          onSetAmount={api.onSetAmount}
+          slippage={api.slippage}
+          fee={api.fee}
+          feeLoading={api.feeLoading}
+          onOpenSlippage={api.onOpenSlippage}
+          labels={api.labels}
+        />
+      }
+    >
+      <MyTokenDrawerBody
+        variant={api.variant}
+        onSelect={(t) => { api.onSelect(t); api.onOpenChange(false); }}
+        generateAddress={api.generateAddress} // From side, defined → render the switch
+      />
+    </BottomSheet>
+  );
+
+  return (
+    <SwapCard
+      fromToken={fromToken} onSelectFromToken={setFromToken}
+      toToken={toToken} onSelectToToken={setToToken}
+      fromAmount={fromAmount} onFromAmountChange={setFromAmount}
+      fromMode={fromMode} onToggleFromMode={() => setFromMode((m) => (m === "usd" ? "token" : "usd"))}
+      toMode={toMode} onToggleToMode={() => setToMode((m) => (m === "usd" ? "token" : "usd"))}
+      fromUsd={fromUsd} fromUnits={fromUnits}
+      toAmount={toAmount} toUsd={toUsd}
+      fee={feeUsd} feeLoading={quoteLoading}
+      slippage={slippage} onOpenSlippage={() => openMyMenuToSlippage()}
+      canFlip={!!fromToken && !!toToken}
+      onSwapTokens={() => { setFromToken(toToken); setToToken(fromToken); }}
+      canSwap={!!fromToken && !!toToken && fromUnits > 0}
+      isPristine={!fromToken && !toToken && Number(fromAmount) === 0}
+      onReset={() => { setFromToken(null); setToToken(null); setFromAmount("0"); }}
+      actionLabel={genAddr ? "Send from your wallet" : deriveLabel(fromToken, toToken)}
+      onSubmit={() => myConnectOrExecute()}
+      // *** present → generate-address available ***
+      generateAddress={{
+        enabled: genAddr,
+        onToggle: (next) => { setGenAddr(next); if (!next) { setFromToken(null); setFromAmount("0"); } },
+        receiveAddress: "0x71C7656EC7ab88b098defB751B7401B5f6d8976F",
+        receivePayload: myEip681Uri,
+        arena: fromToken?.logo,
+      }}
+      renderFromPicker={renderPicker}
+      renderToPicker={renderPicker}
+      renderMenu={(menu) => <MySettingsViews {...menu} slippage={slippage} onSlippageChange={setSlippage} />}
+      onCopyAddress={(addr) => myToast(`Copied ${addr}`)}
+    />
+  );
+}
+```
+
+## Usage — connected (no generate-address button)
+
+Identical, except `generateAddress` is **omitted**:
+
+```tsx
+<SwapCard
+  /* …same controlled props… */
+  walletAddress={address}
+  actionLabel={deriveLabel(fromToken, toToken)}
+  onSubmit={() => myExecute(quote)}
+  // *** generateAddress intentionally ABSENT → no receive view, no toggle ***
+  renderFromPicker={renderPicker}
+  renderToPicker={renderPicker}
+  renderMenu={(menu) => <MySettingsViews {...menu} />}
+/>
+```
+
+## Center-logo QR (optional)
+
+`CryptoAddress` defaults to the dependency-free `<QrCode/>`. For a center asset logo, pass the `cuer` adapter (and install `cuer`):
+
+```tsx
+import { CryptoAddress } from "@joeblau/unified-ui";
+import { cuerQr } from "@joeblau/unified-ui/cuer";
+
+<CryptoAddress address={addr} arena={logo} renderQr={cuerQr} />;
+```
+
+## Exports
+
+`SwapCard`, `SwapFrom`, `SwapTo` · `ActionRow`, `AppMenuShell`, `BottomSheet`, `SheetHeader`, `TokenTrigger`, `SettingsRow`, `SegmentedControl`, `ResizablePanel`, `Keypad`, `MobileKeypad` · `HapticButton`, `AppleBorderGradient`, `CryptoAddress`, `QrCode`, `TokenAmount`, `AmountInput`, `ConversionValue`, `Pill` · helpers `cn`, `formatPct`, `fmtUsd`, `price`, `computeTest`, `truncateAddress`, `formatTokenParts`, `trim`, `trimUsd`, `sanitizeAmount`, `applyAmountKey`, `sanitizePastedAmount`, `useMeasuredHeight`, `shouldUseHapticOverlay` · types `TokenRow`, `Mode`, `GenerateAddressConfig`, `PickerSlotApi`, `MenuSlotApi`, `TokenTriggerLabels`, `SwapCardLabels`, `SegmentOption`.
+
+## Notes
+
+- **Types ship from source.** The package `exports` resolve types to `./src`, so a TS-aware bundler gets full types directly. `bun run build` emits JS bundles (ESM + CJS); standalone `.d.ts` emit is disabled because this monorepo carries two `@types/react` majors that trip declaration generation — flip `dts` on in a deduped-types environment.
+- **Haptics** are additive and iOS-WebKit only (`HapticButton` degrades to a plain button elsewhere).

--- a/packages/unified-ui/package.json
+++ b/packages/unified-ui/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@joeblau/unified-ui",
+  "version": "0.1.0",
+  "description": "Presentational, fully-controlled React components for a unified send/swap/bridge card. Pixel-faithful layout/spacing; bring your own data (Relay/wallet/i18n).",
+  "license": "MIT",
+  "private": false,
+  "type": "module",
+  "sideEffects": [
+    "*.css"
+  ],
+  "files": [
+    "src",
+    "styles.css",
+    "tailwind-preset.cjs",
+    "README.md"
+  ],
+  "main": "./src/index.ts",
+  "module": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./cuer": {
+      "types": "./src/cuer-qr.tsx",
+      "default": "./src/cuer-qr.tsx"
+    },
+    "./styles.css": "./styles.css",
+    "./tailwind-preset": "./tailwind-preset.cjs"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@number-flow/react": "^0.6.0",
+    "boring-avatars": "^2.0.4",
+    "clsx": "^2.1.1",
+    "lucide-react": "^1.18.0",
+    "qrcode-generator": "^2.0.4",
+    "tailwind-merge": "^3.4.0"
+  },
+  "peerDependencies": {
+    "cuer": "^0.0.3",
+    "framer-motion": "^12.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "vaul": "^1.1.0"
+  },
+  "peerDependenciesMeta": {
+    "cuer": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "tsup": "^8",
+    "typescript": "^5"
+  }
+}

--- a/packages/unified-ui/src/components/action-row.tsx
+++ b/packages/unified-ui/src/components/action-row.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { RotateCcw } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { cn } from "../lib/utils";
+import { HapticButton } from "./haptic-button";
+
+/**
+ * The action row: a left `menu` slot (e.g. <AppMenuShell/>), the primary CTA
+ * (fills remaining width), and a circular reset button on the right. The menu
+ * and reset are visually identical size-12 bookends. Used internally by
+ * SwapCard; exported for bespoke layouts.
+ */
+export function ActionRow({
+	menu,
+	actionLabel,
+	onSubmit,
+	submitDisabled,
+	submitting,
+	submitConfirming = "Confirming…",
+	onReset,
+	resetDisabled,
+	resetAriaLabel = "Reset",
+	className,
+}: {
+	menu?: ReactNode;
+	actionLabel: ReactNode;
+	onSubmit?: () => void;
+	submitDisabled?: boolean;
+	submitting?: boolean;
+	submitConfirming?: string;
+	onReset?: () => void;
+	resetDisabled?: boolean;
+	resetAriaLabel?: string;
+	className?: string;
+}) {
+	return (
+		<div className={cn("mt-2 flex items-center gap-2", className)}>
+			{menu}
+			<HapticButton
+				wrapperClassName="grid flex-1"
+				type="button"
+				onClick={onSubmit}
+				disabled={submitDisabled}
+				className="h-12 w-full rounded-full bg-primary text-base font-semibold text-primary-foreground transition-colors hover:bg-primary/90 active:scale-[0.99] disabled:cursor-not-allowed disabled:bg-secondary/40 disabled:text-muted-foreground disabled:hover:bg-secondary/40 disabled:active:scale-100"
+			>
+				{submitting ? submitConfirming : actionLabel}
+			</HapticButton>
+			<HapticButton
+				type="button"
+				onClick={onReset}
+				disabled={resetDisabled}
+				aria-label={resetAriaLabel}
+				className="flex size-12 shrink-0 items-center justify-center rounded-full bg-secondary text-secondary-foreground transition-colors hover:bg-secondary/80 active:scale-95 disabled:cursor-not-allowed disabled:bg-secondary/40 disabled:text-muted-foreground disabled:hover:bg-secondary/40 disabled:active:scale-100"
+			>
+				<RotateCcw className="size-5" />
+			</HapticButton>
+		</div>
+	);
+}

--- a/packages/unified-ui/src/components/app-menu-shell.tsx
+++ b/packages/unified-ui/src/components/app-menu-shell.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { Menu } from "lucide-react";
+import { useState } from "react";
+
+import type { MenuSlotApi } from "../types";
+import { BottomSheet, SheetHeader } from "./bottom-sheet";
+import { HapticButton } from "./haptic-button";
+import { ResizablePanel } from "./resizable-panel";
+
+/**
+ * The presentational shell of the settings menu: the size-12 circular trigger
+ * (matching the reset button), the bottom sheet, the back/title/close header,
+ * and the morphing ResizablePanel view host. The per-view CONTENT is your
+ * `renderMenu` render prop — switch on `api.view` and push sub-views with
+ * `api.setView`. Titles come from the `titles` map.
+ */
+export function AppMenuShell({
+	renderMenu,
+	titles = {},
+	initialView = "root",
+	menuAriaLabel = "Menu",
+	backAriaLabel,
+	closeAriaLabel,
+}: {
+	renderMenu?: (api: MenuSlotApi) => React.ReactNode;
+	titles?: Record<string, string>;
+	initialView?: string;
+	menuAriaLabel?: string;
+	backAriaLabel?: string;
+	closeAriaLabel?: string;
+}) {
+	const [open, setOpen] = useState(false);
+	const [view, setViewState] = useState(initialView);
+	const [direction, setDirection] = useState(1);
+
+	const setView = (next: string, dir = 1) => {
+		setDirection(dir);
+		setViewState(next);
+	};
+
+	const onOpenChange = (next: boolean) => {
+		setOpen(next);
+		// Reset back to the root view once the sheet has closed.
+		if (!next) {
+			setDirection(-1);
+			setViewState(initialView);
+		}
+	};
+
+	const trigger = (
+		<HapticButton
+			type="button"
+			onClick={() => setOpen(true)}
+			aria-label={menuAriaLabel}
+			className="flex size-12 shrink-0 items-center justify-center rounded-full bg-secondary text-secondary-foreground transition-colors hover:bg-secondary/80 active:scale-95"
+		>
+			<Menu className="size-5" />
+		</HapticButton>
+	);
+
+	return (
+		<BottomSheet open={open} onOpenChange={onOpenChange} trigger={trigger}>
+			<div className="flex flex-col gap-4 px-3 pb-8 pt-4">
+				<SheetHeader
+					title={titles[view] ?? ""}
+					onBack={view !== initialView ? () => setView(initialView, -1) : undefined}
+					backAriaLabel={backAriaLabel}
+					closeAriaLabel={closeAriaLabel}
+				/>
+				<ResizablePanel activeKey={view} direction={direction}>
+					{renderMenu?.({ view, setView, close: () => onOpenChange(false) }) ?? null}
+				</ResizablePanel>
+			</div>
+		</BottomSheet>
+	);
+}

--- a/packages/unified-ui/src/components/apple-border-gradient.tsx
+++ b/packages/unified-ui/src/components/apple-border-gradient.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import type { CSSProperties } from "react";
+
+import { cn } from "../lib/utils";
+
+/**
+ * Animated "Apple AI gradient" edge glow. A full-size rectangle painted with a
+ * linear-gradient (blue → purple → red → orange) whose angle spins 0deg → 360deg
+ * over 5s; the centre is transparent (the `.apple-edge-glow` mask feathers the
+ * gradient inward), so it overlays the live card without covering it.
+ *
+ * Requires the `.apple-edge-glow` CSS from the package stylesheet — without it
+ * the glow is a flat opaque rectangle. Fixed to the viewport (`inset-1`);
+ * override `className` to scope it to a container.
+ */
+const COLORS = "#3b82f6, #a855f7, #ef4444, #f97316";
+
+export function AppleBorderGradient({
+	preview,
+	intensity = "xl",
+	className,
+}: {
+	preview: boolean;
+	intensity?: "lg" | "xl" | "2xl" | "3xl";
+	className?: string;
+}) {
+	// Band thickness: how far the gradient reaches inward before fading out.
+	const feather = { lg: 22, xl: 32, "2xl": 48, "3xl": 72 }[intensity];
+
+	return (
+		<AnimatePresence>
+			{preview && (
+				<motion.div
+					aria-hidden
+					initial={{ opacity: 0 }}
+					animate={{ opacity: 0.45 }}
+					exit={{ opacity: 0 }}
+					transition={{ duration: 0.5, ease: "easeInOut" }}
+					className={cn("pointer-events-none fixed inset-1 z-[100]", className)}
+				>
+					<motion.div
+						className="apple-edge-glow absolute inset-0"
+						style={{ "--feather": `${feather}px` } as CSSProperties}
+						animate={{
+							background: [
+								`linear-gradient(0deg, ${COLORS})`,
+								`linear-gradient(360deg, ${COLORS})`,
+							],
+						}}
+						transition={{ duration: 5, ease: "linear", repeat: Infinity }}
+					/>
+				</motion.div>
+			)}
+		</AnimatePresence>
+	);
+}

--- a/packages/unified-ui/src/components/bottom-sheet.tsx
+++ b/packages/unified-ui/src/components/bottom-sheet.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { ChevronLeft, X } from "lucide-react";
+import type { ReactNode } from "react";
+import { Drawer } from "vaul";
+
+import { cn } from "../lib/utils";
+
+/**
+ * Controlled bottom sheet — the byte-identical vaul chrome (overlay, rounded-top
+ * card content, drag handle) shared by the token picker and the settings menu.
+ * Render your `trigger` (it opens the sheet via its own handler) and the body as
+ * `children`. The body layout (header, scroll area, padding) is yours; use
+ * <SheetHeader/> for the standard header. Set `contentClassName` to size the
+ * sheet (e.g. "h-[88vh]" for a tall scrolling drawer).
+ */
+export function BottomSheet({
+	open,
+	onOpenChange,
+	trigger,
+	children,
+	contentClassName,
+	showHandle = true,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	trigger?: ReactNode;
+	children: ReactNode;
+	contentClassName?: string;
+	showHandle?: boolean;
+}) {
+	return (
+		<Drawer.Root open={open} onOpenChange={onOpenChange}>
+			{trigger}
+			<Drawer.Portal>
+				<Drawer.Overlay className="fixed inset-0 z-50 bg-black/60" />
+				<Drawer.Content
+					aria-describedby={undefined}
+					className={cn(
+						"fixed inset-x-0 bottom-0 z-50 mx-auto flex max-w-md flex-col rounded-t-3xl bg-card outline-none",
+						contentClassName,
+					)}
+				>
+					{showHandle && (
+						<div className="mx-auto mt-3 h-1.5 w-12 shrink-0 rounded-full bg-foreground/20" />
+					)}
+					{children}
+				</Drawer.Content>
+			</Drawer.Portal>
+		</Drawer.Root>
+	);
+}
+
+/**
+ * Standard sheet header row: an optional back button, a title, and a close
+ * button. Must render inside a <BottomSheet/> (uses vaul's Title/Close). Carries
+ * no outer padding — place it inside your padded body container.
+ */
+export function SheetHeader({
+	title,
+	onBack,
+	backAriaLabel = "Back",
+	closeAriaLabel = "Close",
+}: {
+	title: ReactNode;
+	onBack?: () => void;
+	backAriaLabel?: string;
+	closeAriaLabel?: string;
+}) {
+	return (
+		<div className="flex items-center justify-between gap-2">
+			<div className="flex min-w-0 items-center gap-1">
+				{onBack && (
+					<button
+						type="button"
+						onClick={onBack}
+						aria-label={backAriaLabel}
+						className="-ml-2 flex size-9 shrink-0 cursor-pointer items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
+					>
+						<ChevronLeft className="size-6" />
+					</button>
+				)}
+				<Drawer.Title className="truncate text-2xl font-bold text-foreground">
+					{title}
+				</Drawer.Title>
+			</div>
+			<Drawer.Close
+				aria-label={closeAriaLabel}
+				className="flex size-9 shrink-0 cursor-pointer items-center justify-center rounded-full bg-foreground/10 text-muted-foreground transition-colors hover:bg-foreground/15"
+			>
+				<X className="size-5" />
+			</Drawer.Close>
+		</div>
+	);
+}

--- a/packages/unified-ui/src/components/crypto-address.tsx
+++ b/packages/unified-ui/src/components/crypto-address.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import { cn } from "../lib/utils";
+import { QrCode } from "./qr-code";
+
+/**
+ * Tap-to-copy receive view: a scannable QR on the left, the address laid out as
+ * a multi-row "vertical address" on the right with the anchor characters (the
+ * leading + trailing chars wallets eyeball) highlighted and the middle faded.
+ * The whole surface copies the address on tap.
+ *
+ * `qrValue` overrides ONLY the QR payload (e.g. an EIP-681 URI so a scanning
+ * wallet pre-fills the right token); the displayed + copied text is always the
+ * bare `address`. By default the QR is the dependency-free <QrCode/>; pass
+ * `renderQr` (e.g. the `@joeblau/unified-ui/cuer` adapter) for a center-logo QR.
+ * `onCopy` is invoked after writing to the clipboard (wire your own toast).
+ */
+export function CryptoAddress({
+	address,
+	qrValue,
+	arena,
+	onCopy,
+	renderQr,
+}: {
+	address: string;
+	qrValue?: string;
+	/** Asset logo for the QR center — only used when `renderQr` supports it. */
+	arena?: string;
+	onCopy?: (address: string) => void;
+	renderQr?: (args: { value: string; arena?: string }) => ReactNode;
+}) {
+	const copy = () => {
+		navigator.clipboard
+			?.writeText(address)
+			.then(() => onCopy?.(address))
+			.catch(() => {});
+	};
+	const value = qrValue ?? address;
+	return (
+		<button
+			type="button"
+			onClick={copy}
+			aria-label="Copy address"
+			className="block w-full rounded-2xl p-2 transition-opacity active:opacity-80"
+		>
+			<div className="flex w-full items-center justify-evenly">
+				{/* Square tile; QR is `currentColor` so it flips with the theme:
+				    white tile + black code (light), black tile + white code (dark). */}
+				<div className="grid aspect-square w-[clamp(112px,38vw,196px)] shrink-0 rounded-2xl bg-white p-2 text-black dark:bg-black dark:text-white [&_svg]:block [&_svg]:size-full">
+					{renderQr ? (
+						renderQr({ value, arena })
+					) : (
+						<QrCode value={value} className="size-full" />
+					)}
+				</div>
+				<AddressColumn address={address} />
+			</div>
+		</button>
+	);
+}
+
+/**
+ * The address as a column of fixed-width chunks. EVM (`0x` + 40 hex) lays out 6
+ * chars × 7 rows at the larger font; everything else (Solana base58, etc.) uses
+ * a narrower 4-char grid at a smaller font. The leading anchor (6 for EVM, else
+ * 4) and trailing 4 chars are bold; the middle is faded.
+ */
+function AddressColumn({ address }: { address: string }) {
+	const isEvm = address.startsWith("0x");
+	const chunkSize = isEvm ? 6 : 4;
+	const hiStart = isEvm ? 6 : 4;
+	const total = address.length;
+	const hiEnd = total - 4;
+	const chunks: string[] = [];
+	for (let i = 0; i < total; i += chunkSize) {
+		chunks.push(address.slice(i, i + chunkSize));
+	}
+	const fontClass = isEvm
+		? "text-[clamp(15px,5vw,26px)] leading-[1.06]"
+		: "text-[clamp(10px,3.4vw,18px)] leading-[1.1]";
+	return (
+		<div
+			className={cn(
+				"flex min-w-0 flex-col font-mono tracking-wide tabular-nums",
+				fontClass,
+			)}
+		>
+			{chunks.map((chunk, chunkIdx) => (
+				<span key={chunkIdx}>
+					{Array.from(chunk).map((ch, i) => {
+						const globalIdx = chunkIdx * chunkSize + i;
+						const highlighted = globalIdx < hiStart || globalIdx >= hiEnd;
+						return (
+							<span
+								key={i}
+								className={
+									highlighted
+										? "font-semibold text-foreground"
+										: "font-medium text-foreground/25"
+								}
+							>
+								{ch}
+							</span>
+						);
+					})}
+				</span>
+			))}
+		</div>
+	);
+}

--- a/packages/unified-ui/src/components/haptic-button.tsx
+++ b/packages/unified-ui/src/components/haptic-button.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import type { ComponentProps } from "react";
+import { useEffect, useId, useRef, useState } from "react";
+
+import { shouldUseHapticOverlay } from "../lib/platform";
+import { cn } from "../lib/utils";
+
+/**
+ * A button that plays a native iOS haptic tick on tap, using the Project Fathom
+ * technique (https://github.com/m1ckc3s/project-fathom).
+ *
+ * On iOS WebKit it appends an invisible `<label>` (filling the button) linked to
+ * a native `<input switch>` via `htmlFor`/`id`. A `<label>` is an ordinary
+ * gesture target, so finger scrolling and Vaul drawer dragging pass straight
+ * through it — only a *completed tap* toggles the switch, which fires the WebKit
+ * system haptic and forwards a click to the real button; a swipe never toggles
+ * it, so it neither buzzes nor blocks the scroll.
+ *
+ * The overlay renders only on iOS WebKit, so on desktop/Android the button is a
+ * plain button with no overlay (hover and clicks behave natively).
+ *
+ * The two-element span(wrapperClassName) + button(className) structure is
+ * load-bearing for layout: `wrapperClassName` controls flex/grid participation
+ * (e.g. "grid flex-1", "block w-full", "pointer-events-auto inline-grid"); the
+ * inner button carries no baked spacing/radius. Requires the `.haptic-*` CSS
+ * from the package stylesheet.
+ */
+export function HapticButton({
+	className,
+	children,
+	wrapperClassName = "inline-grid",
+	disabled,
+	...props
+}: ComponentProps<"button"> & { wrapperClassName?: string }) {
+	const ref = useRef<HTMLButtonElement>(null);
+	const switchId = useId();
+	// Resolve out of render so SSR and the first client paint agree; flips true
+	// one tick after mount on iOS.
+	const [overlay, setOverlay] = useState(false);
+	useEffect(() => setOverlay(shouldUseHapticOverlay()), []);
+
+	return (
+		<span className={cn("relative", wrapperClassName)}>
+			<button ref={ref} className={className} disabled={disabled} {...props}>
+				{children}
+			</button>
+			{overlay && !disabled && (
+				<span aria-hidden="true" className="haptic-clip">
+					<input
+						className="haptic-switch"
+						id={switchId}
+						type="checkbox"
+						tabIndex={-1}
+						aria-hidden="true"
+						// `switch` isn't a valid JSX/TS attr; set it imperatively.
+						ref={(el) => el?.setAttribute("switch", "")}
+						onChange={() => ref.current?.click()}
+					/>
+					<label
+						className="haptic-label"
+						htmlFor={switchId}
+						aria-hidden="true"
+						onClick={(e) => e.stopPropagation()}
+					/>
+				</span>
+			)}
+		</span>
+	);
+}

--- a/packages/unified-ui/src/components/keypad.tsx
+++ b/packages/unified-ui/src/components/keypad.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import { Delete } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { cn } from "../lib/utils";
+import { HapticButton } from "./haptic-button";
+
+const KEYS = ["1", "2", "3", "4", "5", "6", "7", "8", "9", ".", "0", "back"];
+
+/**
+ * The bare numeric keypad grid. Keys emit "0"-"9", ".", or "back" to the parent.
+ * Always rendered — use where the keypad should be permanently visible.
+ */
+export function Keypad({
+	onKey,
+	className,
+	deleteAriaLabel = "Delete",
+}: {
+	onKey: (key: string) => void;
+	className?: string;
+	deleteAriaLabel?: string;
+}) {
+	return (
+		<div className={cn("grid grid-cols-3", className)}>
+			{KEYS.map((k) => (
+				<HapticButton
+					key={k}
+					wrapperClassName="grid"
+					type="button"
+					onClick={() => onKey(k)}
+					aria-label={k === "back" ? deleteAriaLabel : k}
+					className="flex h-14 items-center justify-center rounded-2xl text-2xl font-semibold text-foreground transition-colors active:bg-foreground/10"
+				>
+					{k === "back" ? <Delete className="size-6" /> : k}
+				</HapticButton>
+			))}
+		</div>
+	);
+}
+
+/**
+ * The keypad, shown only in mobile-width viewports (≤767px). It animates in when
+ * the viewport compresses to mobile and out when it widens. On desktop it
+ * unmounts so the row below sits directly under the card.
+ */
+export function MobileKeypad({
+	onKey,
+	deleteAriaLabel,
+}: {
+	onKey: (key: string) => void;
+	deleteAriaLabel?: string;
+}) {
+	const [isMobile, setIsMobile] = useState(false);
+
+	useEffect(() => {
+		const mq = window.matchMedia("(max-width: 767px)");
+		const update = () => setIsMobile(mq.matches);
+		update();
+		mq.addEventListener("change", update);
+		return () => mq.removeEventListener("change", update);
+	}, []);
+
+	return (
+		<AnimatePresence initial={false}>
+			{isMobile && (
+				<motion.div
+					initial={{ opacity: 0, height: 0, y: 16 }}
+					animate={{ opacity: 1, height: "auto", y: 0 }}
+					exit={{ opacity: 0, height: 0, y: 16 }}
+					transition={{ duration: 0.12, ease: "easeOut" }}
+					className="overflow-hidden"
+				>
+					<Keypad onKey={onKey} className="pt-2" deleteAriaLabel={deleteAriaLabel} />
+				</motion.div>
+			)}
+		</AnimatePresence>
+	);
+}

--- a/packages/unified-ui/src/components/qr-code.tsx
+++ b/packages/unified-ui/src/components/qr-code.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import qrcode from "qrcode-generator";
+import { useMemo } from "react";
+
+import { cn } from "../lib/utils";
+
+/**
+ * Renders a QR code as a crisp SVG path (no canvas, no network, SSR-safe).
+ * `value` is the encoded payload (an address or an EIP-681 URI). Colors default
+ * to `currentColor` on transparent so it inherits the surrounding theme. This is
+ * the dependency-free default; for a center-logo QR use the `cuer` subpath.
+ */
+export function QrCode({
+	value,
+	size = 200,
+	margin = 2,
+	background = "transparent",
+	foreground = "currentColor",
+	className,
+}: {
+	value: string;
+	size?: number;
+	margin?: number;
+	background?: string;
+	foreground?: string;
+	className?: string;
+}) {
+	const { path, dimension } = useMemo(() => {
+		const qr = qrcode(0, "M");
+		qr.addData(value);
+		qr.make();
+		const count = qr.getModuleCount();
+		const dim = count + margin * 2;
+		let d = "";
+		for (let row = 0; row < count; row++) {
+			for (let col = 0; col < count; col++) {
+				if (qr.isDark(row, col)) {
+					d += `M${col + margin},${row + margin}h1v1h-1z`;
+				}
+			}
+		}
+		return { path: d, dimension: dim };
+	}, [value, margin]);
+
+	return (
+		<svg
+			viewBox={`0 0 ${dimension} ${dimension}`}
+			width={size}
+			height={size}
+			role="img"
+			aria-label="QR code"
+			shapeRendering="crispEdges"
+			className={cn("block", className)}
+		>
+			{background !== "transparent" && (
+				<rect width={dimension} height={dimension} fill={background} />
+			)}
+			<path d={path} fill={foreground} />
+		</svg>
+	);
+}

--- a/packages/unified-ui/src/components/resizable-panel.tsx
+++ b/packages/unified-ui/src/components/resizable-panel.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import { type ReactNode, useLayoutEffect, useRef, useState } from "react";
+
+import { cn } from "../lib/utils";
+
+/**
+ * Family-wallet-style resizable container. The outer box springs its height to
+ * whatever the active view measures, while views cross-fade and slide in the
+ * push/pop direction — so navigating between sheet views morphs the sheet
+ * instead of snapping. `activeKey` identifies the current view; `direction` is
+ * +1 for a forward push (slide in from the right) and -1 for a back pop.
+ */
+
+const SPRING = { type: "spring", stiffness: 350, damping: 34 } as const;
+
+const slide = {
+	enter: (dir: number) => ({ x: dir >= 0 ? 28 : -28, opacity: 0 }),
+	center: { x: 0, opacity: 1 },
+	exit: (dir: number) => ({ x: dir >= 0 ? -28 : 28, opacity: 0 }),
+};
+
+export function ResizablePanel({
+	activeKey,
+	direction,
+	children,
+	className,
+}: {
+	activeKey: string;
+	direction: number;
+	children: ReactNode;
+	className?: string;
+}) {
+	const measureRef = useRef<HTMLDivElement>(null);
+	const [height, setHeight] = useState<number | null>(null);
+
+	// Track the measured height of the in-flow view. popLayout pulls the exiting
+	// view out of flow, so this reflects the incoming view immediately and the
+	// wrapper can spring to it.
+	useLayoutEffect(() => {
+		const el = measureRef.current;
+		if (!el) return;
+		const observer = new ResizeObserver(() => setHeight(el.offsetHeight));
+		observer.observe(el);
+		setHeight(el.offsetHeight);
+		return () => observer.disconnect();
+	}, []);
+
+	return (
+		<motion.div
+			initial={false}
+			animate={{ height: height ?? "auto" }}
+			transition={SPRING}
+			className={cn("relative overflow-hidden", className)}
+		>
+			<div ref={measureRef}>
+				<AnimatePresence mode="popLayout" initial={false} custom={direction}>
+					<motion.div
+						key={activeKey}
+						custom={direction}
+						variants={slide}
+						initial="enter"
+						animate="center"
+						exit="exit"
+						transition={SPRING}
+						className="w-full"
+					>
+						{children}
+					</motion.div>
+				</AnimatePresence>
+			</div>
+		</motion.div>
+	);
+}

--- a/packages/unified-ui/src/components/segmented-control.tsx
+++ b/packages/unified-ui/src/components/segmented-control.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { motion } from "framer-motion";
+import type { ComponentType } from "react";
+
+import { cn } from "../lib/utils";
+import { HapticButton } from "./haptic-button";
+
+/**
+ * Generic icon + label segmented control. A single pill slides between segments
+ * via a shared `layoutId` (must be unique per instance on the page).
+ */
+export interface SegmentOption<T extends string> {
+	value: T;
+	label: string;
+	icon: ComponentType<{ className?: string }>;
+}
+
+export function SegmentedControl<T extends string>({
+	options,
+	value,
+	onChange,
+	layoutId,
+	className,
+}: {
+	options: SegmentOption<T>[];
+	value: T;
+	onChange: (value: T) => void;
+	/** Unique id for the sliding pill's shared layout animation. */
+	layoutId: string;
+	className?: string;
+}) {
+	return (
+		<div
+			className={cn(
+				"flex items-center gap-1 rounded-full bg-foreground/[0.06] p-1",
+				className,
+			)}
+		>
+			{options.map(({ value: optionValue, label, icon: Icon }) => {
+				const isActive = value === optionValue;
+				return (
+					<HapticButton
+						key={optionValue}
+						type="button"
+						wrapperClassName="grid flex-1"
+						onClick={() => onChange(optionValue)}
+						aria-pressed={isActive}
+						className={cn(
+							"relative flex items-center justify-center gap-2 rounded-full px-3 py-2.5 text-sm font-medium transition-colors",
+							isActive
+								? "text-foreground"
+								: "text-muted-foreground hover:text-foreground",
+						)}
+					>
+						{isActive && (
+							<motion.span
+								layoutId={layoutId}
+								className="absolute inset-0 rounded-full bg-background shadow-sm"
+								transition={{ type: "spring", stiffness: 400, damping: 32 }}
+							/>
+						)}
+						<span className="relative flex items-center gap-2">
+							<Icon className="size-4" />
+							{label}
+						</span>
+					</HapticButton>
+				);
+			})}
+		</div>
+	);
+}

--- a/packages/unified-ui/src/components/settings-row.tsx
+++ b/packages/unified-ui/src/components/settings-row.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { ChevronRight } from "lucide-react";
+import type { ComponentType, ReactNode } from "react";
+
+import { cn } from "../lib/utils";
+import { HapticButton } from "./haptic-button";
+
+/**
+ * A presentational menu row: leading icon + label + optional trailing value + a
+ * chevron. Compose your settings views (slippage, order type, language, fees …)
+ * from these so they share the exact look — strings + formatting are yours.
+ */
+export function SettingsRow({
+	icon: Icon,
+	label,
+	value,
+	onClick,
+	className,
+}: {
+	icon?: ComponentType<{ className?: string }>;
+	label: ReactNode;
+	value?: ReactNode;
+	onClick?: () => void;
+	className?: string;
+}) {
+	return (
+		<HapticButton
+			type="button"
+			onClick={onClick}
+			wrapperClassName="block w-full"
+			className={cn(
+				"flex h-12 w-full cursor-pointer items-center gap-3 rounded-full bg-foreground/[0.06] px-4 text-left transition-colors hover:bg-foreground/10",
+				className,
+			)}
+		>
+			{Icon && <Icon className="size-5 shrink-0 text-muted-foreground" />}
+			<span className="flex-1 truncate text-base font-medium text-foreground">{label}</span>
+			{value != null && (
+				<span className="shrink-0 text-muted-foreground tabular-nums">{value}</span>
+			)}
+			<ChevronRight className="size-5 shrink-0 text-muted-foreground" />
+		</HapticButton>
+	);
+}

--- a/packages/unified-ui/src/components/swap-card.tsx
+++ b/packages/unified-ui/src/components/swap-card.tsx
@@ -1,0 +1,372 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { ArrowUpDown } from "lucide-react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
+
+import { cn } from "../lib/utils";
+import type {
+	GenerateAddressConfig,
+	MenuSlotApi,
+	Mode,
+	PickerSlotApi,
+	SwapCardLabels,
+	TokenRow,
+	TokenTriggerLabels,
+} from "../types";
+import { ActionRow } from "./action-row";
+import { AppleBorderGradient } from "./apple-border-gradient";
+import { AppMenuShell } from "./app-menu-shell";
+import { HapticButton } from "./haptic-button";
+import { MobileKeypad } from "./keypad";
+import { applyAmountKey, sanitizePastedAmount } from "./swap-field";
+import { SwapFrom } from "./swap-from";
+import { SwapTo } from "./swap-to";
+import { TokenTrigger } from "./token-trigger";
+
+export interface SwapCardProps {
+	// ── From ────────────────────────────────────────────────────────────────
+	fromToken: TokenRow | null;
+	onSelectFromToken: (token: TokenRow) => void;
+	fromAmount: string;
+	onFromAmountChange: (amount: string) => void;
+	fromMode: Mode;
+	onToggleFromMode: () => void;
+	/** USD value of the entered From amount. */
+	fromUsd: number;
+	/** Token units of the entered From amount. */
+	fromUnits: number;
+
+	// ── To ──────────────────────────────────────────────────────────────────
+	toToken: TokenRow | null;
+	onSelectToToken: (token: TokenRow) => void;
+	/** Received amount in token units. */
+	toAmount: number;
+	/** Received amount in USD. */
+	toUsd: number;
+	toMode: Mode;
+	onToggleToMode: () => void;
+	/** Live total fee in USD (null until a quote resolves / for sends). */
+	fee?: number | null;
+	feeLoading?: boolean;
+	slippage: number;
+	onOpenSlippage: () => void;
+
+	// ── Wallet / direction ───────────────────────────────────────────────────
+	walletAddress?: string | null;
+	canFlip: boolean;
+	onSwapTokens: () => void;
+
+	// ── Action row ───────────────────────────────────────────────────────────
+	canSwap: boolean;
+	actionLabel: ReactNode;
+	onSubmit: () => void;
+	submitting?: boolean;
+	isPristine: boolean;
+	onReset: () => void;
+
+	/**
+	 * Generate-address (receive) config. PRESENT → disconnected mode: the From
+	 * field can flip to a receive view and the From picker gets the toggle.
+	 * OMITTED → connected mode: no generate-address affordance anywhere.
+	 */
+	generateAddress?: GenerateAddressConfig;
+
+	// ── Slots ────────────────────────────────────────────────────────────────
+	/** Render the From token-picker (drawer body). Falls back to a bare trigger. */
+	renderFromPicker?: (api: PickerSlotApi) => ReactNode;
+	/** Render the To token-picker (drawer body). Falls back to a bare trigger. */
+	renderToPicker?: (api: PickerSlotApi) => ReactNode;
+	/** Render the settings-menu views inside the shared sheet. */
+	renderMenu?: (api: MenuSlotApi) => ReactNode;
+	menuTitles?: Record<string, string>;
+	menuInitialView?: string;
+	/** Labels for the token triggers (placeholders, Test/Max/Slippage/Fee). */
+	triggerLabels?: { from?: TokenTriggerLabels; to?: TokenTriggerLabels };
+
+	/** Install document keyboard + paste handlers that drive the From amount (default true). */
+	keyboardInput?: boolean;
+	/** Optional copy handler for the receive view (wire your own toast). */
+	onCopyAddress?: (address: string) => void;
+	/** Optional center-logo QR for the receive view (e.g. the `cuer` adapter). */
+	renderQr?: (args: { value: string; arena?: string }) => ReactNode;
+
+	labels?: SwapCardLabels;
+	className?: string;
+}
+
+const FROM_TRIGGER_CLASS =
+	"-mx-4 -mt-4 w-[calc(100%+2rem)] rounded-t-3xl px-4 pb-4 pt-4 hover:bg-foreground/[0.03]";
+
+/**
+ * The unified send / swap / bridge card — presentational and fully controlled.
+ * Compose the two fields, the swap-direction button, the keypad, the action row
+ * (menu + CTA + reset), and the border-gradient overlay. All data (tokens,
+ * amounts, quote, wallet) lives in the parent; the token pickers and menu are
+ * injected via render props.
+ */
+export function SwapCard({
+	fromToken,
+	onSelectFromToken,
+	fromAmount,
+	onFromAmountChange,
+	fromMode,
+	onToggleFromMode,
+	fromUsd,
+	fromUnits,
+	toToken,
+	onSelectToToken,
+	toAmount,
+	toUsd,
+	toMode,
+	onToggleToMode,
+	fee = null,
+	feeLoading,
+	slippage,
+	onOpenSlippage,
+	walletAddress,
+	canFlip,
+	onSwapTokens,
+	canSwap,
+	actionLabel,
+	onSubmit,
+	submitting,
+	isPristine,
+	onReset,
+	generateAddress,
+	renderFromPicker,
+	renderToPicker,
+	renderMenu,
+	menuTitles,
+	menuInitialView,
+	triggerLabels,
+	keyboardInput = true,
+	onCopyAddress,
+	renderQr,
+	labels,
+	className,
+}: SwapCardProps) {
+	const [fromOpen, setFromOpen] = useState(false);
+	const [toOpen, setToOpen] = useState(false);
+
+	// Presence of `generateAddress` is the single switch for the receive
+	// affordance. When omitted, genAddress is forced false (no toggle anywhere).
+	const canGenerateAddress = generateAddress !== undefined;
+	const genAddress = canGenerateAddress && generateAddress.enabled;
+
+	const toTriggerClass = cn(
+		"-mx-4 -mt-6 w-[calc(100%+2rem)] px-4 pb-4 pt-6 hover:bg-foreground/[0.03]",
+		genAddress ? "rounded-3xl" : "rounded-t-3xl",
+	);
+
+	// ── Token picker slots ────────────────────────────────────────────────────
+	const fromApi: PickerSlotApi = {
+		variant: "from",
+		selected: fromToken,
+		onSelect: onSelectFromToken,
+		triggerClassName: FROM_TRIGGER_CLASS,
+		open: fromOpen,
+		onOpenChange: setFromOpen,
+		onActivate: () => setFromOpen(true),
+		walletAddress,
+		generateAddress: canGenerateAddress ? generateAddress : undefined,
+		onSetAmount: onFromAmountChange,
+		labels: triggerLabels?.from ?? {},
+	};
+	const toApi: PickerSlotApi = {
+		variant: "to",
+		selected: toToken,
+		onSelect: onSelectToToken,
+		triggerClassName: toTriggerClass,
+		open: toOpen,
+		onOpenChange: setToOpen,
+		onActivate: () => setToOpen(true),
+		walletAddress,
+		slippage,
+		fee,
+		feeLoading,
+		onOpenSlippage,
+		labels: triggerLabels?.to ?? {},
+	};
+
+	const fromPicker = renderFromPicker ? (
+		renderFromPicker(fromApi)
+	) : (
+		<TokenTrigger
+			variant="from"
+			selected={fromToken}
+			triggerClassName={FROM_TRIGGER_CLASS}
+			walletAddress={walletAddress}
+			onActivate={fromApi.onActivate}
+			onSetAmount={onFromAmountChange}
+			labels={triggerLabels?.from}
+		/>
+	);
+	const toPicker = renderToPicker ? (
+		renderToPicker(toApi)
+	) : (
+		<TokenTrigger
+			variant="to"
+			selected={toToken}
+			triggerClassName={toTriggerClass}
+			walletAddress={walletAddress}
+			onActivate={toApi.onActivate}
+			slippage={slippage}
+			fee={fee}
+			feeLoading={feeLoading}
+			onOpenSlippage={onOpenSlippage}
+			labels={triggerLabels?.to}
+		/>
+	);
+
+	// ── Keypad + physical keyboard (drive the From amount) ────────────────────
+	const amountRef = useRef(fromAmount);
+	amountRef.current = fromAmount;
+	const modeRef = useRef(fromMode);
+	modeRef.current = fromMode;
+	const changeRef = useRef(onFromAmountChange);
+	changeRef.current = onFromAmountChange;
+
+	const handleKey = (key: string) => {
+		const next = applyAmountKey(amountRef.current, key, modeRef.current);
+		if (next !== amountRef.current) changeRef.current(next);
+	};
+
+	useEffect(() => {
+		if (!keyboardInput) return;
+		const inField = () => {
+			const el = document.activeElement;
+			return (
+				!!el &&
+				(el.tagName === "INPUT" ||
+					el.tagName === "TEXTAREA" ||
+					(el as HTMLElement).isContentEditable)
+			);
+		};
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (e.metaKey || e.ctrlKey || e.altKey || inField()) return;
+			if (/^[0-9]$/.test(e.key)) {
+				handleKey(e.key);
+				e.preventDefault();
+			} else if (e.key === ".") {
+				handleKey(".");
+				e.preventDefault();
+			} else if (e.key === "Backspace") {
+				handleKey("back");
+				e.preventDefault();
+			}
+		};
+		const onPaste = (e: ClipboardEvent) => {
+			if (inField()) return;
+			const parsed = sanitizePastedAmount(
+				e.clipboardData?.getData("text") ?? "",
+				modeRef.current,
+			);
+			if (parsed !== null) {
+				changeRef.current(parsed);
+				e.preventDefault();
+			}
+		};
+		document.addEventListener("keydown", onKeyDown);
+		document.addEventListener("paste", onPaste);
+		return () => {
+			document.removeEventListener("keydown", onKeyDown);
+			document.removeEventListener("paste", onPaste);
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [keyboardInput]);
+
+	return (
+		<motion.div
+			className={cn("unified-ui-root w-full max-w-md", className)}
+			initial={{ opacity: 0, y: 12 }}
+			animate={{ opacity: 1, y: 0 }}
+			transition={{ duration: 0.4, ease: "easeOut" }}
+		>
+			{/* You pay */}
+			<SwapFrom
+				picker={fromPicker}
+				amount={fromAmount}
+				mode={fromMode}
+				onToggleMode={onToggleFromMode}
+				usd={fromUsd}
+				units={fromUnits}
+				symbol={fromToken?.symbol}
+				amountAriaLabel={labels?.amountAriaLabel}
+				genAddress={genAddress}
+				receiveAddress={generateAddress?.receiveAddress}
+				receivePayload={generateAddress?.receivePayload}
+				arena={generateAddress?.arena}
+				onCopyAddress={onCopyAddress}
+				renderQr={renderQr}
+			/>
+
+			{/* Swap direction */}
+			<div className="relative z-10 mx-auto -my-3 flex w-fit">
+				{/* Filled disc behind the button — breaks the seam line; sized to
+				    include what used to be the 2px ring (size-8 + 2px each side). */}
+				<span
+					aria-hidden
+					className="absolute left-1/2 top-1/2 size-9 -translate-x-1/2 -translate-y-1/2 rounded-full bg-background"
+				/>
+				<HapticButton
+					type="button"
+					onClick={onSwapTokens}
+					disabled={!canFlip}
+					style={
+						canFlip
+							? {
+									background:
+										"linear-gradient(hsl(var(--foreground) / 0.07), hsl(var(--foreground) / 0.07)), hsl(var(--card))",
+								}
+							: undefined
+					}
+					className={cn(
+						"relative flex size-8 items-center justify-center rounded-full transition-colors",
+						canFlip
+							? "text-muted-foreground"
+							: "cursor-not-allowed bg-secondary/40 text-muted-foreground",
+					)}
+					aria-label={labels?.swapDirectionAriaLabel ?? "Swap direction"}
+				>
+					<ArrowUpDown className="size-4" />
+				</HapticButton>
+			</div>
+
+			{/* You receive */}
+			<SwapTo
+				picker={toPicker}
+				amount={toAmount}
+				usd={toUsd}
+				mode={toMode}
+				onToggleMode={onToggleToMode}
+				symbol={toToken?.symbol}
+				amountAriaLabel={labels?.amountAriaLabel}
+				collapsed={genAddress}
+			/>
+
+			<MobileKeypad onKey={handleKey} deleteAriaLabel={labels?.deleteKeyAriaLabel} />
+
+			<ActionRow
+				menu={
+					<AppMenuShell
+						renderMenu={renderMenu}
+						titles={menuTitles}
+						initialView={menuInitialView}
+						menuAriaLabel={labels?.menuAriaLabel}
+					/>
+				}
+				actionLabel={actionLabel}
+				onSubmit={onSubmit}
+				submitDisabled={submitting || (!genAddress && !canSwap)}
+				submitting={submitting}
+				submitConfirming={labels?.submitConfirming}
+				onReset={onReset}
+				resetDisabled={isPristine || submitting}
+				resetAriaLabel={labels?.resetAriaLabel}
+			/>
+
+			<AppleBorderGradient preview={!!submitting} intensity="xl" />
+		</motion.div>
+	);
+}

--- a/packages/unified-ui/src/components/swap-field.tsx
+++ b/packages/unified-ui/src/components/swap-field.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import NumberFlow from "@number-flow/react";
+import { useEffect, useRef, useState } from "react";
+
+import { cn } from "../lib/utils";
+import type { Mode } from "../types";
+import { HapticButton } from "./haptic-button";
+
+/** Trim a number to a clean string (drops trailing zeros, caps at 8 decimals). */
+export function trim(n: number) {
+	return String(Number(n.toFixed(8)));
+}
+
+/** Trim a USD value to a clean string, capped at 2 decimal places. */
+export function trimUsd(n: number) {
+	return String(Number(n.toFixed(2)));
+}
+
+/** Keep only digits and a single decimal point; strip leading zeros. */
+export function sanitizeAmount(raw: string) {
+	let v = raw.replace(/[^0-9.]/g, "");
+	const dot = v.indexOf(".");
+	if (dot !== -1) {
+		v = v.slice(0, dot + 1) + v.slice(dot + 1).replace(/\./g, "");
+	}
+	v = v.replace(/^0+(\d)/, "$1");
+	return v === "" || v === "." ? "0" : v;
+}
+
+/**
+ * Apply a keypad/keyboard key to the current amount string and return the next
+ * string. `key` is "0"-"9", "." or "back". In USD mode digits past 2 decimals
+ * are rejected (returns `current` unchanged). Pure — safe to call from both the
+ * on-screen keypad and the physical-keyboard handler.
+ */
+export function applyAmountKey(current: string, key: string, mode: Mode): string {
+	if (key === "back") return current.length <= 1 ? "0" : current.slice(0, -1);
+	if (key === ".") return current.includes(".") ? current : `${current}.`;
+	const next = sanitizeAmount(current === "0" ? key : current + key);
+	if (mode === "usd") {
+		const dot = next.indexOf(".");
+		if (dot !== -1 && next.length - dot - 1 > 2) return current;
+	}
+	return next;
+}
+
+/**
+ * Normalize a pasted string to an amount, or null if it isn't a plain number.
+ * In USD mode the result is clamped to 2 decimals.
+ */
+export function sanitizePastedAmount(text: string, mode: Mode): string | null {
+	const cleaned = text.trim().replace(/,/g, "");
+	if (cleaned === "" || !/^[0-9]*\.?[0-9]*$/.test(cleaned)) return null;
+	const next = sanitizeAmount(cleaned);
+	return mode === "usd" ? trimUsd(Number(next) || 0) : next;
+}
+
+/**
+ * The animated value inside a conversion Pill. In "token" mode the field is
+ * entered in token units so the pill shows the USD equivalent ($, 2dp); in "usd"
+ * mode it shows the token amount + symbol (up to 8dp, no grouping).
+ */
+export function ConversionValue({
+	mode,
+	usd,
+	units,
+	symbol,
+}: {
+	mode: Mode;
+	usd: number;
+	units: number;
+	symbol: string;
+}) {
+	if (mode === "token") {
+		return (
+			<NumberFlow
+				value={usd}
+				prefix="$"
+				format={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }}
+				className="overflow-hidden [--number-flow-mask-height:0px]"
+			/>
+		);
+	}
+	return (
+		<NumberFlow
+			value={units}
+			suffix={symbol ? ` ${symbol}` : ""}
+			format={{ maximumFractionDigits: 8, useGrouping: false }}
+			className="overflow-hidden [--number-flow-mask-height:0px]"
+		/>
+	);
+}
+
+export function Pill({
+	onClick,
+	children,
+}: {
+	onClick?: () => void;
+	children: React.ReactNode;
+}) {
+	return (
+		<HapticButton
+			type="button"
+			onClick={onClick}
+			wrapperClassName="pointer-events-auto inline-grid"
+			className="inline-flex cursor-pointer items-center gap-1.5 rounded-full bg-foreground/[0.07] px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-foreground/[0.12]"
+		>
+			{children}
+		</HapticButton>
+	);
+}
+
+/**
+ * Animated amount display. Dollar values ($ prefix) never show more than 2
+ * decimals; token amounts up to 8. The [--number-flow-mask-height:0px] kills
+ * NumberFlow's top/bottom fade so large bold digits aren't clipped.
+ */
+export function AmountInput({
+	value,
+	prefix,
+	muted,
+	ariaLabel = "Amount",
+	sizeClassName = "text-3xl md:text-5xl",
+}: {
+	value: string;
+	prefix?: string;
+	muted?: boolean;
+	ariaLabel?: string;
+	sizeClassName?: string;
+}) {
+	const maxFraction = prefix === "$" ? 2 : 8;
+	const dot = value.indexOf(".");
+	const fractionDigits =
+		dot === -1 ? 0 : Math.min(value.length - dot - 1, maxFraction);
+	return (
+		<div
+			role="textbox"
+			aria-label={ariaLabel}
+			tabIndex={0}
+			className="cursor-text overflow-hidden rounded-lg outline-none"
+		>
+			<NumberFlow
+				value={Number(value) || 0}
+				prefix={prefix}
+				suffix={value.endsWith(".") ? "." : ""}
+				format={{
+					minimumFractionDigits: fractionDigits,
+					maximumFractionDigits: maxFraction,
+					useGrouping: false,
+				}}
+				className={cn(
+					"font-bold tracking-tight [--number-flow-mask-height:0px]",
+					sizeClassName,
+					muted ? "text-muted-foreground" : "text-foreground",
+				)}
+			/>
+		</div>
+	);
+}
+
+/** Shared CSS height transition for the animated amount fields. */
+export const AMOUNT_FIELD_TRANSITION =
+	"overflow-hidden transition-[height] duration-[400ms] ease-[cubic-bezier(0.22,1,0.36,1)]";
+
+/**
+ * Measures the natural (content-box) height of an element and keeps it current
+ * across breakpoint/value changes via a ResizeObserver. Returns the ref to put
+ * on the content and its measured height (`null` until first measured). Used to
+ * coordinate the generate-address animation: the "from" amount field grows by
+ * exactly the height the removed "to" amount block gives up, so the card's total
+ * height is unchanged.
+ *
+ * A hook rather than a wrapper component so call sites use inline JSX — a
+ * `children: ReactNode` prop trips duplicated `@types/react`.
+ */
+export function useMeasuredHeight() {
+	const ref = useRef<HTMLDivElement>(null);
+	const [height, setHeight] = useState<number | null>(null);
+
+	useEffect(() => {
+		const el = ref.current;
+		if (!el) return;
+		const measure = () => setHeight(el.offsetHeight);
+		measure();
+		const ro = new ResizeObserver(measure);
+		ro.observe(el);
+		return () => ro.disconnect();
+	}, []);
+
+	return { ref, height };
+}

--- a/packages/unified-ui/src/components/swap-from.tsx
+++ b/packages/unified-ui/src/components/swap-from.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { ArrowUpDown } from "lucide-react";
+import type { ReactNode } from "react";
+
+import type { Mode } from "../types";
+import { cn } from "../lib/utils";
+import { CryptoAddress } from "./crypto-address";
+import {
+	AMOUNT_FIELD_TRANSITION,
+	AmountInput,
+	ConversionValue,
+	Pill,
+	useMeasuredHeight,
+} from "./swap-field";
+
+export interface SwapFromProps {
+	/** The token-selector node (your <BottomSheet trigger={<TokenTrigger/>}>… or a bare <TokenTrigger/>). */
+	picker: ReactNode;
+	/** Editable amount string, in `mode`'s denomination. */
+	amount: string;
+	mode: Mode;
+	onToggleMode: () => void;
+	/** USD value of the entered amount (for the conversion pill). */
+	usd: number;
+	/** Token units of the entered amount (for the conversion pill). */
+	units: number;
+	/** Selected token symbol (shown in the token-mode conversion pill). */
+	symbol?: string;
+	amountAriaLabel?: string;
+	/** Generate-address (receive) mode: swaps the amount field for a QR + address. */
+	genAddress?: boolean;
+	receiveAddress?: string;
+	receivePayload?: string;
+	arena?: string;
+	onCopyAddress?: (address: string) => void;
+	renderQr?: (args: { value: string; arena?: string }) => ReactNode;
+}
+
+/**
+ * The "You pay" side: a token-selector slot plus an animated amount field that
+ * flips between token and USD denomination. In generate-address mode the amount
+ * field is replaced by a QR + vertical address (receive view). Fully controlled.
+ */
+export function SwapFrom({
+	picker,
+	amount,
+	mode,
+	onToggleMode,
+	usd,
+	units,
+	symbol,
+	amountAriaLabel,
+	genAddress = false,
+	receiveAddress,
+	receivePayload,
+	arena,
+	onCopyAddress,
+	renderQr,
+}: SwapFromProps) {
+	const box = useMeasuredHeight();
+	const height = box.height ?? undefined;
+
+	return (
+		<section className="rounded-3xl bg-card px-4 pb-3 pt-4">
+			{picker}
+			<div className="-mx-4 border-t-2 border-background" />
+			<div
+				className={cn("flex flex-col justify-center", AMOUNT_FIELD_TRANSITION)}
+				style={{ height }}
+			>
+				<div ref={box.ref}>
+					{genAddress ? (
+						<CryptoAddress
+							address={receiveAddress ?? ""}
+							qrValue={receivePayload}
+							arena={arena}
+							onCopy={onCopyAddress}
+							renderQr={renderQr}
+						/>
+					) : (
+						<div className="flex flex-col items-center gap-2 p-2">
+							<AmountInput
+								value={amount}
+								prefix={mode === "usd" ? "$" : undefined}
+								ariaLabel={amountAriaLabel}
+							/>
+							<Pill onClick={onToggleMode}>
+								<span className="opacity-50">=</span>{" "}
+								<ConversionValue mode={mode} usd={usd} units={units} symbol={symbol ?? ""} />
+								<ArrowUpDown className="size-3.5" />
+							</Pill>
+						</div>
+					)}
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/packages/unified-ui/src/components/swap-to.tsx
+++ b/packages/unified-ui/src/components/swap-to.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { ArrowUpDown } from "lucide-react";
+import type { ReactNode } from "react";
+
+import type { Mode } from "../types";
+import {
+	AMOUNT_FIELD_TRANSITION,
+	AmountInput,
+	ConversionValue,
+	Pill,
+	trim,
+	useMeasuredHeight,
+} from "./swap-field";
+
+export interface SwapToProps {
+	/** The token-selector node (your <BottomSheet trigger={<TokenTrigger/>}>… or a bare <TokenTrigger/>). */
+	picker: ReactNode;
+	/** Received token amount (units). */
+	amount: number;
+	/** Received USD value. */
+	usd: number;
+	mode: Mode;
+	onToggleMode: () => void;
+	/** Selected token symbol (shown in the token-mode conversion pill). */
+	symbol?: string;
+	amountAriaLabel?: string;
+	/** Collapse the amount block to height 0 (generate-address / receive mode). */
+	collapsed?: boolean;
+}
+
+/**
+ * The "You receive" side: a token-selector slot plus a muted, read-only animated
+ * amount that flips between token and USD denomination. The amount block
+ * collapses to nothing when `collapsed` so the card's total height stays
+ * constant while the From side grows into a receive view. Fully controlled.
+ */
+export function SwapTo({
+	picker,
+	amount,
+	usd,
+	mode,
+	onToggleMode,
+	symbol,
+	amountAriaLabel,
+	collapsed = false,
+}: SwapToProps) {
+	const box = useMeasuredHeight();
+	const height = box.height == null ? undefined : collapsed ? 0 : box.height;
+
+	return (
+		<section className="rounded-3xl bg-card px-4 pb-0 pt-6">
+			{picker}
+			<div className={AMOUNT_FIELD_TRANSITION} style={{ height }}>
+				<div ref={box.ref}>
+					<div className="-mx-4 border-t-2 border-background" />
+					<div className="flex flex-col items-center gap-2 p-2">
+						<AmountInput
+							value={trim(mode === "token" ? amount : usd)}
+							prefix={mode === "usd" ? "$" : undefined}
+							muted
+							ariaLabel={amountAriaLabel}
+						/>
+						<Pill onClick={onToggleMode}>
+							<span className="opacity-50">=</span>{" "}
+							<ConversionValue mode={mode} usd={usd} units={amount} symbol={symbol ?? ""} />
+							<ArrowUpDown className="size-3.5" />
+						</Pill>
+					</div>
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/packages/unified-ui/src/components/token-amount.tsx
+++ b/packages/unified-ui/src/components/token-amount.tsx
@@ -1,0 +1,22 @@
+import { formatTokenParts } from "../lib/format";
+
+/**
+ * Renders a token amount with the DexScreener-style leading-zero count rendered
+ * as a styled <sub> (e.g. 0.0₅4773). Display only.
+ */
+export function TokenAmount({
+	value,
+	className,
+}: {
+	value: string | number;
+	className?: string;
+}) {
+	const { lead, sub, rest } = formatTokenParts(value);
+	return (
+		<span className={className}>
+			{lead}
+			{sub && <sub className="text-[0.7em] font-normal">{sub}</sub>}
+			{rest}
+		</span>
+	);
+}

--- a/packages/unified-ui/src/components/token-trigger.tsx
+++ b/packages/unified-ui/src/components/token-trigger.tsx
@@ -1,0 +1,294 @@
+"use client";
+
+import Avatar from "boring-avatars";
+import { AnimatePresence, motion } from "framer-motion";
+import { FlaskConical, SlidersHorizontal } from "lucide-react";
+
+import { computeTest, formatPct, truncateAddress } from "../lib/format";
+import { cn } from "../lib/utils";
+import type { TokenRow, TokenTriggerLabels } from "../types";
+import { HapticButton } from "./haptic-button";
+import { TokenAmount } from "./token-amount";
+
+const ADDRESS = "0x71•••976F";
+const AVATAR_COLORS = ["#7dd3fc", "#3b82f6", "#2563eb", "#1e3a8a", "#0ea5e9"];
+
+/** Relay icon CDN; override per token via `chainIconUrl` if you host your own. */
+const defaultChainIcon = (chainId: number) =>
+	`https://assets.relay.link/icons/${chainId}/light.png`;
+
+const DEFAULT_LABELS: Required<
+	Pick<TokenTriggerLabels, "test" | "max" | "slippage" | "fee">
+> = {
+	test: "Test",
+	max: "Max",
+	slippage: (percent) => percent,
+	fee: (amount) => `Fee ${amount}`,
+};
+
+function AssetStack({
+	token,
+	seed,
+	chainIconUrl,
+}: {
+	token: TokenRow;
+	seed: string;
+	chainIconUrl: (chainId: number) => string;
+}) {
+	return (
+		<div className="relative h-14 w-7 shrink-0">
+			<div className="absolute left-1/2 top-0 size-7 -translate-x-1/2 overflow-hidden rounded-full ring-2 ring-card">
+				<Avatar size={28} name={seed} variant="marble" colors={AVATAR_COLORS} />
+			</div>
+			{/* biome-ignore lint/a11y/useAltText: decorative chain glyph */}
+			<img
+				src={chainIconUrl(token.chainId)}
+				alt={token.chain}
+				className="absolute left-1/2 top-3.5 size-7 -translate-x-1/2 rounded-full bg-card object-cover ring-2 ring-card"
+			/>
+			{/* biome-ignore lint/a11y/useAltText: token logo */}
+			<img
+				src={token.logo}
+				alt={token.name}
+				className="absolute left-1/2 top-7 size-7 -translate-x-1/2 rounded-full bg-card object-cover ring-2 ring-card"
+			/>
+		</div>
+	);
+}
+
+function ClickablePill({
+	onClick,
+	children,
+}: {
+	onClick: (e: React.MouseEvent) => void;
+	children: React.ReactNode;
+}) {
+	return (
+		<HapticButton
+			type="button"
+			onClick={onClick}
+			wrapperClassName="pointer-events-auto inline-grid"
+			className="inline-flex cursor-pointer items-center gap-1.5 rounded-full bg-foreground/[0.07] px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-foreground/[0.12]"
+		>
+			{children}
+		</HapticButton>
+	);
+}
+
+function SelectedMeta({
+	variant,
+	token,
+	labels,
+	onSetAmount,
+	slippage,
+	fee,
+	feeLoading,
+	onOpenSlippage,
+}: {
+	variant: "from" | "to";
+	token: TokenRow;
+	labels: Required<Pick<TokenTriggerLabels, "test" | "max" | "slippage" | "fee">>;
+	onSetAmount?: (amount: string) => void;
+	slippage?: number;
+	fee?: number | null;
+	feeLoading?: boolean;
+	onOpenSlippage?: () => void;
+}) {
+	if (variant === "to") {
+		const feeAmount = feeLoading ? "…" : fee != null ? `$${fee.toFixed(2)}` : "—";
+		return (
+			<div className="flex flex-col items-end gap-2">
+				<ClickablePill
+					onClick={(e) => {
+						e.stopPropagation();
+						onOpenSlippage?.();
+					}}
+				>
+					<SlidersHorizontal className="size-3.5" />
+					{labels.slippage(formatPct(slippage ?? 0.005))}
+				</ClickablePill>
+				<span className="text-sm text-muted-foreground">{labels.fee(feeAmount)}</span>
+			</div>
+		);
+	}
+	const set = (amount: string) => (e: React.MouseEvent) => {
+		e.stopPropagation();
+		onSetAmount?.(amount);
+	};
+	// No holdings known (catalog without wallet balances) — show nothing.
+	if (Number.parseFloat(token.amount) <= 0) return null;
+	return (
+		<div className="flex flex-col items-end gap-2">
+			<div className="flex gap-2">
+				<ClickablePill onClick={set(computeTest(token))}>
+					<FlaskConical className="size-3.5" />
+					{labels.test}
+				</ClickablePill>
+				<ClickablePill onClick={set(token.amount)}>{labels.max}</ClickablePill>
+			</div>
+			<span className="text-sm text-muted-foreground">
+				<TokenAmount value={token.amount} /> {token.symbol}
+			</span>
+		</div>
+	);
+}
+
+function SelectedHeader({
+	variant,
+	token,
+	walletAddress,
+	chainIconUrl,
+	labels,
+	onSetAmount,
+	slippage,
+	fee,
+	feeLoading,
+	onOpenSlippage,
+}: {
+	variant: "from" | "to";
+	token: TokenRow;
+	walletAddress?: string | null;
+	chainIconUrl: (chainId: number) => string;
+	labels: Required<Pick<TokenTriggerLabels, "test" | "max" | "slippage" | "fee">>;
+	onSetAmount?: (amount: string) => void;
+	slippage?: number;
+	fee?: number | null;
+	feeLoading?: boolean;
+	onOpenSlippage?: () => void;
+}) {
+	return (
+		<div className="flex items-start justify-between gap-3">
+			<div className="flex items-center gap-3">
+				<AssetStack
+					token={token}
+					seed={walletAddress ?? ADDRESS}
+					chainIconUrl={chainIconUrl}
+				/>
+				<div className="flex flex-col leading-none -space-y-0.5">
+					<span className="text-sm text-muted-foreground">
+						{walletAddress ? truncateAddress(walletAddress) : ADDRESS}
+					</span>
+					<span className="text-sm text-muted-foreground">{token.chain}</span>
+					<span className="text-base font-semibold text-foreground">{token.name}</span>
+				</div>
+			</div>
+			<SelectedMeta
+				variant={variant}
+				token={token}
+				labels={labels}
+				onSetAmount={onSetAmount}
+				slippage={slippage}
+				fee={fee}
+				feeLoading={feeLoading}
+				onOpenSlippage={onOpenSlippage}
+			/>
+		</div>
+	);
+}
+
+/**
+ * The presentational token selector face. Shows a large "From..." / "To..."
+ * placeholder until a token is picked, then a stacked icon + address/chain/name
+ * with side-specific meta (Test/Max + holdings for From, Slippage/Fee for To).
+ * Tapping anywhere calls `onActivate` (open your drawer); the meta pills opt back
+ * into pointer events and act without opening it.
+ *
+ * Fully presentational — no data, wallet, or drawer logic. Wrap it in your own
+ * <BottomSheet trigger={<TokenTrigger … />}> and render the drawer body yourself.
+ */
+export function TokenTrigger({
+	variant,
+	selected = null,
+	triggerClassName,
+	walletAddress,
+	onActivate,
+	labels,
+	kbdHint,
+	chainIconUrl = defaultChainIcon,
+	onSetAmount,
+	slippage,
+	fee,
+	feeLoading,
+	onOpenSlippage,
+}: {
+	variant: "from" | "to";
+	selected?: TokenRow | null;
+	triggerClassName?: string;
+	walletAddress?: string | null;
+	/** Open your drawer. */
+	onActivate?: () => void;
+	labels?: TokenTriggerLabels;
+	/** Optional keyboard hint glyph rendered as a ⌘<hint> kbd (e.g. "F"). */
+	kbdHint?: string;
+	/** Override the chain-icon URL builder (defaults to Relay's CDN). */
+	chainIconUrl?: (chainId: number) => string;
+	onSetAmount?: (amount: string) => void;
+	slippage?: number;
+	fee?: number | null;
+	feeLoading?: boolean;
+	onOpenSlippage?: () => void;
+}) {
+	const merged = { ...DEFAULT_LABELS, ...labels };
+	const placeholder = labels?.placeholder ?? (variant === "from" ? "From..." : "To...");
+	const selectAriaLabel = labels?.selectAriaLabel ?? `Select ${variant} token`;
+
+	return (
+		<div className={cn("relative block text-left transition-colors", triggerClassName)}>
+			{/* Full-area tap target. It sits behind a pass-through content layer; the
+			    pills re-enable pointer events so they act without opening the drawer. */}
+			<div className="absolute inset-0">
+				<HapticButton
+					type="button"
+					onClick={() => onActivate?.()}
+					aria-label={selectAriaLabel}
+					wrapperClassName="grid size-full"
+					className="size-full cursor-pointer"
+				/>
+			</div>
+			<div className="pointer-events-none relative flex min-h-[3.75rem] flex-col justify-center">
+				<AnimatePresence mode="wait" initial={false}>
+					{selected ? (
+						<motion.div
+							key="selected"
+							initial={{ opacity: 0 }}
+							animate={{ opacity: 1 }}
+							exit={{ opacity: 0 }}
+							transition={{ duration: 0.2, ease: "easeOut" }}
+						>
+							<SelectedHeader
+								variant={variant}
+								token={selected}
+								walletAddress={walletAddress}
+								chainIconUrl={chainIconUrl}
+								labels={merged}
+								onSetAmount={onSetAmount}
+								slippage={slippage}
+								fee={fee}
+								feeLoading={feeLoading}
+								onOpenSlippage={onOpenSlippage}
+							/>
+						</motion.div>
+					) : (
+						<motion.div
+							key="placeholder"
+							initial={{ opacity: 0 }}
+							animate={{ opacity: 1 }}
+							exit={{ opacity: 0 }}
+							transition={{ duration: 0.2, ease: "easeOut" }}
+						>
+							<span className="token-box-label block text-5xl font-semibold text-foreground/30">
+								{placeholder}
+							</span>
+							{kbdHint && (
+								<kbd className="pointer-events-none absolute right-0 top-1/2 hidden h-5 -translate-y-1/2 select-none items-center gap-1 rounded border border-border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground md:inline-flex">
+									<span className="text-xs">⌘</span>
+									{kbdHint}
+								</kbd>
+							)}
+						</motion.div>
+					)}
+				</AnimatePresence>
+			</div>
+		</div>
+	);
+}

--- a/packages/unified-ui/src/cuer-qr.tsx
+++ b/packages/unified-ui/src/cuer-qr.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Cuer } from "cuer";
+
+/**
+ * Optional center-logo QR backed by `cuer`, for use as CryptoAddress's
+ * `renderQr` slot:
+ *
+ *   import { cuerQr } from "@joeblau/unified-ui/cuer";
+ *   <CryptoAddress address={addr} arena={logo} renderQr={cuerQr} />
+ *
+ * Kept in a separate entry so the core package does not depend on `cuer`
+ * (declared an OPTIONAL peer). Note: in some setups cuer's center-logo rendering
+ * benefits from the upstream `cuer@0.0.3` patch; without it the QR still scans.
+ */
+export function cuerQr({ value, arena }: { value: string; arena?: string }) {
+	return (
+		<Cuer
+			value={value}
+			size={196}
+			color="currentColor"
+			arena={arena}
+			errorCorrection={arena ? "high" : undefined}
+		/>
+	);
+}

--- a/packages/unified-ui/src/index.ts
+++ b/packages/unified-ui/src/index.ts
@@ -1,0 +1,63 @@
+// ── Card + fields ───────────────────────────────────────────────────────────
+export { SwapCard, type SwapCardProps } from "./components/swap-card";
+export { SwapFrom, type SwapFromProps } from "./components/swap-from";
+export { SwapTo, type SwapToProps } from "./components/swap-to";
+
+// ── Composition primitives ──────────────────────────────────────────────────
+export { ActionRow } from "./components/action-row";
+export { AppMenuShell } from "./components/app-menu-shell";
+export { BottomSheet, SheetHeader } from "./components/bottom-sheet";
+export { TokenTrigger } from "./components/token-trigger";
+export { SettingsRow } from "./components/settings-row";
+export {
+	SegmentedControl,
+	type SegmentOption,
+} from "./components/segmented-control";
+export { ResizablePanel } from "./components/resizable-panel";
+export { Keypad, MobileKeypad } from "./components/keypad";
+
+// ── Leaf primitives ─────────────────────────────────────────────────────────
+export { HapticButton } from "./components/haptic-button";
+export { AppleBorderGradient } from "./components/apple-border-gradient";
+export { CryptoAddress } from "./components/crypto-address";
+export { QrCode } from "./components/qr-code";
+export { TokenAmount } from "./components/token-amount";
+export {
+	AmountInput,
+	ConversionValue,
+	Pill,
+	AMOUNT_FIELD_TRANSITION,
+	useMeasuredHeight,
+	// amount helpers
+	trim,
+	trimUsd,
+	sanitizeAmount,
+	applyAmountKey,
+	sanitizePastedAmount,
+} from "./components/swap-field";
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+export {
+	cn,
+} from "./lib/utils";
+export {
+	formatPct,
+	fmtUsd,
+	price,
+	computeTest,
+	truncateAddress,
+	formatTokenParts,
+	type TokenDisplayParts,
+} from "./lib/format";
+export { shouldUseHapticOverlay } from "./lib/platform";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+export type {
+	Mode,
+	TokenRow,
+	GenerateAddressConfig,
+	TokenTriggerLabels,
+	PickerSlotApi,
+	MenuSlotApi,
+	SwapCardLabels,
+} from "./types";

--- a/packages/unified-ui/src/lib/format.ts
+++ b/packages/unified-ui/src/lib/format.ts
@@ -1,0 +1,78 @@
+import type { TokenRow } from "../types";
+
+/** Format a slippage fraction as a percent string with trailing zeros trimmed. */
+export function formatPct(fraction: number) {
+	return `${Number((fraction * 100).toFixed(4))}%`;
+}
+
+/** Format a USD value with two decimals. */
+export function fmtUsd(n: number) {
+	return `$${n.toFixed(2)}`;
+}
+
+/** USD price per unit of a token: total usd ÷ holdings. 0 if NaN / divide-by-zero. */
+export function price(token: TokenRow) {
+	const usd = Number.parseFloat(token.usd.replace(/[^0-9.]/g, "")) || 0;
+	const amount = Number.parseFloat(token.amount) || 0;
+	if (!(usd > 0) || !(amount > 0)) return 0;
+	return usd / amount;
+}
+
+/** Test amount: 1% of holdings, capped at ~$1 worth of the asset. */
+export function computeTest(token: TokenRow) {
+	const usd = Number.parseFloat(token.usd.replace(/[^0-9.]/g, "")) || 0;
+	const amount = Number.parseFloat(token.amount) || 0;
+	if (usd <= 0 || amount <= 0) return "0";
+	const test = Math.min(0.01 * amount, amount / usd);
+	return String(Number(test.toFixed(8)));
+}
+
+/** Shorten a wallet address (EVM or Solana) to `123456…wxyz` for display. */
+export function truncateAddress(addr: string) {
+	return addr.length <= 12 ? addr : `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+}
+
+export interface TokenDisplayParts {
+	lead: string;
+	/** Leading-zero count to render as a subscript, or null. */
+	sub: string | null;
+	rest: string;
+}
+
+/**
+ * Split a token amount into display parts: a leading string, an optional
+ * leading-zero count (rendered as a subscript, DexScreener-style), and the
+ * remaining significant digits. Whole amounts group thousands and cap at 4
+ * decimals; sub-1 amounts keep 4 significant digits, collapsing >3 leading
+ * zeros to a subscript.
+ */
+export function formatTokenParts(value: string | number): TokenDisplayParts {
+	if (typeof value === "number" && !Number.isFinite(value)) {
+		return { lead: "0", sub: null, rest: "" };
+	}
+	const raw =
+		typeof value === "string"
+			? value.trim()
+			: value.toLocaleString("en-US", {
+					maximumFractionDigits: 20,
+					useGrouping: false,
+				});
+	if (raw === "" || Number(raw) === 0) return { lead: "0", sub: null, rest: "" };
+
+	const sign = raw.startsWith("-") ? "-" : "";
+	const abs = sign ? raw.slice(1) : raw;
+	const [whole = "0", fracRaw = ""] = abs.split(".");
+
+	if (whole !== "0" && whole !== "") {
+		const dec = fracRaw.slice(0, 4).replace(/0+$/, "");
+		const grouped = whole.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+		return { lead: sign + (dec ? `${grouped}.${dec}` : grouped), sub: null, rest: "" };
+	}
+
+	const frac = fracRaw.replace(/0+$/, "");
+	const zeros = frac.length - frac.replace(/^0+/, "").length;
+	const sig = frac.replace(/^0+/, "").slice(0, 4) || "0";
+	// Only collapse to subscript once there are more than 3 leading zeros.
+	if (zeros >= 4) return { lead: `${sign}0.0`, sub: String(zeros), rest: sig };
+	return { lead: `${sign}0.${"0".repeat(zeros)}${sig}`, sub: null, rest: "" };
+}

--- a/packages/unified-ui/src/lib/platform.ts
+++ b/packages/unified-ui/src/lib/platform.ts
@@ -1,0 +1,23 @@
+let _hapticOverlay: boolean | null = null;
+
+/**
+ * True only on iOS WebKit, where the Project Fathom `<input switch>` haptic
+ * works. Gates the invisible haptic overlay so it never renders on
+ * desktop/Android. Memoized and SSR-safe (returns false when `navigator` is
+ * undefined). NEVER call at module load — call it from an effect so the server
+ * and first client paint agree.
+ */
+export function shouldUseHapticOverlay(): boolean {
+	if (_hapticOverlay !== null) return _hapticOverlay;
+	if (typeof navigator === "undefined") return false; // SSR
+	const platform = navigator.platform ?? "";
+	const isIOS =
+		/iP(hone|ad|od)/.test(platform) ||
+		// iPadOS 13+ reports "MacIntel" with touch points.
+		(platform === "MacIntel" && navigator.maxTouchPoints > 1);
+	// The Vibration API is absent on every iOS browser; that absence is the
+	// canonical "no script haptic" tell, so require iOS AND no-vibrate.
+	const noVibration = typeof navigator.vibrate !== "function";
+	_hapticOverlay = isIOS && noVibration;
+	return _hapticOverlay;
+}

--- a/packages/unified-ui/src/lib/utils.ts
+++ b/packages/unified-ui/src/lib/utils.ts
@@ -1,0 +1,7 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+/** Merge Tailwind class lists, de-duplicating conflicts. */
+export function cn(...inputs: ClassValue[]) {
+	return twMerge(clsx(inputs));
+}

--- a/packages/unified-ui/src/types.ts
+++ b/packages/unified-ui/src/types.ts
@@ -1,0 +1,112 @@
+import type { ReactNode } from "react";
+
+/** Amount-input denomination: entered in token units or in USD. */
+export type Mode = "token" | "usd";
+
+/** A selectable token row. Identity is `chainId` + `address`. */
+export interface TokenRow {
+	name: string;
+	symbol: string;
+	chain: string;
+	chainId: number;
+	address: string;
+	/** Asset logo URL. */
+	logo: string;
+	/** Holdings in token units, as a string (e.g. "1.2345"). "0" when unknown. */
+	amount: string;
+	/** Holdings in USD, as a string (e.g. "$12.34"). "$0" when unknown. */
+	usd: string;
+	/** Token decimals — for converting display amounts to on-chain base units. */
+	decimals: number;
+	/** Chain VM family (EVM today; SVM guarded). */
+	vmType?: "evm" | "svm";
+}
+
+/**
+ * Presence of this config on `<SwapCard>` is the single switch for the
+ * generate-address (receive) affordance:
+ *   • PASS it  → disconnected mode: the From field can flip to a receive view
+ *                (QR + address) and the From picker slot receives the toggle.
+ *   • OMIT it  → connected mode: there is NO generate-address button anywhere.
+ */
+export interface GenerateAddressConfig {
+	/** Whether receive/generate-address mode is currently ON (controlled). */
+	enabled: boolean;
+	/** Flip receive mode. The From picker slot renders the actual toggle UI. */
+	onToggle: (next: boolean) => void;
+	/** Address shown + copied in the receive view. */
+	receiveAddress: string;
+	/** Optional QR payload override (e.g. an EIP-681 URI). Defaults to the address. */
+	receivePayload?: string;
+	/** Optional asset logo rendered in the QR center. */
+	arena?: string;
+}
+
+/** Visible strings used by the token trigger (English defaults provided). */
+export interface TokenTriggerLabels {
+	/** Placeholder shown before a token is picked, e.g. "From..." / "To...". */
+	placeholder?: string;
+	/** aria-label for the trigger's tap target. */
+	selectAriaLabel?: string;
+	/** "Test" pill (From side). */
+	test?: string;
+	/** "Max" pill (From side). */
+	max?: string;
+	/** Slippage pill text builder (To side). */
+	slippage?: (percent: string) => string;
+	/** Fee line text builder (To side). */
+	fee?: (amount: string) => string;
+}
+
+/**
+ * Payload handed to `renderFromPicker` / `renderToPicker`. The package owns the
+ * presentational <TokenTrigger/>; your render prop returns the data-heavy drawer
+ * body (search, list, connect, etc.), typically wrapped in <BottomSheet/>.
+ */
+export interface PickerSlotApi {
+	variant: "from" | "to";
+	selected: TokenRow | null;
+	onSelect: (token: TokenRow) => void;
+	/** Exact wrapper classes the trigger must use (state-dependent on the To side). */
+	triggerClassName: string;
+	/** Controlled drawer open state (owned by SwapCard). */
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	/** Convenience: opens the drawer (`() => onOpenChange(true)`) for the trigger. */
+	onActivate: () => void;
+	walletAddress?: string | null;
+	/** From side, disconnected mode only — render your generate-address toggle. */
+	generateAddress?: GenerateAddressConfig;
+	/** To side — current slippage fraction. */
+	slippage?: number;
+	/** To side — live fee in USD (null until a quote resolves). */
+	fee?: number | null;
+	feeLoading?: boolean;
+	onOpenSlippage?: () => void;
+	/** From side — set the amount from a Test/Max pill. */
+	onSetAmount?: (amount: string) => void;
+	labels: TokenTriggerLabels;
+}
+
+/** Payload handed to `renderMenu`. Push/pop sub-views inside the same sheet. */
+export interface MenuSlotApi {
+	/** Current view key. Switch on this to render the right panel. */
+	view: string;
+	/** Navigate to a view. `direction` is +1 forward (default) / -1 back. */
+	setView: (view: string, direction?: number) => void;
+	/** Close the menu sheet. */
+	close: () => void;
+}
+
+/** User-facing strings for the card chrome (English defaults provided). */
+export interface SwapCardLabels {
+	amountAriaLabel?: string;
+	swapDirectionAriaLabel?: string;
+	resetAriaLabel?: string;
+	menuAriaLabel?: string;
+	deleteKeyAriaLabel?: string;
+	/** CTA text while `submitting`. */
+	submitConfirming?: string;
+}
+
+export type { ReactNode };

--- a/packages/unified-ui/styles.css
+++ b/packages/unified-ui/styles.css
@@ -1,0 +1,285 @@
+/**
+ * @joeblau/unified-ui — standalone style contract.
+ *
+ * Import once in your app (e.g. `import "@joeblau/unified-ui/styles.css"`). This
+ * file is self-contained: it defines every CSS custom property the components
+ * read (light + dark), the themed-border reset, and the component-local classes
+ * (.apple-edge-glow, .haptic-*, .scrollbar-subtle, .scroll-fade, .token-box-label).
+ *
+ * The semantic Tailwind utilities the components use (bg-card, text-foreground,
+ * border-background, the foreground/<opacity> overlays, etc.) still need the
+ * color scale mapped in YOUR Tailwind config — use ./tailwind-preset (v3) or the
+ * documented @theme block (v4). This file only supplies the raw token values +
+ * the non-utility CSS; it does not register the utilities themselves.
+ */
+
+:root {
+  /* Easings (only needed if you wire the optional theme-toggle view transition) */
+  --expo-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --expo-in: cubic-bezier(0.7, 0, 0.84, 0);
+
+  --background: 0 0% 100%;
+  --foreground: 0 0% 3.9%;
+
+  --muted: 0 0% 96.1%;
+  --muted-foreground: 0 0% 45.1%;
+
+  --popover: 0 0% 100%;
+  --popover-foreground: 0 0% 3.9%;
+
+  /* NOTE the deliberate asymmetry: --card (96%) is DARKER than --background
+     (100%) in light, and LIGHTER than --background (3.9%) in dark, so the card
+     lifts off the page in both themes. */
+  --card: 0 0% 96%;
+  --card-foreground: 0 0% 3.9%;
+
+  --border: 0 0% 89.8%;
+  --input: 0 0% 89.8%;
+
+  --primary: 0 0% 9%;
+  --primary-foreground: 0 0% 98%;
+
+  --secondary: 0 0% 96.1%;
+  --secondary-foreground: 0 0% 9%;
+
+  --accent: 0 0% 96.1%;
+  --accent-foreground: 0 0% 9%;
+
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 0 0% 98%;
+
+  --ring: 0 0% 3.9%;
+
+  /* Drives only rounded-lg/md/sm. The card geometry (rounded-3xl/2xl/full) uses
+     Tailwind defaults and is NOT derived from --radius. */
+  --radius: 0.5rem;
+}
+
+.dark {
+  --background: 0 0% 3.9%;
+  --foreground: 0 0% 98%;
+
+  --muted: 0 0% 14.9%;
+  --muted-foreground: 0 0% 63.9%;
+
+  --popover: 0 0% 3.9%;
+  --popover-foreground: 0 0% 98%;
+
+  --card: 0 0% 7.5%;
+  --card-foreground: 0 0% 98%;
+
+  --border: 0 0% 14.9%;
+  --input: 0 0% 14.9%;
+
+  --primary: 0 0% 98%;
+  --primary-foreground: 0 0% 9%;
+
+  --secondary: 0 0% 14.9%;
+  --secondary-foreground: 0 0% 98%;
+
+  --accent: 0 0% 14.9%;
+  --accent-foreground: 0 0% 98%;
+
+  --destructive: 0 62.8% 30.6%;
+  --destructive-foreground: 0 0% 98%;
+
+  --ring: 0 0% 83.1%;
+}
+
+/* The card relies on bare `border`/`border-t` utilities painting themed; mirror
+   the app's `* { @apply border-border }` reset. Scope to the card if you don't
+   want it global by wrapping in your own selector. */
+.unified-ui-root *,
+.unified-ui-root *::before,
+.unified-ui-root *::after {
+  border-color: hsl(var(--border));
+}
+
+/* Structural hook for the large From/To placeholder label. Font handling
+   (incl. CJK weight tweaks) is the consumer's responsibility — this class
+   carries no weight override. */
+.token-box-label {
+}
+
+/* Subtle, theme-aware scrollbar (shadcn-style). */
+.scrollbar-subtle {
+  scrollbar-width: thin;
+  scrollbar-color: hsl(var(--muted-foreground) / 0.25) transparent;
+}
+.scrollbar-subtle::-webkit-scrollbar {
+  width: 6px;
+}
+.scrollbar-subtle::-webkit-scrollbar-track {
+  background: transparent;
+}
+.scrollbar-subtle::-webkit-scrollbar-thumb {
+  border-radius: 9999px;
+  background-color: hsl(var(--muted-foreground) / 0.25);
+}
+.scrollbar-subtle::-webkit-scrollbar-thumb:hover {
+  background-color: hsl(var(--muted-foreground) / 0.4);
+}
+
+/* Project Fathom haptic overlay (iOS only). Rendered by HapticButton; the host
+   stays a normal button while an invisible <label> linked to a native
+   <input switch> fills it. Swipes pass through; only a completed tap toggles
+   the switch and fires the WebKit system haptic. */
+.haptic-clip {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+.haptic-label {
+  position: absolute;
+  inset: 0;
+  pointer-events: auto;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+.haptic-switch {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  margin: 0;
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, -50%);
+}
+
+/* Apple-Intelligence edge glow. The element is painted with the animated
+   linear-gradient (set inline by AppleBorderGradient); here we round the outer
+   corners and feather the gradient inward to transparent. `--feather` (set by
+   the component's `intensity`) controls band thickness; this MUST ship or the
+   glow becomes a flat opaque rectangle. */
+.apple-edge-glow {
+  --feather: 32px;
+  border-radius: 26px;
+  -webkit-mask-image: linear-gradient(
+      to top,
+      rgb(0 0 0 / 1) 0,
+      rgb(0 0 0 / 0.82) calc(var(--feather) * 0.18),
+      rgb(0 0 0 / 0.58) calc(var(--feather) * 0.36),
+      rgb(0 0 0 / 0.36) calc(var(--feather) * 0.55),
+      rgb(0 0 0 / 0.16) calc(var(--feather) * 0.75),
+      transparent var(--feather)
+    ),
+    linear-gradient(
+      to bottom,
+      rgb(0 0 0 / 1) 0,
+      rgb(0 0 0 / 0.82) calc(var(--feather) * 0.18),
+      rgb(0 0 0 / 0.58) calc(var(--feather) * 0.36),
+      rgb(0 0 0 / 0.36) calc(var(--feather) * 0.55),
+      rgb(0 0 0 / 0.16) calc(var(--feather) * 0.75),
+      transparent var(--feather)
+    ),
+    linear-gradient(
+      to left,
+      rgb(0 0 0 / 1) 0,
+      rgb(0 0 0 / 0.82) calc(var(--feather) * 0.18),
+      rgb(0 0 0 / 0.58) calc(var(--feather) * 0.36),
+      rgb(0 0 0 / 0.36) calc(var(--feather) * 0.55),
+      rgb(0 0 0 / 0.16) calc(var(--feather) * 0.75),
+      transparent var(--feather)
+    ),
+    linear-gradient(
+      to right,
+      rgb(0 0 0 / 1) 0,
+      rgb(0 0 0 / 0.82) calc(var(--feather) * 0.18),
+      rgb(0 0 0 / 0.58) calc(var(--feather) * 0.36),
+      rgb(0 0 0 / 0.36) calc(var(--feather) * 0.55),
+      rgb(0 0 0 / 0.16) calc(var(--feather) * 0.75),
+      transparent var(--feather)
+    );
+  mask-image: linear-gradient(
+      to top,
+      rgb(0 0 0 / 1) 0,
+      rgb(0 0 0 / 0.82) calc(var(--feather) * 0.18),
+      rgb(0 0 0 / 0.58) calc(var(--feather) * 0.36),
+      rgb(0 0 0 / 0.36) calc(var(--feather) * 0.55),
+      rgb(0 0 0 / 0.16) calc(var(--feather) * 0.75),
+      transparent var(--feather)
+    ),
+    linear-gradient(
+      to bottom,
+      rgb(0 0 0 / 1) 0,
+      rgb(0 0 0 / 0.82) calc(var(--feather) * 0.18),
+      rgb(0 0 0 / 0.58) calc(var(--feather) * 0.36),
+      rgb(0 0 0 / 0.36) calc(var(--feather) * 0.55),
+      rgb(0 0 0 / 0.16) calc(var(--feather) * 0.75),
+      transparent var(--feather)
+    ),
+    linear-gradient(
+      to left,
+      rgb(0 0 0 / 1) 0,
+      rgb(0 0 0 / 0.82) calc(var(--feather) * 0.18),
+      rgb(0 0 0 / 0.58) calc(var(--feather) * 0.36),
+      rgb(0 0 0 / 0.36) calc(var(--feather) * 0.55),
+      rgb(0 0 0 / 0.16) calc(var(--feather) * 0.75),
+      transparent var(--feather)
+    ),
+    linear-gradient(
+      to right,
+      rgb(0 0 0 / 1) 0,
+      rgb(0 0 0 / 0.82) calc(var(--feather) * 0.18),
+      rgb(0 0 0 / 0.58) calc(var(--feather) * 0.36),
+      rgb(0 0 0 / 0.36) calc(var(--feather) * 0.55),
+      rgb(0 0 0 / 0.16) calc(var(--feather) * 0.75),
+      transparent var(--feather)
+    );
+}
+
+/* Skiper87-style scroll fade for scrollable lists (e.g. a token drawer). Pure
+   CSS via scroll-driven animation-timeline; degrades to no fade where
+   unsupported. */
+@property --ft {
+  syntax: "<length-percentage>";
+  inherits: false;
+  initial-value: 0%;
+}
+@property --fb {
+  syntax: "<length-percentage>";
+  inherits: false;
+  initial-value: 0%;
+}
+@keyframes scroll-fade-top {
+  0%,
+  6% {
+    --ft: 0%;
+  }
+  14%,
+  100% {
+    --ft: 8%;
+  }
+}
+@keyframes scroll-fade-bottom {
+  0%,
+  86% {
+    --fb: 8%;
+  }
+  94%,
+  100% {
+    --fb: 0%;
+  }
+}
+.scroll-fade {
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    transparent 0,
+    #000 var(--ft),
+    #000 calc(100% - var(--fb)),
+    transparent 100%
+  );
+  mask-image: linear-gradient(
+    to bottom,
+    transparent 0,
+    #000 var(--ft),
+    #000 calc(100% - var(--fb)),
+    transparent 100%
+  );
+  animation-name: scroll-fade-top, scroll-fade-bottom;
+  animation-timeline: scroll(self), scroll(self);
+  animation-timing-function: linear;
+  animation-fill-mode: both;
+}

--- a/packages/unified-ui/tailwind-preset.cjs
+++ b/packages/unified-ui/tailwind-preset.cjs
@@ -1,0 +1,68 @@
+/**
+ * Tailwind v3 preset for @joeblau/unified-ui. Maps the bare-HSL token contract in
+ * styles.css to the semantic color scale + radius the components use.
+ *
+ *   // tailwind.config.js
+ *   module.exports = {
+ *     presets: [require("@joeblau/unified-ui/tailwind-preset")],
+ *     content: [
+ *       "./src/**\/*.{ts,tsx}",
+ *       "./node_modules/@joeblau/unified-ui/src/**\/*.{ts,tsx}",
+ *     ],
+ *   };
+ *
+ * Tailwind v4 (no JS config): instead of this preset, add an @theme inline block
+ * mapping --color-card: hsl(var(--card)) etc. (see README), and add the package
+ * source to your content/@source so the utilities are generated.
+ *
+ * @type {import('tailwindcss').Config}
+ */
+module.exports = {
+	darkMode: ["class"],
+	content: [],
+	theme: {
+		extend: {
+			colors: {
+				border: "hsl(var(--border))",
+				input: "hsl(var(--input))",
+				ring: "hsl(var(--ring))",
+				background: "hsl(var(--background))",
+				foreground: "hsl(var(--foreground))",
+				primary: {
+					DEFAULT: "hsl(var(--primary))",
+					foreground: "hsl(var(--primary-foreground))",
+				},
+				secondary: {
+					DEFAULT: "hsl(var(--secondary))",
+					foreground: "hsl(var(--secondary-foreground))",
+				},
+				destructive: {
+					DEFAULT: "hsl(var(--destructive))",
+					foreground: "hsl(var(--destructive-foreground))",
+				},
+				muted: {
+					DEFAULT: "hsl(var(--muted))",
+					foreground: "hsl(var(--muted-foreground))",
+				},
+				accent: {
+					DEFAULT: "hsl(var(--accent))",
+					foreground: "hsl(var(--accent-foreground))",
+				},
+				popover: {
+					DEFAULT: "hsl(var(--popover))",
+					foreground: "hsl(var(--popover-foreground))",
+				},
+				card: {
+					DEFAULT: "hsl(var(--card))",
+					foreground: "hsl(var(--card-foreground))",
+				},
+			},
+			borderRadius: {
+				lg: "var(--radius)",
+				md: "calc(var(--radius) - 2px)",
+				sm: "calc(var(--radius) - 4px)",
+			},
+		},
+	},
+	plugins: [],
+};

--- a/packages/unified-ui/tsconfig.json
+++ b/packages/unified-ui/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "declaration": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": false,
+    "types": []
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/unified-ui/tsup.config.ts
+++ b/packages/unified-ui/tsup.config.ts
@@ -1,0 +1,27 @@
+import { copyFileSync } from "node:fs";
+import { defineConfig } from "tsup";
+
+/**
+ * Optional build for publishing a compiled dist. In-monorepo consumers can
+ * import the package straight from source (the package.json `exports` point at
+ * ./src), so this build is only needed when shipping to npm or a non-TS
+ * bundler. `react`, `react-dom`, `framer-motion`, `vaul`, and `cuer` are left
+ * external (peer deps).
+ */
+export default defineConfig({
+	entry: ["src/index.ts", "src/cuer-qr.tsx"],
+	format: ["esm", "cjs"],
+	// Types ship from source: package.json `exports` resolve types to ./src, so
+	// consumers get full .d.ts from the TS sources. Standalone .d.ts emit is left
+	// off because this monorepo carries two @types/react majors (18 + 19) that
+	// trip declaration generation — a tooling/env condition, not a code issue.
+	// Flip to `true` in a deduped-types environment to emit dist/*.d.ts.
+	dts: false,
+	clean: true,
+	external: ["react", "react-dom", "framer-motion", "vaul", "cuer"],
+	onSuccess: async () => {
+		// Ship the standalone token contract + the Tailwind preset alongside dist.
+		copyFileSync("styles.css", "dist/styles.css");
+		copyFileSync("tailwind-preset.cjs", "dist/tailwind-preset.cjs");
+	},
+});

--- a/workers/jb-gear/package.json
+++ b/workers/jb-gear/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"packageManager": "bun@1.3.0",
 	"scripts": {
-		"dev": "wrangler dev",
+		"dev": "next dev --turbopack -p 33002",
 		"build": "next build",
 		"start": "next start",
 		"lint": "next lint",

--- a/workers/jb-swap/src/components/swap-card.tsx
+++ b/workers/jb-swap/src/components/swap-card.tsx
@@ -1,18 +1,23 @@
 "use client";
 
-import NumberFlow from "@number-flow/react";
 import { motion } from "framer-motion";
 import { ArrowUpDown, RotateCcw } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 import { AppleBorderGradient } from "@/components/apple-border-gradient";
 import { AppMenu, type Denomination, DENOMINATION_KEY } from "@/components/app-menu";
-import { CryptoAddress } from "@/components/crypto-address";
 import { HapticButton } from "@/components/haptic-button";
 import { MobileKeypad } from "@/components/keypad";
 import { SlippageDrawer } from "@/components/slippage-drawer";
 import type { OrderType } from "@/components/settings-panels";
-import { price, TokenBox, type TokenRow } from "@/components/token-drawer";
+import {
+	sanitizeAmount,
+	trim,
+	trimUsd,
+} from "@/components/swap-field";
+import { SwapFrom } from "@/components/swap-from";
+import { SwapTo } from "@/components/swap-to";
+import { price, type TokenRow } from "@/components/token-drawer";
 import { buildPaymentPayload } from "@/lib/eip681";
 import { useTranslations } from "@/i18n/locale-provider";
 import { usePersistentState } from "@/lib/use-persistent-state";
@@ -42,162 +47,6 @@ const FEE_USD = 0.25;
 /** Placeholder receive address shown before a wallet is connected (a well-known example address). */
 const PREVIEW_ADDRESS = "0x71C7656EC7ab88b098defB751B7401B5f6d8976F";
 
-/** Trim a number to a clean string (drops trailing zeros, caps at 8 decimals). */
-function trim(n: number) {
-	return String(Number(n.toFixed(8)));
-}
-
-/** Trim a USD value to a clean string, capped at 2 decimal places. */
-function trimUsd(n: number) {
-	return String(Number(n.toFixed(2)));
-}
-
-/**
- * The animated value inside a conversion Pill. In "token" mode the field is
- * entered in token units so the pill shows the USD equivalent ($, 2dp); in
- * "usd" mode it shows the token amount + symbol (up to 8dp, no grouping).
- * NumberFlow animates digit changes the same way the main AmountInput does.
- */
-function ConversionValue({
-	mode,
-	usd,
-	units,
-	symbol,
-}: {
-	mode: "token" | "usd";
-	usd: number;
-	units: number;
-	symbol: string;
-}) {
-	if (mode === "token") {
-		return (
-			<NumberFlow
-				value={usd}
-				prefix="$"
-				format={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }}
-				className="overflow-hidden [--number-flow-mask-height:0px]"
-			/>
-		);
-	}
-	return (
-		<NumberFlow
-			value={units}
-			suffix={symbol ? ` ${symbol}` : ""}
-			format={{ maximumFractionDigits: 8, useGrouping: false }}
-			className="overflow-hidden [--number-flow-mask-height:0px]"
-		/>
-	);
-}
-
-function Pill({
-	onClick,
-	children,
-}: {
-	onClick?: () => void;
-	children: React.ReactNode;
-}) {
-	return (
-		<HapticButton
-			type="button"
-			onClick={onClick}
-			wrapperClassName="pointer-events-auto inline-grid"
-			className="inline-flex cursor-pointer items-center gap-1.5 rounded-full bg-foreground/[0.07] px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-foreground/[0.12]"
-		>
-			{children}
-		</HapticButton>
-	);
-}
-
-/** Keep only digits and a single decimal point; strip leading zeros. */
-function sanitizeAmount(raw: string) {
-	let v = raw.replace(/[^0-9.]/g, "");
-	const dot = v.indexOf(".");
-	if (dot !== -1) {
-		v = v.slice(0, dot + 1) + v.slice(dot + 1).replace(/\./g, "");
-	}
-	v = v.replace(/^0+(\d)/, "$1");
-	return v === "" || v === "." ? "0" : v;
-}
-
-/**
- * Animated amount display. Typing, the keypad, and paste are handled globally
- * by SwapCard and always drive the "from" amount.
- */
-function AmountInput({
-	value,
-	prefix,
-	muted,
-	sizeClassName = "text-3xl md:text-5xl",
-}: {
-	value: string;
-	prefix?: string;
-	muted?: boolean;
-	sizeClassName?: string;
-}) {
-	const t = useTranslations();
-	// Dollar values ($ prefix) never show more than 2 decimals; token amounts up to 8.
-	const maxFraction = prefix === "$" ? 2 : 8;
-	const dot = value.indexOf(".");
-	const fractionDigits =
-		dot === -1 ? 0 : Math.min(value.length - dot - 1, maxFraction);
-	return (
-		<div
-			role="textbox"
-			aria-label={t("swapCard.amountInput.ariaLabel")}
-			tabIndex={0}
-			className="cursor-text overflow-hidden rounded-lg outline-none"
-		>
-			<NumberFlow
-				value={Number(value) || 0}
-				prefix={prefix}
-				suffix={value.endsWith(".") ? "." : ""}
-				format={{
-					minimumFractionDigits: fractionDigits,
-					maximumFractionDigits: maxFraction,
-					useGrouping: false,
-				}}
-				className={cn(
-					"font-bold tracking-tight [--number-flow-mask-height:0px]",
-					sizeClassName,
-					muted ? "text-muted-foreground" : "text-foreground",
-				)}
-			/>
-		</div>
-	);
-}
-
-/** Shared CSS height transition for the animated amount fields. */
-const AMOUNT_FIELD_TRANSITION =
-	"overflow-hidden transition-[height] duration-[400ms] ease-[cubic-bezier(0.22,1,0.36,1)]";
-
-/**
- * Measures the natural (content-box) height of an element and keeps it current
- * across breakpoint/value changes via a ResizeObserver. Returns the ref to put
- * on the content and its measured height (`null` until first measured). Used to
- * coordinate the generate-address animation: the "from" amount field grows by
- * exactly the height the removed "to" amount block gives up, so the card's total
- * height is unchanged.
- *
- * A hook rather than a wrapper component so call sites use inline JSX — a
- * `children: ReactNode` prop trips the repo's duplicated `@types/react`.
- */
-function useMeasuredHeight() {
-	const ref = useRef<HTMLDivElement>(null);
-	const [height, setHeight] = useState<number | null>(null);
-
-	useEffect(() => {
-		const el = ref.current;
-		if (!el) return;
-		const measure = () => setHeight(el.offsetHeight);
-		measure();
-		const ro = new ResizeObserver(measure);
-		ro.observe(el);
-		return () => ro.disconnect();
-	}, []);
-
-	return { ref, height };
-}
-
 export function SwapCard() {
 	const t = useTranslations();
 	// Default amount denomination, set in the menu and persisted. It seeds the
@@ -221,12 +70,7 @@ export function SwapCard() {
 	const [genAddress, setGenAddress] = useState(false);
 	// Generate-address mode swaps the "from" amount ($0 + units) for a receive
 	// view (QR + vertical address) and removes the "to" amount block entirely.
-	// Each area animates its measured height to fit whatever content it holds.
-	const fromAmountBox = useMeasuredHeight();
-	const toAmountBox = useMeasuredHeight();
-	const fromAmountHeight = fromAmountBox.height ?? undefined;
-	const toAmountHeight =
-		toAmountBox.height == null ? undefined : genAddress ? 0 : toAmountBox.height;
+	// SwapFrom / SwapTo each animate their own measured height to fit content.
 	const [submitting, setSubmitting] = useState(false);
 	const action = getActionLabel(fromToken, toToken);
 	const canFlip = fromToken !== null && toToken !== null;
@@ -493,67 +337,34 @@ export function SwapCard() {
 			transition={{ duration: 0.4, ease: "easeOut" }}
 		>
 			{/* You pay */}
-			<section className="rounded-3xl bg-card px-4 pb-3 pt-4">
-				<TokenBox
-					variant="from"
-					selected={fromToken}
-					onSelect={setFromToken}
-					onSetAmount={setFromAmount}
-					connected={connected}
-					walletAddress={address}
-					onConnect={connect}
-					onDisconnect={disconnect}
-					genAddress={genAddress}
-					onToggleGenAddress={() => {
-						const next = !genAddress;
-						setGenAddress(next);
-						// Deselecting generate-address while not connected: the address
-						// shown was only a placeholder, so revert the "from" field to its
-						// empty state instead of leaving a fake selected token.
-						if (!next && !connected) {
-							setFromToken(null);
-							setFromAmount("0");
-						}
-					}}
-					triggerClassName="-mx-4 -mt-4 w-[calc(100%+2rem)] rounded-t-3xl px-4 pb-4 pt-4 hover:bg-foreground/[0.03]"
-				/>
-				<div className="-mx-4 border-t-2 border-background" />
-				<div
-					className={cn("flex flex-col justify-center", AMOUNT_FIELD_TRANSITION)}
-					style={{ height: fromAmountHeight }}
-				>
-					<div ref={fromAmountBox.ref}>
-						{genAddress ? (
-							// Receive view: QR + vertical address, formatted per asset.
-							// The $0 + units are hidden in this mode. CryptoAddress's own
-							// p-2 matches the normal field's p-2, so the gap below it to the
-							// flip button is identical (no extra wrapper padding).
-							<CryptoAddress
-								address={receiveAddress}
-								qrValue={receivePayload}
-								arena={fromToken?.logo}
-							/>
-						) : (
-							<div className="flex flex-col items-center gap-2 p-2">
-								<AmountInput
-									value={fromAmount}
-									prefix={fromMode === "usd" ? "$" : undefined}
-								/>
-								<Pill onClick={toggleFromMode}>
-									<span className="opacity-50">=</span>{" "}
-									<ConversionValue
-										mode={fromMode}
-										usd={fromUsd}
-										units={fromUnits}
-										symbol={fromToken?.symbol ?? ""}
-									/>
-									<ArrowUpDown className="size-3.5" />
-								</Pill>
-							</div>
-						)}
-					</div>
-				</div>
-			</section>
+			<SwapFrom
+				token={fromToken}
+				onSelectToken={setFromToken}
+				amount={fromAmount}
+				onSetAmount={setFromAmount}
+				mode={fromMode}
+				onToggleMode={toggleFromMode}
+				usd={fromUsd}
+				units={fromUnits}
+				connected={connected}
+				walletAddress={address}
+				onConnect={connect}
+				onDisconnect={disconnect}
+				genAddress={genAddress}
+				onToggleGenAddress={() => {
+					const next = !genAddress;
+					setGenAddress(next);
+					// Deselecting generate-address while not connected: the address
+					// shown was only a placeholder, so revert the "from" field to its
+					// empty state instead of leaving a fake selected token.
+					if (!next && !connected) {
+						setFromToken(null);
+						setFromAmount("0");
+					}
+				}}
+				receiveAddress={receiveAddress}
+				receivePayload={receivePayload}
+			/>
 
 			{/* Swap direction */}
 			<div className="relative z-10 mx-auto -my-3 flex w-fit">
@@ -588,47 +399,20 @@ export function SwapCard() {
 			</div>
 
 			{/* You receive */}
-			<section className="rounded-3xl bg-card px-4 pb-0 pt-6">
-				<TokenBox
-					variant="to"
-					selected={toToken}
-					onSelect={setToToken}
-					walletAddress={address}
-					slippage={slippage}
-					fee={feeUsd}
-					feeLoading={quoteLoading}
-					onOpenSlippage={() => setSlippageOpen(true)}
-					triggerClassName={cn(
-						"-mx-4 -mt-6 w-[calc(100%+2rem)] px-4 pb-4 pt-6 hover:bg-foreground/[0.03]",
-						genAddress ? "rounded-3xl" : "rounded-t-3xl",
-					)}
-				/>
-				{/* The destination amount is removed entirely in generate-address
-				    mode; the "from" field grows by exactly this block's height so
-				    the card's total height never changes. */}
-				<div className={AMOUNT_FIELD_TRANSITION} style={{ height: toAmountHeight }}>
-					<div ref={toAmountBox.ref}>
-						<div className="-mx-4 border-t-2 border-background" />
-						<div className="flex flex-col items-center gap-2 p-2">
-							<AmountInput
-								value={trim(toMode === "token" ? toAmount : toUsd)}
-								prefix={toMode === "usd" ? "$" : undefined}
-								muted
-							/>
-							<Pill onClick={toggleToMode}>
-								<span className="opacity-50">=</span>{" "}
-								<ConversionValue
-									mode={toMode}
-									usd={toUsd}
-									units={toAmount}
-									symbol={toToken?.symbol ?? ""}
-								/>
-								<ArrowUpDown className="size-3.5" />
-							</Pill>
-						</div>
-					</div>
-				</div>
-			</section>
+			<SwapTo
+				token={toToken}
+				onSelectToken={setToToken}
+				walletAddress={address}
+				slippage={slippage}
+				fee={feeUsd}
+				feeLoading={quoteLoading}
+				onOpenSlippage={() => setSlippageOpen(true)}
+				amount={toAmount}
+				usd={toUsd}
+				mode={toMode}
+				onToggleMode={toggleToMode}
+				collapsed={genAddress}
+			/>
 
 			<MobileKeypad onKey={handleKey} />
 

--- a/workers/jb-swap/src/components/swap-field.tsx
+++ b/workers/jb-swap/src/components/swap-field.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import NumberFlow from "@number-flow/react";
+import { useEffect, useRef, useState } from "react";
+
+import { HapticButton } from "@/components/haptic-button";
+import { useTranslations } from "@/i18n/locale-provider";
+import { cn } from "@/lib/utils";
+
+/** Trim a number to a clean string (drops trailing zeros, caps at 8 decimals). */
+export function trim(n: number) {
+	return String(Number(n.toFixed(8)));
+}
+
+/** Trim a USD value to a clean string, capped at 2 decimal places. */
+export function trimUsd(n: number) {
+	return String(Number(n.toFixed(2)));
+}
+
+/** Keep only digits and a single decimal point; strip leading zeros. */
+export function sanitizeAmount(raw: string) {
+	let v = raw.replace(/[^0-9.]/g, "");
+	const dot = v.indexOf(".");
+	if (dot !== -1) {
+		v = v.slice(0, dot + 1) + v.slice(dot + 1).replace(/\./g, "");
+	}
+	v = v.replace(/^0+(\d)/, "$1");
+	return v === "" || v === "." ? "0" : v;
+}
+
+/** Shared CSS height transition for the animated amount fields. */
+export const AMOUNT_FIELD_TRANSITION =
+	"overflow-hidden transition-[height] duration-[400ms] ease-[cubic-bezier(0.22,1,0.36,1)]";
+
+/**
+ * The animated value inside a conversion Pill. In "token" mode the field is
+ * entered in token units so the pill shows the USD equivalent ($, 2dp); in
+ * "usd" mode it shows the token amount + symbol (up to 8dp, no grouping).
+ * NumberFlow animates digit changes the same way the main AmountInput does.
+ */
+export function ConversionValue({
+	mode,
+	usd,
+	units,
+	symbol,
+}: {
+	mode: "token" | "usd";
+	usd: number;
+	units: number;
+	symbol: string;
+}) {
+	if (mode === "token") {
+		return (
+			<NumberFlow
+				value={usd}
+				prefix="$"
+				format={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }}
+				className="overflow-hidden [--number-flow-mask-height:0px]"
+			/>
+		);
+	}
+	return (
+		<NumberFlow
+			value={units}
+			suffix={symbol ? ` ${symbol}` : ""}
+			format={{ maximumFractionDigits: 8, useGrouping: false }}
+			className="overflow-hidden [--number-flow-mask-height:0px]"
+		/>
+	);
+}
+
+export function Pill({
+	onClick,
+	children,
+}: {
+	onClick?: () => void;
+	children: React.ReactNode;
+}) {
+	return (
+		<HapticButton
+			type="button"
+			onClick={onClick}
+			wrapperClassName="pointer-events-auto inline-grid"
+			className="inline-flex cursor-pointer items-center gap-1.5 rounded-full bg-foreground/[0.07] px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-foreground/[0.12]"
+		>
+			{children}
+		</HapticButton>
+	);
+}
+
+/**
+ * Animated amount display. Typing, the keypad, and paste are handled globally
+ * by SwapCard and always drive the "from" amount.
+ */
+export function AmountInput({
+	value,
+	prefix,
+	muted,
+	sizeClassName = "text-3xl md:text-5xl",
+}: {
+	value: string;
+	prefix?: string;
+	muted?: boolean;
+	sizeClassName?: string;
+}) {
+	const t = useTranslations();
+	// Dollar values ($ prefix) never show more than 2 decimals; token amounts up to 8.
+	const maxFraction = prefix === "$" ? 2 : 8;
+	const dot = value.indexOf(".");
+	const fractionDigits =
+		dot === -1 ? 0 : Math.min(value.length - dot - 1, maxFraction);
+	return (
+		<div
+			role="textbox"
+			aria-label={t("swapCard.amountInput.ariaLabel")}
+			tabIndex={0}
+			className="cursor-text overflow-hidden rounded-lg outline-none"
+		>
+			<NumberFlow
+				value={Number(value) || 0}
+				prefix={prefix}
+				suffix={value.endsWith(".") ? "." : ""}
+				format={{
+					minimumFractionDigits: fractionDigits,
+					maximumFractionDigits: maxFraction,
+					useGrouping: false,
+				}}
+				className={cn(
+					"font-bold tracking-tight [--number-flow-mask-height:0px]",
+					sizeClassName,
+					muted ? "text-muted-foreground" : "text-foreground",
+				)}
+			/>
+		</div>
+	);
+}
+
+/**
+ * Measures the natural (content-box) height of an element and keeps it current
+ * across breakpoint/value changes via a ResizeObserver. Returns the ref to put
+ * on the content and its measured height (`null` until first measured). Used to
+ * coordinate the generate-address animation: the "from" amount field grows by
+ * exactly the height the removed "to" amount block gives up, so the card's total
+ * height is unchanged.
+ *
+ * A hook rather than a wrapper component so call sites use inline JSX — a
+ * `children: ReactNode` prop trips the repo's duplicated `@types/react`.
+ */
+export function useMeasuredHeight() {
+	const ref = useRef<HTMLDivElement>(null);
+	const [height, setHeight] = useState<number | null>(null);
+
+	useEffect(() => {
+		const el = ref.current;
+		if (!el) return;
+		const measure = () => setHeight(el.offsetHeight);
+		measure();
+		const ro = new ResizeObserver(measure);
+		ro.observe(el);
+		return () => ro.disconnect();
+	}, []);
+
+	return { ref, height };
+}

--- a/workers/jb-swap/src/components/swap-from.tsx
+++ b/workers/jb-swap/src/components/swap-from.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { ArrowUpDown } from "lucide-react";
+
+import { CryptoAddress } from "@/components/crypto-address";
+import {
+	AMOUNT_FIELD_TRANSITION,
+	AmountInput,
+	ConversionValue,
+	Pill,
+	useMeasuredHeight,
+} from "@/components/swap-field";
+import { TokenBox, type TokenRow } from "@/components/token-drawer";
+import { cn } from "@/lib/utils";
+
+export interface SwapFromProps {
+	/** Controlled selected "from" token (owned by the parent so flip can swap them). */
+	token: TokenRow | null;
+	onSelectToken: (token: TokenRow) => void;
+	/** Editable amount string, in `mode`'s denomination. */
+	amount: string;
+	onSetAmount: (amount: string) => void;
+	/** Whether the amount is entered in token units or USD. */
+	mode: "token" | "usd";
+	onToggleMode: () => void;
+	/** USD value of the entered amount (for the conversion pill). */
+	usd: number;
+	/** Token units of the entered amount (for the conversion pill). */
+	units: number;
+	connected: boolean;
+	walletAddress?: string | null;
+	onConnect: () => void;
+	onDisconnect: () => void;
+	/** Generate-address (receive) mode: swaps the amount field for a QR + address. */
+	genAddress: boolean;
+	onToggleGenAddress: () => void;
+	/** Address shown in the receive view (connected wallet, or a placeholder). */
+	receiveAddress: string;
+	/** QR payload for the receive view (e.g. an EIP-681 asset-transfer URI). */
+	receivePayload: string;
+}
+
+/**
+ * The "You pay" side of a swap: a token picker plus an animated amount field
+ * that flips between token and USD denomination. In generate-address mode the
+ * amount field is replaced by a QR code + vertical address (receive view).
+ *
+ * Presentational and fully controlled — all state lives in the parent.
+ */
+export function SwapFrom({
+	token,
+	onSelectToken,
+	amount,
+	onSetAmount,
+	mode,
+	onToggleMode,
+	usd,
+	units,
+	connected,
+	walletAddress,
+	onConnect,
+	onDisconnect,
+	genAddress,
+	onToggleGenAddress,
+	receiveAddress,
+	receivePayload,
+}: SwapFromProps) {
+	const box = useMeasuredHeight();
+	const height = box.height ?? undefined;
+
+	return (
+		<section className="rounded-3xl bg-card px-4 pb-3 pt-4">
+			<TokenBox
+				variant="from"
+				selected={token}
+				onSelect={onSelectToken}
+				onSetAmount={onSetAmount}
+				connected={connected}
+				walletAddress={walletAddress}
+				onConnect={onConnect}
+				onDisconnect={onDisconnect}
+				genAddress={genAddress}
+				onToggleGenAddress={onToggleGenAddress}
+				triggerClassName="-mx-4 -mt-4 w-[calc(100%+2rem)] rounded-t-3xl px-4 pb-4 pt-4 hover:bg-foreground/[0.03]"
+			/>
+			<div className="-mx-4 border-t-2 border-background" />
+			<div
+				className={cn("flex flex-col justify-center", AMOUNT_FIELD_TRANSITION)}
+				style={{ height }}
+			>
+				<div ref={box.ref}>
+					{genAddress ? (
+						// Receive view: QR + vertical address, formatted per asset.
+						// The $0 + units are hidden in this mode. CryptoAddress's own
+						// p-2 matches the normal field's p-2, so the gap below it to the
+						// flip button is identical (no extra wrapper padding).
+						<CryptoAddress
+							address={receiveAddress}
+							qrValue={receivePayload}
+							arena={token?.logo}
+						/>
+					) : (
+						<div className="flex flex-col items-center gap-2 p-2">
+							<AmountInput
+								value={amount}
+								prefix={mode === "usd" ? "$" : undefined}
+							/>
+							<Pill onClick={onToggleMode}>
+								<span className="opacity-50">=</span>{" "}
+								<ConversionValue
+									mode={mode}
+									usd={usd}
+									units={units}
+									symbol={token?.symbol ?? ""}
+								/>
+								<ArrowUpDown className="size-3.5" />
+							</Pill>
+						</div>
+					)}
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/workers/jb-swap/src/components/swap-to.tsx
+++ b/workers/jb-swap/src/components/swap-to.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { ArrowUpDown } from "lucide-react";
+
+import {
+	AMOUNT_FIELD_TRANSITION,
+	AmountInput,
+	ConversionValue,
+	Pill,
+	trim,
+	useMeasuredHeight,
+} from "@/components/swap-field";
+import { TokenBox, type TokenRow } from "@/components/token-drawer";
+import { cn } from "@/lib/utils";
+
+export interface SwapToProps {
+	/** Controlled selected "to" token (owned by the parent so flip can swap them). */
+	token: TokenRow | null;
+	onSelectToken: (token: TokenRow) => void;
+	walletAddress?: string | null;
+	slippage: number;
+	/** Live total fee in USD from the quote (null until it resolves / for sends). */
+	fee: number | null;
+	/** Whether a fresh quote is loading (so the fee can show a placeholder). */
+	feeLoading: boolean;
+	onOpenSlippage: () => void;
+	/** Received token amount (units). */
+	amount: number;
+	/** Received USD value. */
+	usd: number;
+	/** Whether the received amount is shown in token units or USD. */
+	mode: "token" | "usd";
+	onToggleMode: () => void;
+	/** Collapse the amount block to height 0 (generate-address / receive mode). */
+	collapsed: boolean;
+}
+
+/**
+ * The "You receive" side of a swap: a token picker plus a muted, read-only
+ * animated amount that flips between token and USD denomination. The amount
+ * block collapses to nothing when `collapsed` (generate-address mode) so the
+ * card's total height stays constant.
+ *
+ * Presentational and fully controlled — all state lives in the parent.
+ */
+export function SwapTo({
+	token,
+	onSelectToken,
+	walletAddress,
+	slippage,
+	fee,
+	feeLoading,
+	onOpenSlippage,
+	amount,
+	usd,
+	mode,
+	onToggleMode,
+	collapsed,
+}: SwapToProps) {
+	const box = useMeasuredHeight();
+	const height = box.height == null ? undefined : collapsed ? 0 : box.height;
+
+	return (
+		<section className="rounded-3xl bg-card px-4 pb-0 pt-6">
+			<TokenBox
+				variant="to"
+				selected={token}
+				onSelect={onSelectToken}
+				walletAddress={walletAddress}
+				slippage={slippage}
+				fee={fee}
+				feeLoading={feeLoading}
+				onOpenSlippage={onOpenSlippage}
+				triggerClassName={cn(
+					"-mx-4 -mt-6 w-[calc(100%+2rem)] px-4 pb-4 pt-6 hover:bg-foreground/[0.03]",
+					collapsed ? "rounded-3xl" : "rounded-t-3xl",
+				)}
+			/>
+			{/* The destination amount is removed entirely in generate-address mode;
+			    the "from" field grows by exactly this block's height so the card's
+			    total height never changes. */}
+			<div className={AMOUNT_FIELD_TRANSITION} style={{ height }}>
+				<div ref={box.ref}>
+					<div className="-mx-4 border-t-2 border-background" />
+					<div className="flex flex-col items-center gap-2 p-2">
+						<AmountInput
+							value={trim(mode === "token" ? amount : usd)}
+							prefix={mode === "usd" ? "$" : undefined}
+							muted
+						/>
+						<Pill onClick={onToggleMode}>
+							<span className="opacity-50">=</span>{" "}
+							<ConversionValue
+								mode={mode}
+								usd={usd}
+								units={amount}
+								symbol={token?.symbol ?? ""}
+							/>
+							<ArrowUpDown className="size-3.5" />
+						</Pill>
+					</div>
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/workers/jb-swap/src/lib/use-wallet.ts
+++ b/workers/jb-swap/src/lib/use-wallet.ts
@@ -57,25 +57,43 @@ export function useWallet() {
 		address,
 		evmAddress: manuallyDisconnected ? null : (evmWallet?.address ?? null),
 		solanaAddress: manuallyDisconnected ? null : (solanaWallet?.address ?? null),
-		// Clear the override first so the wallet re-surfaces, then open Privy's
-		// login modal. `login()` (vs `connectWallet()`) creates an authenticated
-		// session so the eventual `logout()` has something real to destroy
-		// (avoids the connect-only `POST /sessions/logout` 400). If a wallet is
-		// already connected at the provider level, just clearing the override
-		// reconnects instantly with no redundant modal.
+		// Clear the override first so a connection can re-surface, then open
+		// Privy's login modal. We ALWAYS open the modal rather than silently
+		// re-using a wallet that's still connected at the connector level: after a
+		// "log out" the injected wallet often persists (see `disconnect` below),
+		// and reconnecting it with no prompt makes logout feel broken and prevents
+		// switching wallets. `login()` (vs `connectWallet()`) creates an
+		// authenticated session so the eventual `logout()` has something real to
+		// destroy (avoids the connect-only `POST /sessions/logout` 400).
 		connect: () => {
 			clearManualDisconnect();
-			if (rawAddress === null) login();
+			login();
 		},
-		// Injected wallets (MetaMask/Phantom) can't be programmatically
-		// disconnected and Privy's `useWallets()` isn't gated on auth, so neither
-		// `wallet.disconnect()` nor `logout()` clears the list. Flip the local
-		// override first (the UI returns to connect immediately and reliably),
-		// then best-effort tear down the connector + Privy session for any wallet
-		// that *does* support it. The logout 400 on a stale session is harmless —
+		// Real disconnect. Flip the local override first so the UI returns to the
+		// connect screen immediately and reliably. Then best-effort sever the
+		// underlying connection: injected EVM wallets ignore connector
+		// `disconnect()` and Privy's `useWallets()` isn't gated on auth, so we ask
+		// the provider to revoke the dApp's account permission (EIP-2255
+		// `wallet_revokePermissions`). MetaMask / Rabby honor this and actually
+		// drop the connection, so the next connect re-prompts for approval; wallets
+		// that don't support it stay hidden behind the override. Solana wallets
+		// (Phantom) support programmatic `disconnect()`. Finally tear down the
+		// Privy session — a 400 on a stale/never-authenticated session is harmless,
 		// Privy still clears local tokens — so swallow it.
-		disconnect: () => {
+		disconnect: async () => {
 			setManualDisconnect();
+			if (evmWallet) {
+				try {
+					const provider = await evmWallet.getEthereumProvider();
+					await provider.request({
+						method: "wallet_revokePermissions",
+						params: [{ eth_accounts: {} }],
+					});
+				} catch {
+					// Wallet doesn't support permission revocation — the override
+					// keeps it hidden until the page is refreshed.
+				}
+			}
 			void evmWallet?.disconnect?.();
 			void solanaWallet?.disconnect?.();
 			void logout().catch(() => {});

--- a/workers/jb-symbols/package.json
+++ b/workers/jb-symbols/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"packageManager": "bun@1.3.0",
 	"scripts": {
-		"dev": "wrangler dev",
+		"dev": "next dev --turbopack -p 33004",
 		"build": "next build",
 		"start": "next start",
 		"lint": "next lint",

--- a/workers/jb-symbols/src/components/symbol-card.tsx
+++ b/workers/jb-symbols/src/components/symbol-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Download } from "lucide-react";
 import type { SymbolRecord } from "@/lib/types";
 
 export function SymbolCard({
@@ -10,22 +11,34 @@ export function SymbolCard({
 	onSelect: (s: SymbolRecord) => void;
 }) {
 	return (
-		<button
-			type="button"
-			onClick={() => onSelect(symbol)}
-			title={symbol.company || symbol.primarySubject}
-			className="group relative flex aspect-square items-center justify-center rounded-lg border border-border bg-card p-4 transition-colors hover:border-foreground/40 hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-		>
-			{/* eslint-disable-next-line @next/next/no-img-element */}
-			<img
-				src={symbol.svg}
-				alt={symbol.primarySubject}
-				loading="lazy"
-				className="h-full w-full object-contain dark:invert"
-			/>
-			<span className="pointer-events-none absolute inset-x-1 bottom-1 truncate rounded bg-background/85 px-1.5 py-0.5 text-center text-[10px] text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100">
-				{symbol.company || symbol.primarySubject}
-			</span>
-		</button>
+		<div className="group relative aspect-square rounded-lg border border-border bg-card transition-colors hover:border-foreground/40 hover:bg-accent focus-within:ring-2 focus-within:ring-ring">
+			<button
+				type="button"
+				onClick={() => onSelect(symbol)}
+				title={symbol.company || symbol.primarySubject}
+				className="flex h-full w-full items-center justify-center p-4 focus:outline-none"
+			>
+				{/* eslint-disable-next-line @next/next/no-img-element */}
+				<img
+					src={symbol.svg}
+					alt={symbol.primarySubject}
+					loading="lazy"
+					className="h-full w-full object-contain dark:invert"
+				/>
+				<span className="pointer-events-none absolute inset-x-1 bottom-1 truncate rounded bg-background/85 px-1.5 py-0.5 text-center text-[10px] text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100">
+					{symbol.company || symbol.primarySubject}
+				</span>
+			</button>
+			<a
+				href={symbol.svg}
+				download={`${symbol.id}.svg`}
+				onClick={(e) => e.stopPropagation()}
+				aria-label="Download SVG"
+				title="Download SVG"
+				className="absolute right-1 top-1 rounded-md bg-background/85 p-1 text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus:opacity-100 group-hover:opacity-100"
+			>
+				<Download className="h-3.5 w-3.5" />
+			</a>
+		</div>
 	);
 }

--- a/workers/jb-symbols/src/components/symbol-detail.tsx
+++ b/workers/jb-symbols/src/components/symbol-detail.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { X } from "lucide-react";
+import { Download, X } from "lucide-react";
 import type { SymbolRecord } from "@/lib/types";
 
 function TagRow({ label, tags, onTag }: { label: string; tags: string[]; onTag: (t: string) => void }) {
@@ -80,6 +80,14 @@ export function SymbolDetail({
 						<div className="text-center text-xs text-muted-foreground">
 							Vol {symbol.vol} · №{symbol.plate ?? symbol.num}
 						</div>
+						<a
+							href={symbol.svg}
+							download={`${symbol.id}.svg`}
+							className="inline-flex items-center justify-center gap-2 rounded-md border border-border bg-secondary px-3 py-2 text-sm font-medium text-secondary-foreground transition-colors hover:border-foreground/40 hover:bg-accent"
+						>
+							<Download className="h-4 w-4" />
+							Download SVG
+						</a>
 					</div>
 
 					<div className="flex flex-col gap-4">

--- a/workers/jb-travel/package.json
+++ b/workers/jb-travel/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"packageManager": "bun@1.3.0",
 	"scripts": {
-		"dev": "wrangler dev",
+		"dev": "next dev --turbopack -p 33001",
 		"build": "next build",
 		"start": "next start",
 		"lint": "next lint",

--- a/workers/jb-www/package.json
+++ b/workers/jb-www/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"packageManager": "bun@1.3.0",
 	"scripts": {
-		"dev": "wrangler dev",
+		"dev": "next dev --turbopack -p 33000",
 		"build": "next build",
 		"start": "next start",
 		"lint": "next lint",


### PR DESCRIPTION
## Summary

- **New `packages/unified-ui`** — presentational, fully-controlled React components for a unified send/swap/bridge card (swap card / from / to / field, keypad, bottom-sheet, QR, crypto address, segmented control, etc.), intended for reuse across workers. Bring-your-own data (Relay/wallet/i18n).
- **jb-swap: wallet logout/reconnect fix** — `connect()` now always opens the Privy picker instead of silently reusing a still-connected wallet, and `disconnect()` revokes account permissions via EIP-2255 `wallet_revokePermissions` for a real disconnect rather than a UI-only hide.
- **jb-swap: component extraction** — `swap-card` split into `swap-from` / `swap-to` / `swap-field`.
- **jb-symbols** — symbol card/detail component updates.
- **workers** — `dev` script switched to `next dev --turbopack` on fixed ports.

## Why the wallet fix

Logout was a UI-only hide: the `manuallyDisconnected` override masked the address but injected wallets (MetaMask/Phantom) stayed connected, so `rawAddress` was never null and `connect()`'s `if (rawAddress === null) login()` guard skipped the picker — reconnect silently reused the same wallet.

## Test plan

- [x] `bun install` — lockfile consistent, no changes
- [x] `next build` passes for jb-swap and jb-symbols
- [x] `bun test src/lib` — wallet-session-store tests pass (6/6)
- [ ] Manual: logout → reconnect shows the wallet picker (needs a real wallet)

> Note: full wallet sign-in still requires enabling **Wallet** login in the Privy "Salone" app dashboard (`wallet_auth` is currently `false`, which 403s SIWE). That's a dashboard config, separate from this code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)