### PR TITLE
fix(jb-swap): connect wallet without SIWE/SIWS auth + silence Phantom disconnect warn

### DIFF
--- a/workers/jb-swap/src/lib/use-wallet.ts
+++ b/workers/jb-swap/src/lib/use-wallet.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { usePrivy, useWallets } from "@privy-io/react-auth";
+import { useConnectWallet, usePrivy, useWallets } from "@privy-io/react-auth";
 import { useWallets as useSolanaWallets } from "@privy-io/react-auth/solana";
 import type { AdaptedWallet } from "@relayprotocol/relay-sdk";
 import { useCallback, useSyncExternalStore } from "react";
@@ -19,9 +19,11 @@ import {
  * embedded/smart wallets are involved — see {@link WalletProvider}.
  */
 export function useWallet() {
-	const { ready, login, logout } = usePrivy();
+	const { ready, authenticated, logout } = usePrivy();
 	const { wallets: evmWallets } = useWallets();
 	const { wallets: solanaWallets } = useSolanaWallets();
+	// Connector-only wallet connect (no SIWE/SIWS identity auth — see `connect`).
+	const { connectWallet } = useConnectWallet();
 
 	const evmWallet = evmWallets[0];
 	const solanaWallet = solanaWallets[0];
@@ -57,17 +59,19 @@ export function useWallet() {
 		address,
 		evmAddress: manuallyDisconnected ? null : (evmWallet?.address ?? null),
 		solanaAddress: manuallyDisconnected ? null : (solanaWallet?.address ?? null),
-		// Clear the override first so a connection can re-surface, then open
-		// Privy's login modal. We ALWAYS open the modal rather than silently
-		// re-using a wallet that's still connected at the connector level: after a
-		// "log out" the injected wallet often persists (see `disconnect` below),
-		// and reconnecting it with no prompt makes logout feel broken and prevents
-		// switching wallets. `login()` (vs `connectWallet()`) creates an
-		// authenticated session so the eventual `logout()` has something real to
-		// destroy (avoids the connect-only `POST /sessions/logout` 400).
+		// Open the external-wallet picker. We use Privy's `connectWallet`
+		// (connector-only) rather than `login()` so we DON'T trigger SIWE/SIWS
+		// identity authentication: a swap only needs a connected wallet to sign
+		// transactions, and the authenticate step was failing against this Privy
+		// app (SIWE `init` 403, then SIWS `authenticate` 400). Nothing here reads
+		// Privy's `authenticated`/`user` — the address comes from the connector
+		// (`useWallets`), which `connectWallet` populates without a user session.
+		// We always open the picker (after clearing the override) rather than
+		// silently re-using a still-connected wallet, so "log out → connect"
+		// re-prompts and lets the user switch wallets.
 		connect: () => {
 			clearManualDisconnect();
-			login();
+			connectWallet();
 		},
 		// Real disconnect. Flip the local override first so the UI returns to the
 		// connect screen immediately and reliably. Then best-effort sever the
@@ -77,9 +81,10 @@ export function useWallet() {
 		// `wallet_revokePermissions`). MetaMask / Rabby honor this and actually
 		// drop the connection, so the next connect re-prompts for approval; wallets
 		// that don't support it stay hidden behind the override. Solana wallets
-		// (Phantom) support programmatic `disconnect()`. Finally tear down the
-		// Privy session — a 400 on a stale/never-authenticated session is harmless,
-		// Privy still clears local tokens — so swallow it.
+		// (Phantom) support programmatic `disconnect()`. Only tear down a Privy
+		// session if one actually exists — with connector-only `connectWallet`
+		// there usually isn't one, and calling `logout()` with no authenticated
+		// user 400s ("Error destroying session").
 		disconnect: async () => {
 			setManualDisconnect();
 			if (evmWallet) {
@@ -96,7 +101,7 @@ export function useWallet() {
 			}
 			void evmWallet?.disconnect?.();
 			void solanaWallet?.disconnect?.();
-			void logout().catch(() => {});
+			if (authenticated) void logout().catch(() => {});
 		},
 		getAdaptedWallet,
 	};

--- a/workers/jb-swap/src/lib/use-wallet.ts
+++ b/workers/jb-swap/src/lib/use-wallet.ts
@@ -74,17 +74,22 @@ export function useWallet() {
 			connectWallet();
 		},
 		// Real disconnect. Flip the local override first so the UI returns to the
-		// connect screen immediately and reliably. Then best-effort sever the
-		// underlying connection: injected EVM wallets ignore connector
-		// `disconnect()` and Privy's `useWallets()` isn't gated on auth, so we ask
-		// the provider to revoke the dApp's account permission (EIP-2255
-		// `wallet_revokePermissions`). MetaMask / Rabby honor this and actually
-		// drop the connection, so the next connect re-prompts for approval; wallets
-		// that don't support it stay hidden behind the override. Solana wallets
-		// (Phantom) support programmatic `disconnect()`. Only tear down a Privy
-		// session if one actually exists — with connector-only `connectWallet`
-		// there usually isn't one, and calling `logout()` with no authenticated
-		// user 400s ("Error destroying session").
+		// connect screen immediately and reliably. Then, for EVM, best-effort
+		// revoke the dApp's account permission (EIP-2255 `wallet_revokePermissions`):
+		// MetaMask / Rabby honor this and actually drop the connection so the next
+		// connect re-prompts; wallets that don't support it stay hidden behind the
+		// override.
+		//
+		// We deliberately DON'T call the Privy connector's `wallet.disconnect()`.
+		// For injected wallets (incl. Phantom on Solana, which has no programmatic
+		// disconnect at all) it's a no-op that only logs a `console.warn`:
+		// "Programmatic disconnect with <wallet> is not yet supported." The override
+		// is what actually returns the UI to the connect screen, and the EVM revoke
+		// above does the real connector teardown where it's supported.
+		//
+		// Only tear down a Privy session if one actually exists — with
+		// connector-only `connectWallet` there usually isn't one, and calling
+		// `logout()` with no authenticated user 400s ("Error destroying session").
 		disconnect: async () => {
 			setManualDisconnect();
 			if (evmWallet) {
@@ -99,8 +104,6 @@ export function useWallet() {
 					// keeps it hidden until the page is refreshed.
 				}
 			}
-			void evmWallet?.disconnect?.();
-			void solanaWallet?.disconnect?.();
 			if (authenticated) void logout().catch(() => {});
 		},
 		getAdaptedWallet,


### PR DESCRIPTION
## Summary

Two related wallet fixes in `jb-swap`, both in `src/lib/use-wallet.ts`:

1. **Connect without identity auth.** `connect()` now uses Privy's `connectWallet()` (connector-only) instead of `login()`. `login()` forced a full SIWE/SIWS *identity authentication*, and the verify step was failing against the Privy app — first SIWE `init` 403 (login method disabled), then, after that was enabled, SIWS `authenticate` 400 (`Invalid SIWS message and/or nonce`). A swap only needs a *connected wallet* to sign transactions, not a Privy user session: the address comes from `useWallets()` (connector level) and nothing in the app reads `authenticated`/`user`.

2. **Silence the Phantom disconnect warn.** Privy's injected-wallet connector logs `Programmatic disconnect with <wallet> is not yet supported.` (a `console.warn`, not a throw) whenever its no-op `disconnect()` runs — e.g. Phantom on Solana. We now drop the `wallet.disconnect()` calls entirely. The manual-disconnect override returns the UI to the connect screen, and `wallet_revokePermissions` already does the real connector teardown for EVM where supported. `logout()` is also gated behind `authenticated` so disconnect no longer 400s with "Error destroying session".

## Behavior after this change

- Connecting a wallet (EVM or Solana) no longer hits `siwe/init` or `siws/authenticate` — no 403/400.
- Logout → reconnect re-opens the picker (lets you switch wallets).
- Console is clean on disconnect (no Phantom warn, no "Error destroying session").

## Test plan

- [x] `next build` passes for jb-swap
- [x] `tsc` — no errors in `use-wallet.ts`
- [x] `bun test src/lib` — wallet-session-store tests pass
- [ ] Manual on preview/prod: connect Phantom (Solana) + an EVM wallet, verify connect works and logout/reconnect is clean

> The CoinGecko `429 / CORS` errors also visible in the console are unrelated (client-side price fetch getting rate-limited) — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)