### PR TITLE
fix(jb-swap): proxy CoinGecko volume data through a worker route

### DIFF
--- a/workers/jb-swap/src/app/api/volume/route.ts
+++ b/workers/jb-swap/src/app/api/volume/route.ts
@@ -1,0 +1,47 @@
+import { fetchVolumeProxy, type VolumeData } from "@/lib/volume-ranking";
+
+/**
+ * Server-side proxy for the swap volume-ranking data.
+ *
+ * The browser used to call CoinGecko's `coins/markets` endpoint directly, which
+ * (a) is blocked by CORS — the endpoint sends no `Access-Control-Allow-Origin` —
+ * and (b) rate-limits (429) once enough visitors each poll it on a 60s timer.
+ * Fetching it here on the worker fixes both: it's a same-origin request for the
+ * client, the `User-Agent` header actually applies (browsers forbid setting it),
+ * and a short module-level cache + CDN cache headers collapse all visitors into
+ * at most ~one upstream call per minute. We return the precomputed maps rather
+ * than the raw 250-coin payload, so the client just consumes them.
+ */
+
+// Always run on the worker — never prerender at build time (which would call
+// CoinGecko during `next build`).
+export const dynamic = "force-dynamic";
+
+/** Serve the same computed maps for this long before refetching upstream. */
+const TTL_MS = 60_000;
+
+let cache: { data: VolumeData; at: number } | null = null;
+
+export async function GET() {
+	const now = Date.now();
+
+	if (!cache || now - cache.at > TTL_MS) {
+		const data = await fetchVolumeProxy();
+		// Only cache a non-empty result, so a transient upstream failure (timeout
+		// or 429) doesn't pin empty maps for a full minute — the next request
+		// retries. With a prior good cache we fall through and serve it (stale).
+		if (Object.keys(data.bySymbol).length > 0) {
+			cache = { data, at: now };
+		} else if (!cache) {
+			return Response.json(data, { headers: { "Cache-Control": "no-store" } });
+		}
+	}
+
+	return Response.json(cache.data, {
+		headers: {
+			// Let the CDN serve a shared copy too, so upstream sees at most
+			// ~one request per minute regardless of how many visitors are polling.
+			"Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+		},
+	});
+}

--- a/workers/jb-swap/src/lib/use-volume-ranking.ts
+++ b/workers/jb-swap/src/lib/use-volume-ranking.ts
@@ -5,18 +5,35 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import type { RelayChainOption } from "@/lib/relay/token-list";
 import type { Direction, VolumeData } from "@/lib/volume-ranking";
 import {
-	fetchVolumeProxy,
 	sortChainsByVolume,
 	sortTokensByVolume,
 } from "@/lib/volume-ranking";
 
 import type { TokenRow } from "@/components/token-drawer";
 
-/** How often to refresh the proxy. 60s stays well under CoinGecko's free limit. */
+/** How often to refresh the proxy. Matches the route's 60s server-side cache. */
 const POLL_INTERVAL_MS = 60_000;
 
 /** Stable empty value for SSR + first client render (avoids hydration mismatch). */
 const EMPTY_DATA: VolumeData = { bySymbol: {}, byChainId: {} };
+
+/**
+ * Fetch the precomputed volume maps from our own worker route, which proxies and
+ * caches CoinGecko server-side (see `app/api/volume/route.ts`). Same-origin, so
+ * no CORS; the route's cache absorbs the rate limit. Never throws — any failure
+ * yields empty maps, which the caller ignores to keep the last good ranking.
+ */
+async function fetchVolumeData(): Promise<VolumeData> {
+	try {
+		const res = await fetch("/api/volume");
+		if (!res.ok) return EMPTY_DATA;
+		const data = (await res.json()) as VolumeData;
+		if (!data || typeof data.bySymbol !== "object") return EMPTY_DATA;
+		return data;
+	} catch {
+		return EMPTY_DATA;
+	}
+}
 
 /**
  * Poll the volume proxy and expose memoized sorters.
@@ -34,7 +51,7 @@ export function useVolumeRanking() {
 		let cancelled = false;
 
 		const refresh = async () => {
-			const next = await fetchVolumeProxy();
+			const next = await fetchVolumeData();
 			if (cancelled) return;
 			// Ignore an empty result (cold-start failure / soft 429) so we keep the
 			// last good data instead of clearing the ranking.


### PR DESCRIPTION
## Summary

The volume-ranking poller (`use-volume-ranking.ts`) fetched `api.coingecko.com/api/v3/coins/markets` **directly from the browser**, which fails two ways in production:

- **CORS** — the endpoint sends no `Access-Control-Allow-Origin`, so the request is blocked.
- **429** — every visitor polls it on a 60s timer, blowing CoinGecko's free rate limit.

(The `User-Agent` header the client set was also silently dropped — browsers forbid setting it — a sign this belonged server-side.)

## Fix

- **New route `app/api/volume/route.ts`** — fetches + processes CoinGecko **on the worker** (no CORS, real UA) and returns the precomputed `VolumeData` maps. A 60s module-level cache plus `Cache-Control: public, s-maxage=60, stale-while-revalidate=300` collapse all visitors into ~one upstream call per minute. `force-dynamic` so it never calls CoinGecko at build time. Transient upstream failures don't pin empty maps (only non-empty results are cached; a prior good cache is served stale).
- **`use-volume-ranking.ts`** — the client now fetches the same-origin `/api/volume` instead of CoinGecko. Same never-throw / stale-while-error semantics.

## Test plan

- [x] `next build` passes; `/api/volume` registered as a dynamic route
- [x] **Smoke-tested live**: `GET /api/volume` → `200`, correct cache header, 250 symbols / 71 chains (BTC ~$21.6B, ETH ~$7.6B, USDC ~$8B)
- [x] `bun test src/lib` — 304/304 pass
- [ ] Post-deploy: confirm the swap token drawer ranks by volume and the console has no CoinGecko CORS/429 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)