### PR TITLE
fix(jb-dexos): inline memo markdown at build to fix runtime 500

### DIFF
--- a/workers/jb-dexos/next.config.js
+++ b/workers/jb-dexos/next.config.js
@@ -3,6 +3,16 @@ const nextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
+  webpack: (config) => {
+    // Import *.md files as raw strings, inlined into the bundle at build time.
+    // This keeps the memo content out of the runtime filesystem (unavailable on
+    // the Cloudflare Workers runtime).
+    config.module.rules.push({
+      test: /\.md$/,
+      type: "asset/source",
+    });
+    return config;
+  },
 };
 
 module.exports = nextConfig;

--- a/workers/jb-dexos/package.json
+++ b/workers/jb-dexos/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"packageManager": "bun@1.3.0",
 	"scripts": {
-		"dev": "next dev --turbopack -p 33005",
+		"dev": "next dev -p 33005",
 		"build": "next build",
 		"start": "next start",
 		"lint": "next lint",

--- a/workers/jb-dexos/src/app/page.tsx
+++ b/workers/jb-dexos/src/app/page.tsx
@@ -1,14 +1,6 @@
-import fs from "node:fs";
-import path from "node:path";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-
-// Read the memo at build time — this page is statically prerendered, so the
-// file read happens during `next build`, never at runtime on the edge.
-const memo = fs.readFileSync(
-  path.join(process.cwd(), "src/content/memo.md"),
-  "utf8",
-);
+import memo from "@/content/memo.md";
 
 export default function Home() {
   return (

--- a/workers/jb-dexos/src/markdown.d.ts
+++ b/workers/jb-dexos/src/markdown.d.ts
@@ -1,0 +1,4 @@
+declare module "*.md" {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
## Problem

`dexos.joeblau.com` returned **HTTP 500** on every request after the initial deploy. Reading the memo with `fs.readFileSync(process.cwd() + "/src/content/memo.md")` fails on the **Cloudflare Workers runtime** (no filesystem) — the server module throws on init, so even though `/` is statically prerendered, OpenNext's server function 500s.

## Fix

Import the `.md` as a raw string via a webpack `asset/source` rule, inlining the content into the bundle at build time. No `fs` access at runtime.

- `next.config.js` — webpack rule mapping `*.md` → `asset/source`
- `page.tsx` — `import memo from "@/content/memo.md"` instead of `fs.readFileSync`
- `src/markdown.d.ts` — module declaration for `*.md`
- `package.json` — dev switched off Turbopack so the same webpack rule applies in dev and build (single config path)

## Verification

Reproduced the 500 and confirmed the fix with `opennextjs-cloudflare preview` (the real **workerd** runtime), which now returns **200** with the memo rendering correctly (Nunito + `prose`, dark mode, `max-w-2xl`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)