### PR TITLE
feat(jb-dexos): add author footer to memo

### DIFF
--- a/workers/jb-dexos/src/app/page.tsx
+++ b/workers/jb-dexos/src/app/page.tsx
@@ -2,6 +2,11 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import memo from "@/content/memo.md";
 
+const AUTHORS = [
+  { name: "Joe Blau", companies: "Uber / Amazon", role: "Design Engineer" },
+  { name: "David Blau", companies: "Jump / MIT", role: "Quant Engineer" },
+];
+
 export default function Home() {
   return (
     <main className="mx-auto max-w-2xl px-6 py-16 sm:py-24">
@@ -11,6 +16,20 @@ export default function Home() {
       <article className="prose prose-neutral max-w-none dark:prose-invert prose-headings:font-extrabold prose-headings:tracking-tight prose-h1:text-balance">
         <ReactMarkdown remarkPlugins={[remarkGfm]}>{memo}</ReactMarkdown>
       </article>
+
+      <footer className="mt-16 grid grid-cols-2 gap-8 border-t border-border pt-8">
+        {AUTHORS.map((author) => (
+          <div key={author.name}>
+            <p className="font-bold">{author.name}</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {author.companies}
+            </p>
+            <p className="mt-3 text-sm font-semibold text-muted-foreground">
+              {author.role}
+            </p>
+          </div>
+        ))}
+      </footer>
     </main>
   );
 }


### PR DESCRIPTION
## Summary

Adds a two-column author footer at the bottom of the DEXos memo:

| Joe Blau | David Blau |
|----------|------------|
| Uber / Amazon | Jump / MIT |
| Design Engineer | Quant Engineer |

Separated from the memo body by a top border, styled to match (Nunito, muted-foreground).

## Verification

- `bun run build` — compiles, `/` still statically prerendered.
- Verified visually in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)