### PR TITLE
feat(jb-dexos): add light/dark theme toggle to memo header

### DIFF
--- a/workers/jb-dexos/src/app/page.tsx
+++ b/workers/jb-dexos/src/app/page.tsx
@@ -1,6 +1,7 @@
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import memo from "@/content/memo.md";
+import { ThemeToggle } from "@/components/theme-toggle";
 
 const AUTHORS = [
   {
@@ -14,9 +15,12 @@ const AUTHORS = [
 export default function Home() {
   return (
     <main className="mx-auto max-w-2xl px-6 py-16 sm:py-24">
-      <p className="mb-3 text-sm font-bold uppercase tracking-widest text-muted-foreground">
-        DEXos
-      </p>
+      <header className="mb-8 flex items-center justify-between gap-4">
+        <p className="text-sm font-bold uppercase tracking-widest text-muted-foreground">
+          DEXos
+        </p>
+        <ThemeToggle />
+      </header>
       <article className="prose prose-neutral max-w-none dark:prose-invert prose-headings:font-extrabold prose-headings:tracking-tight prose-h1:text-balance">
         <ReactMarkdown remarkPlugins={[remarkGfm]}>{memo}</ReactMarkdown>
       </article>

--- a/workers/jb-dexos/src/components/theme-toggle.tsx
+++ b/workers/jb-dexos/src/components/theme-toggle.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+
+export function ThemeToggle() {
+	const { theme, setTheme, systemTheme } = useTheme();
+	const [mounted, setMounted] = useState(false);
+
+	useEffect(() => {
+		setMounted(true);
+	}, []);
+
+	if (!mounted) {
+		return (
+			<button
+				type="button"
+				disabled
+				aria-label="Toggle theme"
+				className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border/70 bg-card/70 text-muted-foreground"
+			>
+				<span className="h-5 w-5" />
+			</button>
+		);
+	}
+
+	const currentTheme = theme === "system" ? systemTheme : theme;
+	const isDark = currentTheme === "dark";
+
+	return (
+		<button
+			type="button"
+			onClick={() => setTheme(isDark ? "light" : "dark")}
+			aria-label="Toggle theme"
+			className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border/70 bg-card/70 text-foreground transition-colors hover:bg-card"
+		>
+			{isDark ? (
+				<Sun className="h-5 w-5" aria-hidden="true" />
+			) : (
+				<Moon className="h-5 w-5" aria-hidden="true" />
+			)}
+		</button>
+	);
+}
+


### PR DESCRIPTION
## Summary

Adds a light/dark theme toggle to the DEXos memo header.

- New `ThemeToggle` client component — Sun/Moon icons (lucide), backed by the existing `next-themes` provider.
- SSR-safe: renders a disabled placeholder until mounted to avoid hydration mismatch.
- Header restructured as a flex row: **DEXos** eyebrow left, toggle right.

## Verification

- `bun run build` — compiles, `/` still statically prerendered.
- Verified in the browser: toggle flips between dark and light, icon swaps correctly, content renders in both modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)