### PR TITLE
feat(jb-dexos): warm theme, skiper toggle + transition, footer + Ask tweaks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -43,6 +43,7 @@
         "@radix-ui/react-slot": "^1.2.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "framer-motion": "^12.42.2",
         "lucide-react": "^0.562.0",
         "next": "15.5.9",
         "next-themes": "^0.4.6",
@@ -2394,7 +2395,7 @@
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
-    "framer-motion": ["framer-motion@12.40.0", "", { "dependencies": { "motion-dom": "^12.40.0", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg=="],
+    "framer-motion": ["framer-motion@12.42.2", "", { "dependencies": { "motion-dom": "^12.42.2", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw=="],
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
@@ -2986,7 +2987,7 @@
 
     "motion": ["motion@12.34.5", "", { "dependencies": { "framer-motion": "^12.34.5", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-N06NLJ9IeBHeielRqIvYvjPfXuRdyTxa+9++BgpGa+hY2D7TcMkI6QzV3jaRuv0aZRXgMa7cPy9YcBUBisPzAQ=="],
 
-    "motion-dom": ["motion-dom@12.40.0", "", { "dependencies": { "motion-utils": "^12.39.0" } }, "sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg=="],
+    "motion-dom": ["motion-dom@12.42.2", "", { "dependencies": { "motion-utils": "^12.39.0" } }, "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA=="],
 
     "motion-utils": ["motion-utils@12.39.0", "", {}, "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ=="],
 
@@ -4260,9 +4261,13 @@
 
     "jayson/ws": ["ws@7.5.11", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA=="],
 
+    "jb-swap/framer-motion": ["framer-motion@12.40.0", "", { "dependencies": { "motion-dom": "^12.40.0", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg=="],
+
     "jb-swap/lucide-react": ["lucide-react@1.18.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-LZDb7H/0YfM+RJncD0hDQRCAu+vSGODqpe35TuVI8EuXaRjkczbsx7p8dY4J87F/MUSj6bpYqeI8nw8qXaAdmA=="],
 
     "jb-travel/@number-flow/react": ["@number-flow/react@0.5.14", "", { "dependencies": { "esm-env": "^1.1.4", "number-flow": "0.5.12" }, "peerDependencies": { "react": "^18 || ^19", "react-dom": "^18 || ^19" } }, "sha512-FGUqjh/P5/ukr0U0ySwb987M0SbRkrnZq70f0wQFncDbXa3SIib4L+FTr5ngvWwGAW8S6b391eTXcfhErZsw4w=="],
+
+    "jb-travel/framer-motion": ["framer-motion@12.40.0", "", { "dependencies": { "motion-dom": "^12.40.0", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg=="],
 
     "jest-util/ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
 
@@ -4828,7 +4833,11 @@
 
     "jayson/@types/ws/@types/node": ["@types/node@25.3.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ=="],
 
+    "jb-swap/framer-motion/motion-dom": ["motion-dom@12.40.0", "", { "dependencies": { "motion-utils": "^12.39.0" } }, "sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg=="],
+
     "jb-travel/@number-flow/react/number-flow": ["number-flow@0.5.12", "", { "dependencies": { "esm-env": "^1.1.4" } }, "sha512-CIs21h2JkfYG4rfgERaUNAk0Cz+Ef14fNJfSCbGGhgRgconQc9b7rcCQfi9SZ36kNjVXmsl2BrzDbjGtEgumAA=="],
+
+    "jb-travel/framer-motion/motion-dom": ["motion-dom@12.40.0", "", { "dependencies": { "motion-utils": "^12.39.0" } }, "sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg=="],
 
     "lighthouse-logger/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 

--- a/workers/jb-dexos/components.json
+++ b/workers/jb-dexos/components.json
@@ -10,6 +10,7 @@
     "cssVariables": true,
     "prefix": ""
   },
+  "iconLibrary": "lucide",
   "aliases": {
     "components": "@/components",
     "utils": "@/lib/utils",
@@ -17,5 +18,7 @@
     "lib": "@/lib",
     "hooks": "@/hooks"
   },
-  "iconLibrary": "lucide"
+  "registries": {
+    "@skiper-ui": "https://skiper-ui.com/registry/{name}.json"
+  }
 }

--- a/workers/jb-dexos/package.json
+++ b/workers/jb-dexos/package.json
@@ -18,6 +18,7 @@
 		"@radix-ui/react-slot": "^1.2.4",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
+		"framer-motion": "^12.42.2",
 		"lucide-react": "^0.562.0",
 		"next": "15.5.9",
 		"next-themes": "^0.4.6",

--- a/workers/jb-dexos/src/app/globals.css
+++ b/workers/jb-dexos/src/app/globals.css
@@ -4,34 +4,35 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 0 0% 3.9%;
+    /* Warm editorial — cream paper, ink-brown text */
+    --background: 40 40% 97%;
+    --foreground: 30 14% 13%;
 
-    --muted: 0 0% 96.1%;
-    --muted-foreground: 0 0% 45.1%;
+    --muted: 40 26% 92%;
+    --muted-foreground: 34 10% 40%;
 
-    --popover: 0 0% 100%;
-    --popover-foreground: 0 0% 3.9%;
+    --popover: 42 44% 98%;
+    --popover-foreground: 30 14% 13%;
 
-    --card: 0 0% 100%;
-    --card-foreground: 0 0% 3.9%;
+    --card: 42 44% 98%;
+    --card-foreground: 30 14% 13%;
 
-    --border: 0 0% 89.8%;
-    --input: 0 0% 89.8%;
+    --border: 38 24% 84%;
+    --input: 38 24% 84%;
 
-    --primary: 0 0% 9%;
-    --primary-foreground: 0 0% 98%;
+    --primary: 30 15% 17%;
+    --primary-foreground: 40 40% 97%;
 
-    --secondary: 0 0% 96.1%;
-    --secondary-foreground: 0 0% 9%;
+    --secondary: 40 26% 92%;
+    --secondary-foreground: 30 15% 17%;
 
-    --accent: 0 0% 96.1%;
-    --accent-foreground: 0 0% 9%;
+    --accent: 40 28% 90%;
+    --accent-foreground: 30 15% 17%;
 
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 0 0% 98%;
+    --destructive: 8 62% 46%;
+    --destructive-foreground: 40 40% 97%;
 
-    --ring: 0 0% 3.9%;
+    --ring: 30 14% 13%;
 
     --radius: 0.5rem;
 
@@ -43,34 +44,35 @@
   }
 
   .dark {
-    --background: 0 0% 3.9%;
-    --foreground: 0 0% 98%;
+    /* Warm-neutral — warm charcoal, warm off-white text */
+    --background: 30 9% 8%;
+    --foreground: 40 32% 91%;
 
-    --muted: 0 0% 14.9%;
-    --muted-foreground: 0 0% 63.9%;
+    --muted: 30 7% 15%;
+    --muted-foreground: 36 12% 62%;
 
-    --popover: 0 0% 3.9%;
-    --popover-foreground: 0 0% 98%;
+    --popover: 30 9% 8%;
+    --popover-foreground: 40 32% 91%;
 
-    --card: 0 0% 3.9%;
-    --card-foreground: 0 0% 98%;
+    --card: 30 8% 11%;
+    --card-foreground: 40 32% 91%;
 
-    --border: 0 0% 14.9%;
-    --input: 0 0% 14.9%;
+    --border: 30 7% 18%;
+    --input: 30 7% 18%;
 
-    --primary: 0 0% 98%;
-    --primary-foreground: 0 0% 9%;
+    --primary: 40 32% 91%;
+    --primary-foreground: 30 15% 12%;
 
-    --secondary: 0 0% 14.9%;
-    --secondary-foreground: 0 0% 98%;
+    --secondary: 30 7% 15%;
+    --secondary-foreground: 40 32% 91%;
 
-    --accent: 0 0% 14.9%;
-    --accent-foreground: 0 0% 98%;
+    --accent: 30 7% 15%;
+    --accent-foreground: 40 32% 91%;
 
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
+    --destructive: 8 58% 40%;
+    --destructive-foreground: 40 32% 91%;
 
-    --ring: 0 0% 83.1%;
+    --ring: 36 20% 70%;
 
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;

--- a/workers/jb-dexos/src/app/page.tsx
+++ b/workers/jb-dexos/src/app/page.tsx
@@ -28,11 +28,11 @@ export default function Home() {
       <footer className="mt-16 grid grid-cols-2 gap-8 border-t border-border pt-10">
         {AUTHORS.map((author) => (
           <div key={author.name}>
-            <p className="text-2xl font-bold">{author.name}</p>
-            <p className="text-lg font-semibold text-muted-foreground">
+            <p className="text-xl font-bold">{author.name}</p>
+            <p className="text-base font-semibold text-muted-foreground">
               {author.role}
             </p>
-            <p className="text-lg text-muted-foreground">{author.companies}</p>
+            <p className="text-base text-muted-foreground">{author.companies}</p>
           </div>
         ))}
       </footer>

--- a/workers/jb-dexos/src/app/page.tsx
+++ b/workers/jb-dexos/src/app/page.tsx
@@ -21,7 +21,7 @@ export default function Home() {
         </p>
         <ThemeToggle />
       </header>
-      <article className="prose prose-neutral max-w-none dark:prose-invert prose-headings:font-extrabold prose-headings:tracking-tight prose-h1:text-balance">
+      <article className="prose prose-stone max-w-none dark:prose-invert prose-headings:font-extrabold prose-headings:tracking-tight prose-h1:text-balance">
         <ReactMarkdown remarkPlugins={[remarkGfm]}>{memo}</ReactMarkdown>
       </article>
 

--- a/workers/jb-dexos/src/components/theme-toggle.tsx
+++ b/workers/jb-dexos/src/components/theme-toggle.tsx
@@ -1,46 +1,78 @@
 "use client";
 
-import { Moon, Sun } from "lucide-react";
-import { useTheme } from "next-themes";
+import { motion } from "framer-motion";
 import { useEffect, useState } from "react";
 
+import { useThemeToggle } from "@/components/ui/skiper-ui/skiper26";
+import { cn } from "@/lib/utils";
+
+// Circular sun/moon button (skiper4 design) driving skiper26's full-page
+// circle-blur theme transition, wired to next-themes.
 export function ThemeToggle() {
-	const { theme, setTheme, systemTheme } = useTheme();
-	const [mounted, setMounted] = useState(false);
+  const { isDark, toggleTheme } = useThemeToggle({
+    variant: "circle",
+    start: "center",
+    blur: true,
+  });
+  const [mounted, setMounted] = useState(false);
 
-	useEffect(() => {
-		setMounted(true);
-	}, []);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
-	if (!mounted) {
-		return (
-			<button
-				type="button"
-				disabled
-				aria-label="Toggle theme"
-				className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border/70 bg-card/70 text-muted-foreground"
-			>
-				<span className="h-5 w-5" />
-			</button>
-		);
-	}
+  const dark = mounted && isDark;
 
-	const currentTheme = theme === "system" ? systemTheme : theme;
-	const isDark = currentTheme === "dark";
-
-	return (
-		<button
-			type="button"
-			onClick={() => setTheme(isDark ? "light" : "dark")}
-			aria-label="Toggle theme"
-			className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border/70 bg-card/70 text-foreground transition-colors hover:bg-card"
-		>
-			{isDark ? (
-				<Sun className="h-5 w-5" aria-hidden="true" />
-			) : (
-				<Moon className="h-5 w-5" aria-hidden="true" />
-			)}
-		</button>
-	);
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      aria-label="Toggle theme"
+      className={cn(
+        "size-9 rounded-full bg-foreground p-2 text-background transition-all duration-300 active:scale-95",
+      )}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+        fill="currentColor"
+        strokeLinecap="round"
+        viewBox="0 0 32 32"
+      >
+        <clipPath id="theme-toggle-clip">
+          <motion.path
+            animate={{ y: dark ? 10 : 0, x: dark ? -12 : 0 }}
+            transition={{ ease: "easeInOut", duration: 0.35 }}
+            d="M0-5h30a1 1 0 0 0 9 13v24H0Z"
+          />
+        </clipPath>
+        <g clipPath="url(#theme-toggle-clip)">
+          <motion.circle
+            animate={{ r: dark ? 10 : 8 }}
+            transition={{ ease: "easeInOut", duration: 0.35 }}
+            cx="16"
+            cy="16"
+          />
+          <motion.g
+            animate={{
+              rotate: dark ? -100 : 0,
+              scale: dark ? 0.5 : 1,
+              opacity: dark ? 0 : 1,
+            }}
+            transition={{ ease: "easeInOut", duration: 0.35 }}
+            stroke="currentColor"
+            strokeWidth="1.5"
+          >
+            <path d="M16 5.5v-4" />
+            <path d="M16 30.5v-4" />
+            <path d="M1.5 16h4" />
+            <path d="M26.5 16h4" />
+            <path d="m23.4 8.6 2.8-2.8" />
+            <path d="m5.7 26.3 2.9-2.9" />
+            <path d="m5.8 5.8 2.8 2.8" />
+            <path d="m23.4 23.4 2.9 2.9" />
+          </motion.g>
+        </g>
+      </svg>
+    </button>
+  );
 }
-

--- a/workers/jb-dexos/src/components/ui/skiper-ui/skiper26.tsx
+++ b/workers/jb-dexos/src/components/ui/skiper-ui/skiper26.tsx
@@ -1,0 +1,1217 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { GripHorizontal } from "lucide-react";
+import { useTheme } from "next-themes";
+import React, { useCallback, useEffect, useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+const Skiper26 = () => {
+  const [variant, setVariant] = useState<AnimationVariant>("rectangle");
+  const [start, setStart] = useState<AnimationStart>("bottom-up");
+  const [blur, setBlur] = useState<boolean>(false);
+  const [gifType, setGifType] = useState<"1" | "2" | "3" | "custom">("1");
+  const [gifUrl, setGifUrl] = useState<string>(
+    "https://media.giphy.com/media/KBbr4hHl9DSahKvInO/giphy.gif?cid=790b76112m5eeeydoe7et0cr3j3ekb1erunxozyshuhxx2vl&ep=v1_stickers_search&rid=giphy.gif&ct=s",
+  );
+
+  return (
+    <div className="relative flex h-full w-full flex-col items-center justify-center">
+      <div className="mx-auto max-w-lg space-y-5">
+        <h2 className="mt-36 text-4xl font-medium tracking-tight">
+          07.09.2025 <br />
+          Skiper ui is live now
+        </h2>
+        <p>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Nihil, ex
+          eligendi veniam praesentium temporibus natus quae laborum nemo
+          repellendus cum!
+        </p>
+        <p>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Nihil, ex
+          eligendi veniam praesentium temporibus natus quae laborum nemo
+          repellendus cum!
+        </p>
+        <p>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Nihil, ex
+          eligendi veniam praesentium temporibus natus quae laborum nemo
+          repellendus cum!
+        </p>
+      </div>
+
+      <div className="text-foreground grid content-start justify-items-center gap-6 py-20 text-center">
+        <span className="after:from-background after:to-foreground relative max-w-[12ch] text-xs uppercase leading-tight opacity-40 after:absolute after:left-1/2 after:top-full after:h-16 after:w-px after:bg-gradient-to-b after:content-['']">
+          Click to toggle the theme
+        </span>
+      </div>
+
+      <ThemeToggleButton
+        variant={variant}
+        start={start}
+        blur={blur}
+        gifUrl={gifUrl}
+      />
+      <Options
+        variant={variant}
+        start={start}
+        blur={blur}
+        gifType={gifType}
+        gifUrl={gifUrl}
+        setVariant={setVariant}
+        setStart={setStart}
+        setBlur={setBlur}
+        setGifType={setGifType}
+        setGifUrl={setGifUrl}
+      />
+    </div>
+  );
+};
+
+export { Skiper26 };
+
+const Options = ({
+  variant,
+  start,
+  blur,
+  gifType,
+  gifUrl,
+  setVariant,
+  setStart,
+  setBlur,
+  setGifType,
+  setGifUrl,
+}: {
+  variant: AnimationVariant;
+  start: AnimationStart;
+  blur: boolean;
+  gifType: "1" | "2" | "3" | "custom";
+  gifUrl: string;
+  setVariant: (variant: AnimationVariant) => void;
+  setStart: (start: AnimationStart) => void;
+  setBlur: (blur: boolean) => void;
+  setGifType: (type: "1" | "2" | "3" | "custom") => void;
+  setGifUrl: (url: string) => void;
+}) => {
+  return (
+    <motion.div
+      drag
+      className="top-30 border-foreground/10 bg-muted2 absolute right-1/2 flex w-[245px] translate-x-1/2 flex-col gap-3 rounded-3xl border p-3 backdrop-blur-sm lg:right-4 lg:translate-x-0"
+    >
+      <div className="flex items-center justify-between">
+        <span className="size-4 cursor-grab active:cursor-grabbing">
+          <GripHorizontal className="size-4 opacity-50" />
+        </span>
+
+        <p className="group flex cursor-pointer items-center justify-center gap-1 rounded-lg px-2 py-1 text-sm opacity-50">
+          Options
+        </p>
+      </div>
+
+      <div className="flex flex-col">
+        <div className="mt-1 flex justify-between py-1">
+          <p className="w-20 whitespace-nowrap text-sm opacity-50">variant :</p>
+          <div className="flex flex-wrap items-center justify-end gap-1">
+            <button
+              onClick={() => setVariant("circle")}
+              className={cn(
+                "cursor-pointer px-1 text-sm transition-opacity",
+                variant === "circle"
+                  ? "opacity-100"
+                  : "hover:bg-foreground/10 opacity-50 hover:opacity-100",
+              )}
+            >
+              circle
+            </button>
+            <button
+              onClick={() => setVariant("rectangle")}
+              className={cn(
+                "cursor-pointer px-1 text-sm transition-opacity",
+                variant === "rectangle"
+                  ? "opacity-100"
+                  : "hover:bg-foreground/10 opacity-50 hover:opacity-100",
+              )}
+            >
+              rectangle
+            </button>
+            <button
+              onClick={() => setVariant("gif")}
+              className={cn(
+                "cursor-pointer px-1 text-sm transition-opacity",
+                variant === "gif"
+                  ? "opacity-100"
+                  : "hover:bg-foreground/10 opacity-50 hover:opacity-100",
+              )}
+            >
+              gif
+            </button>
+            <button
+              onClick={() => setVariant("polygon")}
+              className={cn(
+                "cursor-pointer px-1 text-sm transition-opacity",
+                variant === "polygon"
+                  ? "opacity-100"
+                  : "hover:bg-foreground/10 opacity-50 hover:opacity-100",
+              )}
+            >
+              polygon
+            </button>
+            <button
+              onClick={() => setVariant("circle-blur")}
+              className={cn(
+                "cursor-pointer px-1 text-sm transition-opacity",
+                variant === "circle-blur"
+                  ? "opacity-100"
+                  : "hover:bg-foreground/10 opacity-50 hover:opacity-100",
+              )}
+            >
+              circle-blur
+            </button>
+          </div>
+        </div>
+
+        <div className="mt-1 flex justify-between py-1">
+          <p className="w-20 whitespace-nowrap text-sm opacity-50">blur :</p>
+          <div className="flex flex-wrap items-center justify-end gap-1">
+            <button
+              onClick={() => setBlur(false)}
+              className={cn(
+                "cursor-pointer px-1 text-sm transition-opacity",
+                !blur
+                  ? "opacity-100"
+                  : "hover:bg-foreground/10 opacity-50 hover:opacity-100",
+              )}
+            >
+              off
+            </button>
+            <button
+              onClick={() => setBlur(true)}
+              className={cn(
+                "cursor-pointer px-1 text-sm transition-opacity",
+                blur
+                  ? "opacity-100"
+                  : "hover:bg-foreground/10 opacity-50 hover:opacity-100",
+              )}
+            >
+              on
+            </button>
+          </div>
+        </div>
+
+        {/* Show start options for circle, rectangle, polygon, and circle-blur */}
+        {(variant === "circle" ||
+          variant === "rectangle" ||
+          variant === "polygon" ||
+          variant === "circle-blur") && (
+          <div className="mt-1 flex justify-between py-1">
+            <p className="w-20 whitespace-nowrap text-sm opacity-50">start :</p>
+            <div className="flex flex-wrap items-center justify-end gap-1">
+              {/* Show center option only for circle and circle-blur */}
+              {(variant === "circle" || variant === "circle-blur") && (
+                <button
+                  onClick={() => setStart("center")}
+                  className={cn(
+                    "cursor-pointer px-1 text-sm transition-opacity",
+                    start === "center"
+                      ? "opacity-100"
+                      : "hover:bg-foreground/10 opacity-50 hover:opacity-100",
+                  )}
+                >
+                  center
+                </button>
+              )}
+
+              {/* Show directional options for rectangle */}
+              {variant === "rectangle" && (
+                <>
+                  <button
+                    onClick={() => setStart("bottom-up")}
+                    className={cn(
+                      "cursor-pointer px-1 text-sm transition-opacity",
+                      start === "bottom-up"
+                        ? "opacity-100"
+                        : "hover:bg-foreground/10 opacity-50 hover:opacity-100",
+                    )}
+                  >
+                    bottom-up
+                  </button>
+                  <button
+                    onClick={() => setStart("top-down")}
+                    className={cn(
+                      "cursor-pointer px-1 text-sm transition-opacity",
+                      start === "top-down"
+                        ? "opacity-100"
+                        : "hover:bg-foreground/10 opacity-50 hover:opacity-100",
+                    )}
+                  >
+                    top-down
+                  </button>
+                  <button
+                    onClick={() => setStart("left-right")}
+                    className={cn(
+                      "cursor-pointer px-1 text-sm transition-opacity",
+                      start === "left-right"
+                        ? "opacity-100"
+                        : "hover:bg-foreground/10 opacity-50 hover:opacity-100",
+                    )}
+                  >
+                    left-right
+                  </button>
+                  <button
+                    onClick={() => setStart("right-left")}
+                    className={cn(
+                      "cursor-pointer px-1 text-sm transition-opacity",
+                      start === "right-left"
+                        ? "opacity-100"
+                        : "hover:bg-foreground/10 opacity-50 hover:opacity-100",
+                    )}
+                  >
+                    right-left
+                  </button>
+                </>
+              )}
+
+              {/* Show corner options for circle, polygon, and circle-blur variants */}
+              {(variant === "circle" ||
+                variant === "polygon" ||
+                variant === "circle-blur") && (
+                <>
+                  <button
+                    onClick={() => setStart("top-left")}
+                    className={cn(
+                      "cursor-pointer px-1 text-sm transition-opacity",
+                      start === "top-left"
+                        ? "opacity-100"
+                        : "hover:bg-foreground/10 opacity-50 hover:opacity-100",
+                    )}
+                  >
+                    top-left
+                  </button>
+                  <button
+                    onClick={() => setStart("top-right")}
+                    className={cn(
+                      "cursor-pointer px-1 text-sm transition-opacity",
+                      start === "top-right"
+                        ? "opacity-100"
+                        : "hover:bg-foreground/10 opacity-50 hover:opacity-100",
+                    )}
+                  >
+                    top-right
+                  </button>
+                  {/* Only show bottom corners for circle, not polygon */}
+                  {variant !== "polygon" && (
+                    <>
+                      <button
+                        onClick={() => setStart("bottom-left")}
+                        className={cn(
+                          "cursor-pointer px-1 text-sm transition-opacity",
+                          start === "bottom-left"
+                            ? "opacity-100"
+                            : "hover:bg-foreground/10 opacity-50 hover:opacity-100",
+                        )}
+                      >
+                        bottom-left
+                      </button>
+                      <button
+                        onClick={() => setStart("bottom-right")}
+                        className={cn(
+                          "cursor-pointer px-1 text-sm transition-opacity",
+                          start === "bottom-right"
+                            ? "opacity-100"
+                            : "hover:bg-foreground/10 opacity-50 hover:opacity-100",
+                        )}
+                      >
+                        bottom-right
+                      </button>
+                    </>
+                  )}
+                </>
+              )}
+
+              {/* Show center options for circle and circle-blur */}
+              {(variant === "circle" || variant === "circle-blur") && (
+                <>
+                  <button
+                    onClick={() => setStart("top-center")}
+                    className={cn(
+                      "cursor-pointer px-1 text-sm transition-opacity",
+                      start === "top-center"
+                        ? "opacity-100"
+                        : "hover:bg-foreground/10 opacity-50 hover:opacity-100",
+                    )}
+                  >
+                    top-center
+                  </button>
+                  <button
+                    onClick={() => setStart("bottom-center")}
+                    className={cn(
+                      "cursor-pointer px-1 text-sm transition-opacity",
+                      start === "bottom-center"
+                        ? "opacity-100"
+                        : "hover:bg-foreground/10 opacity-50 hover:opacity-100",
+                    )}
+                  >
+                    bottom-center
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Show gif type options only for gif variant */}
+        {variant === "gif" && (
+          <div className="mt-1 flex justify-between py-1">
+            <p className="w-20 text-sm opacity-50">gif type :</p>
+            <div className="flex flex-wrap items-center justify-end gap-1">
+              <button
+                onClick={() => {
+                  setGifType("1");
+                  setGifUrl(
+                    "https://media.giphy.com/media/KBbr4hHl9DSahKvInO/giphy.gif?cid=790b76112m5eeeydoe7et0cr3j3ekb1erunxozyshuhxx2vl&ep=v1_stickers_search&rid=giphy.gif&ct=s",
+                  );
+                }}
+                className={cn(
+                  "cursor-pointer px-1 text-sm transition-opacity",
+                  gifType === "1"
+                    ? "opacity-100"
+                    : "hover:bg-foreground/10 opacity-50 hover:opacity-100",
+                )}
+              >
+                1
+              </button>
+              <button
+                onClick={() => {
+                  setGifType("2");
+                  setGifUrl(
+                    "https://media.giphy.com/media/5PncuvcXbBuIZcSiQo/giphy.gif?cid=ecf05e47j7vdjtytp3fu84rslaivdun4zvfhej6wlvl6qqsz&ep=v1_stickers_search&rid=giphy.gif&ct=s",
+                  );
+                }}
+                className={cn(
+                  "cursor-pointer px-1 text-sm transition-opacity",
+                  gifType === "2"
+                    ? "opacity-100"
+                    : "hover:bg-foreground/10 opacity-50 hover:opacity-100",
+                )}
+              >
+                2
+              </button>
+              <button
+                onClick={() => {
+                  setGifType("3");
+                  setGifUrl(
+                    "https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZ3JwcXdzcHd5MW92NWprZXVpcTBtNXM5cG9obWh0N3I4NzFpaDE3byZlcD12MV9zdGlja2Vyc19zZWFyY2gmY3Q9cw/WgsVx6C4N8tjy/giphy.gif",
+                  );
+                }}
+                className={cn(
+                  "cursor-pointer px-1 text-sm transition-opacity",
+                  gifType === "3"
+                    ? "opacity-100"
+                    : "hover:bg-foreground/10 opacity-50 hover:opacity-100",
+                )}
+              >
+                3
+              </button>
+              <button
+                onClick={() => setGifType("custom")}
+                className={cn(
+                  "cursor-pointer px-1 text-sm transition-opacity",
+                  gifType === "custom"
+                    ? "opacity-100"
+                    : "hover:bg-foreground/10 opacity-50 hover:opacity-100",
+                )}
+              >
+                custom
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Show input only when gif variant and custom type are selected */}
+        {variant === "gif" && gifType === "custom" && (
+          <div className="mt-1 flex flex-col gap-1 py-1">
+            <p className="text-sm opacity-50">gif url :</p>
+            <input
+              type="text"
+              value={gifUrl}
+              onChange={(e) => setGifUrl(e.target.value)}
+              placeholder="Enter GIF URL"
+              className="text-foreground placeholder:text-foreground/50 w-full rounded-lg bg-transparent px-2 py-1 text-xs focus:outline-none"
+            />
+          </div>
+        )}
+      </div>
+    </motion.div>
+  );
+};
+
+// ///////////////////////////////////////////////////////////////////////////
+// Custom hook for theme toggle functionality
+export const useThemeToggle = ({
+  variant = "circle",
+  start = "center",
+  blur = false,
+  gifUrl = "",
+}: {
+  variant?: AnimationVariant;
+  start?: AnimationStart;
+  blur?: boolean;
+  gifUrl?: string;
+} = {}) => {
+  const { theme, setTheme, resolvedTheme } = useTheme();
+
+  const [isDark, setIsDark] = useState(false);
+
+  // Sync isDark state with resolved theme after hydration
+  useEffect(() => {
+    setIsDark(resolvedTheme === "dark");
+  }, [resolvedTheme]);
+
+  const styleId = "theme-transition-styles";
+
+  const updateStyles = useCallback((css: string, name: string) => {
+    if (typeof window === "undefined") return;
+
+    let styleElement = document.getElementById(styleId) as HTMLStyleElement;
+
+    if (!styleElement) {
+      styleElement = document.createElement("style");
+      styleElement.id = styleId;
+      document.head.appendChild(styleElement);
+    }
+
+    styleElement.textContent = css;
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setIsDark(!isDark);
+
+    const animation = createAnimation(variant, start, blur, gifUrl);
+
+    updateStyles(animation.css, animation.name);
+
+    if (typeof window === "undefined") return;
+
+    const switchTheme = () => {
+      setTheme(theme === "light" ? "dark" : "light");
+    };
+
+    if (!document.startViewTransition) {
+      switchTheme();
+      return;
+    }
+
+    document.startViewTransition(switchTheme);
+  }, [
+    theme,
+    setTheme,
+    variant,
+    start,
+    blur,
+    gifUrl,
+    updateStyles,
+    isDark,
+    setIsDark,
+  ]);
+
+  const setCrazyLightTheme = useCallback(() => {
+    setIsDark(false);
+
+    const animation = createAnimation(variant, start, blur, gifUrl);
+
+    updateStyles(animation.css, animation.name);
+
+    if (typeof window === "undefined") return;
+
+    const switchTheme = () => {
+      setTheme("light");
+    };
+
+    if (!document.startViewTransition) {
+      switchTheme();
+      return;
+    }
+
+    document.startViewTransition(switchTheme);
+  }, [setTheme, variant, start, blur, gifUrl, updateStyles, setIsDark]);
+
+  const setCrazyDarkTheme = useCallback(() => {
+    setIsDark(true);
+
+    const animation = createAnimation(variant, start, blur, gifUrl);
+
+    updateStyles(animation.css, animation.name);
+
+    if (typeof window === "undefined") return;
+
+    const switchTheme = () => {
+      setTheme("dark");
+    };
+
+    if (!document.startViewTransition) {
+      switchTheme();
+      return;
+    }
+
+    document.startViewTransition(switchTheme);
+  }, [setTheme, variant, start, blur, gifUrl, updateStyles, setIsDark]);
+
+  const setCrazySystemTheme = useCallback(() => {
+    if (typeof window === "undefined") return;
+
+    // Check system preference for dark mode
+    const prefersDark = window.matchMedia(
+      "(prefers-color-scheme: dark)",
+    ).matches;
+    setIsDark(prefersDark);
+
+    const animation = createAnimation(variant, start, blur, gifUrl);
+
+    updateStyles(animation.css, animation.name);
+
+    const switchTheme = () => {
+      setTheme("system");
+    };
+
+    if (!document.startViewTransition) {
+      switchTheme();
+      return;
+    }
+
+    document.startViewTransition(switchTheme);
+  }, [setTheme, variant, start, blur, gifUrl, updateStyles, setIsDark]);
+
+  return {
+    isDark,
+    setIsDark,
+    toggleTheme,
+    setCrazyLightTheme,
+    setCrazyDarkTheme,
+    setCrazySystemTheme,
+  };
+};
+
+// ///////////////////////////////////////////////////////////////////////////
+
+export const ThemeToggleButton = ({
+  className = "",
+  variant = "circle",
+  start = "center",
+  blur = false,
+  gifUrl = "",
+}: {
+  className?: string;
+  variant?: AnimationVariant;
+  start?: AnimationStart;
+  blur?: boolean;
+  gifUrl?: string;
+}) => {
+  const { isDark, toggleTheme } = useThemeToggle({
+    variant,
+    start,
+    blur,
+    gifUrl,
+  });
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        "size-10 cursor-pointer rounded-full bg-black p-0 transition-all duration-300 active:scale-95",
+        className,
+      )}
+      onClick={toggleTheme}
+      aria-label="Toggle theme"
+    >
+      <span className="sr-only">Toggle theme</span>
+      <svg viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <motion.g
+          animate={{ rotate: isDark ? -180 : 0 }}
+          transition={{ ease: "easeInOut", duration: 0.5 }}
+        >
+          <path
+            d="M120 67.5C149.25 67.5 172.5 90.75 172.5 120C172.5 149.25 149.25 172.5 120 172.5"
+            fill="white"
+          />
+          <path
+            d="M120 67.5C90.75 67.5 67.5 90.75 67.5 120C67.5 149.25 90.75 172.5 120 172.5"
+            fill="black"
+          />
+        </motion.g>
+        <motion.path
+          animate={{ rotate: isDark ? 180 : 0 }}
+          transition={{ ease: "easeInOut", duration: 0.5 }}
+          d="M120 3.75C55.5 3.75 3.75 55.5 3.75 120C3.75 184.5 55.5 236.25 120 236.25C184.5 236.25 236.25 184.5 236.25 120C236.25 55.5 184.5 3.75 120 3.75ZM120 214.5V172.5C90.75 172.5 67.5 149.25 67.5 120C67.5 90.75 90.75 67.5 120 67.5V25.5C172.5 25.5 214.5 67.5 214.5 120C214.5 172.5 172.5 214.5 120 214.5Z"
+          fill="white"
+        />
+      </svg>
+    </button>
+  );
+};
+
+// ///////////////////////////////////////////////////////////////////////////
+
+export type AnimationVariant =
+  | "circle"
+  | "rectangle"
+  | "gif"
+  | "polygon"
+  | "circle-blur";
+export type AnimationStart =
+  | "top-left"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-right"
+  | "center"
+  | "top-center"
+  | "bottom-center"
+  | "bottom-up"
+  | "top-down"
+  | "left-right"
+  | "right-left";
+
+interface Animation {
+  name: string;
+  css: string;
+}
+
+const getPositionCoords = (position: AnimationStart) => {
+  switch (position) {
+    case "top-left":
+      return { cx: "0", cy: "0" };
+    case "top-right":
+      return { cx: "40", cy: "0" };
+    case "bottom-left":
+      return { cx: "0", cy: "40" };
+    case "bottom-right":
+      return { cx: "40", cy: "40" };
+    case "top-center":
+      return { cx: "20", cy: "0" };
+    case "bottom-center":
+      return { cx: "20", cy: "40" };
+    // For directional positions, default to center (these are used for rectangle variant)
+    case "bottom-up":
+    case "top-down":
+    case "left-right":
+    case "right-left":
+      return { cx: "20", cy: "20" };
+  }
+};
+
+const generateSVG = (variant: AnimationVariant, start: AnimationStart) => {
+  // circle-blur variant handles center case differently, so check it first
+  if (variant === "circle-blur") {
+    if (start === "center") {
+      return `data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><defs><filter id="blur"><feGaussianBlur stdDeviation="2"/></filter></defs><circle cx="20" cy="20" r="18" fill="white" filter="url(%23blur)"/></svg>`;
+    }
+    const positionCoords = getPositionCoords(start);
+    if (!positionCoords) {
+      throw new Error(`Invalid start position: ${start}`);
+    }
+    const { cx, cy } = positionCoords;
+    return `data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><defs><filter id="blur"><feGaussianBlur stdDeviation="2"/></filter></defs><circle cx="${cx}" cy="${cy}" r="18" fill="white" filter="url(%23blur)"/></svg>`;
+  }
+
+  if (start === "center") return;
+
+  // Rectangle variant doesn't use SVG masks, so return early
+  if (variant === "rectangle") return "";
+
+  const positionCoords = getPositionCoords(start);
+  if (!positionCoords) {
+    throw new Error(`Invalid start position: ${start}`);
+  }
+  const { cx, cy } = positionCoords;
+
+  if (variant === "circle") {
+    return `data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><circle cx="${cx}" cy="${cy}" r="20" fill="white"/></svg>`;
+  }
+
+  return "";
+};
+
+const getTransformOrigin = (start: AnimationStart) => {
+  switch (start) {
+    case "top-left":
+      return "top left";
+    case "top-right":
+      return "top right";
+    case "bottom-left":
+      return "bottom left";
+    case "bottom-right":
+      return "bottom right";
+    case "top-center":
+      return "top center";
+    case "bottom-center":
+      return "bottom center";
+    // For directional positions, default to center
+    case "bottom-up":
+    case "top-down":
+    case "left-right":
+    case "right-left":
+      return "center";
+  }
+};
+
+export const createAnimation = (
+  variant: AnimationVariant,
+  start: AnimationStart = "center",
+  blur = false,
+  url?: string,
+): Animation => {
+  const svg = generateSVG(variant, start);
+  const transformOrigin = getTransformOrigin(start);
+
+  if (variant === "rectangle") {
+    const getClipPath = (direction: AnimationStart) => {
+      switch (direction) {
+        case "bottom-up":
+          return {
+            from: "polygon(0% 100%, 100% 100%, 100% 100%, 0% 100%)",
+            to: "polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%)",
+          };
+        case "top-down":
+          return {
+            from: "polygon(0% 0%, 100% 0%, 100% 0%, 0% 0%)",
+            to: "polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%)",
+          };
+        case "left-right":
+          return {
+            from: "polygon(0% 0%, 0% 0%, 0% 100%, 0% 100%)",
+            to: "polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%)",
+          };
+        case "right-left":
+          return {
+            from: "polygon(100% 0%, 100% 0%, 100% 100%, 100% 100%)",
+            to: "polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%)",
+          };
+        case "top-left":
+          return {
+            from: "polygon(0% 0%, 0% 0%, 0% 0%, 0% 0%)",
+            to: "polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%)",
+          };
+        case "top-right":
+          return {
+            from: "polygon(100% 0%, 100% 0%, 100% 0%, 100% 0%)",
+            to: "polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%)",
+          };
+        case "bottom-left":
+          return {
+            from: "polygon(0% 100%, 0% 100%, 0% 100%, 0% 100%)",
+            to: "polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%)",
+          };
+        case "bottom-right":
+          return {
+            from: "polygon(100% 100%, 100% 100%, 100% 100%, 100% 100%)",
+            to: "polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%)",
+          };
+        default:
+          return {
+            from: "polygon(0% 100%, 100% 100%, 100% 100%, 0% 100%)",
+            to: "polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%)",
+          };
+      }
+    };
+
+    const clipPath = getClipPath(start);
+
+    return {
+      name: `${variant}-${start}${blur ? "-blur" : ""}`,
+      css: `
+       ::view-transition-group(root) {
+        animation-duration: 0.7s;
+        animation-timing-function: var(--expo-out);
+      }
+            
+      ::view-transition-new(root) {
+        animation-name: reveal-light-${start}${blur ? "-blur" : ""};
+        ${blur ? "filter: blur(2px);" : ""}
+      }
+
+      ::view-transition-old(root),
+      .dark::view-transition-old(root) {
+        animation: none;
+        z-index: -1;
+      }
+      .dark::view-transition-new(root) {
+        animation-name: reveal-dark-${start}${blur ? "-blur" : ""};
+        ${blur ? "filter: blur(2px);" : ""}
+      }
+
+      @keyframes reveal-dark-${start}${blur ? "-blur" : ""} {
+        from {
+          clip-path: ${clipPath.from};
+          ${blur ? "filter: blur(8px);" : ""}
+        }
+        ${blur ? "50% { filter: blur(4px); }" : ""}
+        to {
+          clip-path: ${clipPath.to};
+          ${blur ? "filter: blur(0px);" : ""}
+        }
+      }
+
+      @keyframes reveal-light-${start}${blur ? "-blur" : ""} {
+        from {
+          clip-path: ${clipPath.from};
+          ${blur ? "filter: blur(8px);" : ""}
+        }
+        ${blur ? "50% { filter: blur(4px); }" : ""}
+        to {
+          clip-path: ${clipPath.to};
+          ${blur ? "filter: blur(0px);" : ""}
+        }
+      }
+      `,
+    };
+  }
+  if (variant === "circle" && start == "center") {
+    return {
+      name: `${variant}-${start}${blur ? "-blur" : ""}`,
+      css: `
+       ::view-transition-group(root) {
+        animation-duration: 0.7s;
+        animation-timing-function: var(--expo-out);
+      }
+            
+      ::view-transition-new(root) {
+        animation-name: reveal-light${blur ? "-blur" : ""};
+        ${blur ? "filter: blur(2px);" : ""}
+      }
+
+      ::view-transition-old(root),
+      .dark::view-transition-old(root) {
+        animation: none;
+        z-index: -1;
+      }
+      .dark::view-transition-new(root) {
+        animation-name: reveal-dark${blur ? "-blur" : ""};
+        ${blur ? "filter: blur(2px);" : ""}
+      }
+
+      @keyframes reveal-dark${blur ? "-blur" : ""} {
+        from {
+          clip-path: circle(0% at 50% 50%);
+          ${blur ? "filter: blur(8px);" : ""}
+        }
+        ${blur ? "50% { filter: blur(4px); }" : ""}
+        to {
+          clip-path: circle(100.0% at 50% 50%);
+          ${blur ? "filter: blur(0px);" : ""}
+        }
+      }
+
+      @keyframes reveal-light${blur ? "-blur" : ""} {
+        from {
+           clip-path: circle(0% at 50% 50%);
+           ${blur ? "filter: blur(8px);" : ""}
+        }
+        ${blur ? "50% { filter: blur(4px); }" : ""}
+        to {
+          clip-path: circle(100.0% at 50% 50%);
+          ${blur ? "filter: blur(0px);" : ""}
+        }
+      }
+      `,
+    };
+  }
+  if (variant === "gif") {
+    return {
+      name: `${variant}-${start}`,
+      css: `
+      ::view-transition-group(root) {
+  animation-timing-function: var(--expo-in);
+}
+
+::view-transition-new(root) {
+  mask: url('${url}') center / 0 no-repeat;
+  animation: scale 3s;
+}
+
+::view-transition-old(root),
+.dark::view-transition-old(root) {
+  animation: scale 3s;
+}
+
+@keyframes scale {
+  0% {
+    mask-size: 0;
+  }
+  10% {
+    mask-size: 50vmax;
+  }
+  90% {
+    mask-size: 50vmax;
+  }
+  100% {
+    mask-size: 2000vmax;
+  }
+}`,
+    };
+  }
+
+  if (variant === "circle-blur") {
+    if (start === "center") {
+      return {
+        name: `${variant}-${start}`,
+        css: `
+        ::view-transition-group(root) {
+          animation-timing-function: var(--expo-out);
+        }
+
+        ::view-transition-new(root) {
+          mask: url('${svg}') center / 0 no-repeat;
+          mask-origin: content-box;
+          animation: scale 1s;
+          transform-origin: center;
+        }
+
+        ::view-transition-old(root),
+        .dark::view-transition-old(root) {
+          animation: scale 1s;
+          transform-origin: center;
+          z-index: -1;
+        }
+
+        @keyframes scale {
+          to {
+            mask-size: 350vmax;
+          }
+        }
+        `,
+      };
+    }
+
+    return {
+      name: `${variant}-${start}`,
+      css: `
+      ::view-transition-group(root) {
+        animation-timing-function: var(--expo-out);
+      }
+
+      ::view-transition-new(root) {
+        mask: url('${svg}') ${start.replace("-", " ")} / 0 no-repeat;
+        mask-origin: content-box;
+        animation: scale 1s;
+        transform-origin: ${transformOrigin};
+      }
+
+      ::view-transition-old(root),
+      .dark::view-transition-old(root) {
+        animation: scale 1s;
+        transform-origin: ${transformOrigin};
+        z-index: -1;
+      }
+
+      @keyframes scale {
+        to {
+          mask-size: 350vmax;
+        }
+      }
+      `,
+    };
+  }
+
+  if (variant === "polygon") {
+    const getPolygonClipPaths = (position: AnimationStart) => {
+      switch (position) {
+        case "top-left":
+          return {
+            darkFrom: "polygon(50% -71%, -50% 71%, -50% 71%, 50% -71%)",
+            darkTo: "polygon(50% -71%, -50% 71%, 50% 171%, 171% 50%)",
+            lightFrom: "polygon(171% 50%, 50% 171%, 50% 171%, 171% 50%)",
+            lightTo: "polygon(171% 50%, 50% 171%, -50% 71%, 50% -71%)",
+          };
+        case "top-right":
+          return {
+            darkFrom: "polygon(150% -71%, 250% 71%, 250% 71%, 150% -71%)",
+            darkTo: "polygon(150% -71%, 250% 71%, 50% 171%, -71% 50%)",
+            lightFrom: "polygon(-71% 50%, 50% 171%, 50% 171%, -71% 50%)",
+            lightTo: "polygon(-71% 50%, 50% 171%, 250% 71%, 150% -71%)",
+          };
+        default:
+          // Default to top-left behavior
+          return {
+            darkFrom: "polygon(50% -71%, -50% 71%, -50% 71%, 50% -71%)",
+            darkTo: "polygon(50% -71%, -50% 71%, 50% 171%, 171% 50%)",
+            lightFrom: "polygon(171% 50%, 50% 171%, 50% 171%, 171% 50%)",
+            lightTo: "polygon(171% 50%, 50% 171%, -50% 71%, 50% -71%)",
+          };
+      }
+    };
+
+    const clipPaths = getPolygonClipPaths(start);
+
+    return {
+      name: `${variant}-${start}${blur ? "-blur" : ""}`,
+      css: `
+      ::view-transition-group(root) {
+        animation-duration: 0.7s;
+        animation-timing-function: var(--expo-out);
+      }
+            
+      ::view-transition-new(root) {
+        animation-name: reveal-light-${start}${blur ? "-blur" : ""};
+        ${blur ? "filter: blur(2px);" : ""}
+      }
+
+      ::view-transition-old(root),
+      .dark::view-transition-old(root) {
+        animation: none;
+        z-index: -1;
+      }
+      .dark::view-transition-new(root) {
+        animation-name: reveal-dark-${start}${blur ? "-blur" : ""};
+        ${blur ? "filter: blur(2px);" : ""}
+      }
+
+      @keyframes reveal-dark-${start}${blur ? "-blur" : ""} {
+        from {
+          clip-path: ${clipPaths.darkFrom};
+          ${blur ? "filter: blur(8px);" : ""}
+        }
+        ${blur ? "50% { filter: blur(4px); }" : ""}
+        to {
+          clip-path: ${clipPaths.darkTo};
+          ${blur ? "filter: blur(0px);" : ""}
+        }
+      }
+
+      @keyframes reveal-light-${start}${blur ? "-blur" : ""} {
+        from {
+          clip-path: ${clipPaths.lightFrom};
+          ${blur ? "filter: blur(8px);" : ""}
+        }
+        ${blur ? "50% { filter: blur(4px); }" : ""}
+        to {
+          clip-path: ${clipPaths.lightTo};
+          ${blur ? "filter: blur(0px);" : ""}
+        }
+      }
+      `,
+    };
+  }
+
+  // Handle circle variants with start positions using clip-path
+  if (variant === "circle" && start !== "center") {
+    const getClipPathPosition = (position: AnimationStart) => {
+      switch (position) {
+        case "top-left":
+          return "0% 0%";
+        case "top-right":
+          return "100% 0%";
+        case "bottom-left":
+          return "0% 100%";
+        case "bottom-right":
+          return "100% 100%";
+        case "top-center":
+          return "50% 0%";
+        case "bottom-center":
+          return "50% 100%";
+        default:
+          return "50% 50%";
+      }
+    };
+
+    const clipPosition = getClipPathPosition(start);
+
+    return {
+      name: `${variant}-${start}${blur ? "-blur" : ""}`,
+      css: `
+       ::view-transition-group(root) {
+        animation-duration: 1s;
+        animation-timing-function: var(--expo-out);
+      }
+            
+      ::view-transition-new(root) {
+        animation-name: reveal-light-${start}${blur ? "-blur" : ""};
+        ${blur ? "filter: blur(2px);" : ""}
+      }
+
+      ::view-transition-old(root),
+      .dark::view-transition-old(root) {
+        animation: none;
+        z-index: -1;
+      }
+      .dark::view-transition-new(root) {
+        animation-name: reveal-dark-${start}${blur ? "-blur" : ""};
+        ${blur ? "filter: blur(2px);" : ""}
+      }
+
+      @keyframes reveal-dark-${start}${blur ? "-blur" : ""} {
+        from {
+          clip-path: circle(0% at ${clipPosition});
+          ${blur ? "filter: blur(8px);" : ""}
+        }
+        ${blur ? "50% { filter: blur(4px); }" : ""}
+        to {
+          clip-path: circle(150.0% at ${clipPosition});
+          ${blur ? "filter: blur(0px);" : ""}
+        }
+      }
+
+      @keyframes reveal-light-${start}${blur ? "-blur" : ""} {
+        from {
+           clip-path: circle(0% at ${clipPosition});
+           ${blur ? "filter: blur(8px);" : ""}
+        }
+        ${blur ? "50% { filter: blur(4px); }" : ""}
+        to {
+          clip-path: circle(150.0% at ${clipPosition});
+          ${blur ? "filter: blur(0px);" : ""}
+        }
+      }
+      `,
+    };
+  }
+
+  return {
+    name: `${variant}-${start}${blur ? "-blur" : ""}`,
+    css: `
+      ::view-transition-group(root) {
+        animation-timing-function: var(--expo-in);
+      }
+      ::view-transition-new(root) {
+        mask: url('${svg}') ${start.replace("-", " ")} / 0 no-repeat;
+        mask-origin: content-box;
+        animation: scale-${start}${blur ? "-blur" : ""} 1s;
+        transform-origin: ${transformOrigin};
+        ${blur ? "filter: blur(2px);" : ""}
+      }
+      ::view-transition-old(root),
+      .dark::view-transition-old(root) {
+        animation: scale-${start}${blur ? "-blur" : ""} 1s;
+        transform-origin: ${transformOrigin};
+        z-index: -1;
+      }
+      @keyframes scale-${start}${blur ? "-blur" : ""} {
+        from {
+          ${blur ? "filter: blur(8px);" : ""}
+        }
+        ${blur ? "50% { filter: blur(4px); }" : ""}
+        to {
+          mask-size: 2000vmax;
+          ${blur ? "filter: blur(0px);" : ""}
+        }
+      }
+    `,
+  };
+};
+
+/**
+ * Skiper 26 Theme_buttons_002 — React + CSS + transition view api  https://developer.chrome.com/docs/web-platform/view-transitions/
+ * Orignal concept from rudrodip
+ * Inspired by from https://github.com/rudrodip/theme-toggle-effect
+ * We respect the original creators. This is an inspired rebuild with our own taste and does not claim any ownership.
+ * These animations aren’t associated with the rudrodip . They’re independent recreations meant to study interaction design
+ *
+ * License & Usage:
+ * - Free to use and modify in both personal and commercial projects.
+ * - Attribution to Skiper UI is required when using the free version.
+ * - No attribution required with Skiper UI Pro.
+ *
+ * Feedback and contributions are welcome.
+ *
+ * Author: @gurvinder-singh02
+ * Website: https://gxuri.me
+ * Twitter: https://x.com/Gur__vi
+ */

--- a/workers/jb-dexos/src/components/ui/skiper-ui/skiper4.tsx
+++ b/workers/jb-dexos/src/components/ui/skiper-ui/skiper4.tsx
@@ -1,0 +1,429 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { GripHorizontal, RefreshCcw } from "lucide-react";
+import React, { useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+const Skiper4 = () => {
+  const [scale, setScale] = useState(0);
+  const [gap, setGap] = useState(0);
+  const [flexDirection, setFlexDirection] = useState("row");
+
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-5">
+      <motion.div
+        className="relative flex items-center justify-center gap-1"
+        animate={{
+          gap: gap ? `${gap}px` : "4px",
+          scale: scale ? `${scale / 20}` : "1",
+        }}
+        style={{
+          flexDirection: flexDirection === "column" ? "column" : "row",
+        }}
+        transition={{ duration: 0.35 }}
+      >
+        <motion.div layout>
+          <ThemeToggleButton1 className={cn("size-12")} />
+        </motion.div>
+        <motion.div layout>
+          <ThemeToggleButton2 className={cn("size-12 p-2")} />
+        </motion.div>
+        <motion.div layout>
+          <ThemeToggleButton3 className={cn("size-12 p-2")} />
+        </motion.div>
+        <motion.div layout>
+          <ThemeToggleButton4 className={cn("size-12 p-2")} />
+        </motion.div>
+        <motion.div layout>
+          <ThemeToggleButton5 className={cn("size-12 p-3")} />
+        </motion.div>
+      </motion.div>
+
+      {/* options */}
+      <Options
+        scale={scale}
+        setScale={setScale}
+        gap={gap}
+        setGap={setGap}
+        setFlexDirection={setFlexDirection}
+      />
+    </div>
+  );
+};
+
+export { Skiper4 };
+
+type OptionsProps = {
+  scale: number;
+  setScale: (value: number) => void;
+  gap: number;
+  setGap: (value: number) => void;
+  setFlexDirection: (value: string) => void;
+};
+
+const Options = ({
+  scale,
+  setScale,
+  gap,
+  setGap,
+  setFlexDirection,
+}: OptionsProps) => {
+  const [isDragging, setIsDragging] = useState(false);
+
+  return (
+    <motion.div
+      className="top-30 border-foreground/10 bg-muted2 absolute right-1/2 flex w-[245px] translate-x-1/2 flex-col gap-3 rounded-3xl border p-3 backdrop-blur-sm lg:right-4 lg:translate-x-0"
+      drag={isDragging}
+      dragMomentum={false}
+    >
+      <div className="flex items-center justify-between">
+        <span
+          onPointerDown={() => setIsDragging(true)}
+          onPointerUp={() => setIsDragging(false)}
+          className="size-4 cursor-grab active:cursor-grabbing"
+        >
+          <GripHorizontal className="size-4 opacity-50" />
+        </span>
+
+        <p
+          onClick={() => {
+            setScale(0);
+            setGap(0);
+            setFlexDirection("row");
+          }}
+          className="hover:bg-foreground/10 group flex cursor-pointer items-center justify-center gap-2 rounded-lg px-2 py-1 text-sm opacity-50"
+        >
+          Options
+          <span className="group-active:-rotate-360 rotate-0 cursor-pointer transition-all duration-300 group-hover:rotate-90">
+            <RefreshCcw className="size-4 opacity-50" />
+          </span>{" "}
+        </p>
+      </div>
+
+      <div className="flex flex-col">
+        <div className="flex items-center justify-between py-1">
+          <p className="text-sm opacity-50">Scale </p>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            value={scale}
+            onChange={(e) => setScale(Number(e.target.value))}
+            className="bg-muted [&::-webkit-slider-runnable-track]:to-background [&::-webkit-slider-thumb]:bg-muted-foreground h-1.5 w-[150px] cursor-pointer appearance-none overflow-clip rounded-lg [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:appearance-none [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-white [&::-moz-range-track]:bg-gradient-to-r [&::-moz-range-track]:from-blue-500 [&::-moz-range-track]:to-[#4F4F4E] [&::-moz-range-track]:bg-[length:var(--range-progress)_100%] [&::-moz-range-track]:bg-no-repeat [&::-webkit-slider-runnable-track]:bg-gradient-to-r [&::-webkit-slider-runnable-track]:from-blue-500 [&::-webkit-slider-runnable-track]:bg-[length:var(--range-progress)_100%] [&::-webkit-slider-runnable-track]:bg-no-repeat [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full"
+            style={{ "--range-progress": `${scale}%` } as React.CSSProperties}
+          />
+        </div>
+        <div className="flex items-center justify-between py-1">
+          <p className="text-sm opacity-50">Gap </p>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            value={gap}
+            onChange={(e) => setGap(Number(e.target.value))}
+            className="bg-muted [&::-webkit-slider-runnable-track]:to-background [&::-webkit-slider-thumb]:bg-muted-foreground h-1.5 w-[150px] cursor-pointer appearance-none overflow-clip rounded-lg [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:appearance-none [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-white [&::-moz-range-track]:bg-gradient-to-r [&::-moz-range-track]:from-blue-500 [&::-moz-range-track]:to-[#4F4F4E] [&::-moz-range-track]:bg-[length:var(--range-progress)_100%] [&::-moz-range-track]:bg-no-repeat [&::-webkit-slider-runnable-track]:bg-gradient-to-r [&::-webkit-slider-runnable-track]:from-blue-500 [&::-webkit-slider-runnable-track]:bg-[length:var(--range-progress)_100%] [&::-webkit-slider-runnable-track]:bg-no-repeat [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full"
+            style={{ "--range-progress": `${gap}%` } as React.CSSProperties}
+          />
+        </div>
+
+        <div className="mt-1 flex items-center justify-between py-1">
+          <p className="text-sm opacity-50">Flex </p>
+          <div className="flex items-center justify-end gap-2">
+            <button
+              className="cursor-pointer text-sm opacity-50 hover:opacity-100"
+              onClick={() => setFlexDirection("column")}
+            >
+              coloumn
+            </button>
+            <button
+              className="cursor-pointer text-sm opacity-50 hover:opacity-100"
+              onClick={() => setFlexDirection("row")}
+            >
+              Row
+            </button>
+          </div>
+        </div>
+      </div>
+    </motion.div>
+  );
+};
+
+//..................................................... //
+
+export const ThemeToggleButton1 = ({
+  className = "",
+}: {
+  className?: string;
+}) => {
+  const [isDark, setIsDark] = useState(false);
+  return (
+    <button
+      type="button"
+      className={cn(
+        "rounded-full bg-black text-white transition-all duration-300 active:scale-95",
+        className,
+      )}
+      onClick={() => setIsDark(!isDark)}
+    >
+      <svg viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <motion.g
+          animate={{ rotate: isDark ? -180 : 0 }}
+          transition={{ ease: "easeInOut", duration: 0.35 }}
+        >
+          <path
+            d="M120 67.5C149.25 67.5 172.5 90.75 172.5 120C172.5 149.25 149.25 172.5 120 172.5"
+            fill="white"
+          />
+          <path
+            d="M120 67.5C90.75 67.5 67.5 90.75 67.5 120C67.5 149.25 90.75 172.5 120 172.5"
+            fill="black"
+          />
+        </motion.g>
+        <motion.path
+          animate={{ rotate: isDark ? 180 : 0 }}
+          transition={{ ease: "easeInOut", duration: 0.35 }}
+          d="M120 3.75C55.5 3.75 3.75 55.5 3.75 120C3.75 184.5 55.5 236.25 120 236.25C184.5 236.25 236.25 184.5 236.25 120C236.25 55.5 184.5 3.75 120 3.75ZM120 214.5V172.5C90.75 172.5 67.5 149.25 67.5 120C67.5 90.75 90.75 67.5 120 67.5V25.5C172.5 25.5 214.5 67.5 214.5 120C214.5 172.5 172.5 214.5 120 214.5Z"
+          fill="white"
+        />
+      </svg>
+    </button>
+  );
+};
+
+//..................................................... //
+export const ThemeToggleButton2 = ({
+  className = "",
+}: {
+  className?: string;
+}) => {
+  const [isDark, setIsDark] = useState(false);
+  return (
+    <button
+      type="button"
+      className={cn(
+        "rounded-full transition-all duration-300 active:scale-95",
+        isDark ? "bg-black text-white" : "bg-white text-black",
+        className,
+      )}
+      onClick={() => setIsDark(!isDark)}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+        fill="currentColor"
+        strokeLinecap="round"
+        viewBox="0 0 32 32"
+      >
+        <clipPath id="skiper-btn-2">
+          <motion.path
+            animate={{ y: isDark ? 10 : 0, x: isDark ? -12 : 0 }}
+            transition={{ ease: "easeInOut", duration: 0.35 }}
+            d="M0-5h30a1 1 0 0 0 9 13v24H0Z"
+          />
+        </clipPath>
+        <g clipPath="url(#skiper-btn-2)">
+          <motion.circle
+            animate={{ r: isDark ? 10 : 8 }}
+            transition={{ ease: "easeInOut", duration: 0.35 }}
+            cx="16"
+            cy="16"
+          />
+          <motion.g
+            animate={{
+              rotate: isDark ? -100 : 0,
+              scale: isDark ? 0.5 : 1,
+              opacity: isDark ? 0 : 1,
+            }}
+            transition={{ ease: "easeInOut", duration: 0.35 }}
+            stroke="currentColor"
+            strokeWidth="1.5"
+          >
+            <path d="M16 5.5v-4" />
+            <path d="M16 30.5v-4" />
+            <path d="M1.5 16h4" />
+            <path d="M26.5 16h4" />
+            <path d="m23.4 8.6 2.8-2.8" />
+            <path d="m5.7 26.3 2.9-2.9" />
+            <path d="m5.8 5.8 2.8 2.8" />
+            <path d="m23.4 23.4 2.9 2.9" />
+          </motion.g>
+        </g>
+      </svg>
+    </button>
+  );
+};
+
+//..................................................... //
+export const ThemeToggleButton3 = ({
+  className = "",
+}: {
+  className?: string;
+}) => {
+  const [isDark, setIsDark] = useState(false);
+  return (
+    <button
+      type="button"
+      className={cn(
+        "rounded-full transition-all duration-300 active:scale-95",
+        isDark ? "bg-black text-white" : "bg-white text-black",
+        className,
+      )}
+      onClick={() => setIsDark(!isDark)}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+        fill="currentColor"
+        strokeLinecap="round"
+        viewBox="0 0 32 32"
+      >
+        <clipPath id="skiper-btn-3">
+          <motion.path
+            animate={{ y: isDark ? 14 : 0, x: isDark ? -11 : 0 }}
+            transition={{ ease: "easeInOut", duration: 0.35 }}
+            d="M0-11h25a1 1 0 0017 13v30H0Z"
+          />
+        </clipPath>
+        <g clipPath="url(#skiper-btn-3)">
+          <motion.circle
+            animate={{ r: isDark ? 10 : 8 }}
+            transition={{ ease: "easeInOut", duration: 0.35 }}
+            cx="16"
+            cy="16"
+          />
+          <motion.g
+            animate={{
+              scale: isDark ? 0.5 : 1,
+              opacity: isDark ? 0 : 1,
+            }}
+            transition={{ ease: "easeInOut", duration: 0.35 }}
+            stroke="currentColor"
+            strokeWidth="1.5"
+          >
+            <path d="M18.3 3.2c0 1.3-1 2.3-2.3 2.3s-2.3-1-2.3-2.3S14.7.9 16 .9s2.3 1 2.3 2.3zm-4.6 25.6c0-1.3 1-2.3 2.3-2.3s2.3 1 2.3 2.3-1 2.3-2.3 2.3-2.3-1-2.3-2.3zm15.1-10.5c-1.3 0-2.3-1-2.3-2.3s1-2.3 2.3-2.3 2.3 1 2.3 2.3-1 2.3-2.3 2.3zM3.2 13.7c1.3 0 2.3 1 2.3 2.3s-1 2.3-2.3 2.3S.9 17.3.9 16s1-2.3 2.3-2.3zm5.8-7C9 7.9 7.9 9 6.7 9S4.4 8 4.4 6.7s1-2.3 2.3-2.3S9 5.4 9 6.7zm16.3 21c-1.3 0-2.3-1-2.3-2.3s1-2.3 2.3-2.3 2.3 1 2.3 2.3-1 2.3-2.3 2.3zm2.4-21c0 1.3-1 2.3-2.3 2.3S23 7.9 23 6.7s1-2.3 2.3-2.3 2.4 1 2.4 2.3zM6.7 23C8 23 9 24 9 25.3s-1 2.3-2.3 2.3-2.3-1-2.3-2.3 1-2.3 2.3-2.3z" />
+          </motion.g>
+        </g>
+      </svg>
+    </button>
+  );
+};
+
+//..................................................... //
+export const ThemeToggleButton4 = ({
+  className = "",
+}: {
+  className?: string;
+}) => {
+  const [isDark, setIsDark] = useState(false);
+  return (
+    <button
+      type="button"
+      className={cn(
+        "rounded-full transition-all duration-300 active:scale-95",
+        isDark ? "bg-black text-white" : "bg-white text-black",
+        className,
+      )}
+      onClick={() => setIsDark(!isDark)}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+        strokeWidth="0.7"
+        stroke="currentColor"
+        fill="currentColor"
+        strokeLinecap="round"
+        viewBox="0 0 32 32"
+      >
+        <path
+          strokeWidth="0"
+          d="M9.4 9.9c1.8-1.8 4.1-2.7 6.6-2.7 5.1 0 9.3 4.2 9.3 9.3 0 2.3-.8 4.4-2.3 6.1-.7.8-2 2.8-2.5 4.4 0 .2-.2.4-.5.4-.2 0-.4-.2-.4-.5v-.1c.5-1.8 2-3.9 2.7-4.8 1.4-1.5 2.1-3.5 2.1-5.6 0-4.7-3.7-8.5-8.4-8.5-2.3 0-4.4.9-5.9 2.5-1.6 1.6-2.5 3.7-2.5 6 0 2.1.7 4 2.1 5.6.8.9 2.2 2.9 2.7 4.9 0 .2-.1.5-.4.5h-.1c-.2 0-.4-.1-.4-.4-.5-1.7-1.8-3.7-2.5-4.5-1.5-1.7-2.3-3.9-2.3-6.1 0-2.3 1-4.7 2.7-6.5z"
+        />
+        <path d="M19.8 28.3h-7.6" />
+        <path d="M19.8 29.5h-7.6" />
+        <path d="M19.8 30.7h-7.6" />
+        <motion.path
+          animate={{
+            pathLength: isDark ? 0 : 1,
+            opacity: isDark ? 0 : 1,
+          }}
+          transition={{ ease: "easeInOut", duration: 0.35 }}
+          pathLength="1"
+          fill="none"
+          d="M14.6 27.1c0-3.4 0-6.8-.1-10.2-.2-1-1.1-1.7-2-1.7-1.2-.1-2.3 1-2.2 2.3.1 1 .9 1.9 2.1 2h7.2c1.1-.1 2-1 2.1-2 .1-1.2-1-2.3-2.2-2.3-.9 0-1.7.7-2 1.7 0 3.4 0 6.8-.1 10.2"
+        />
+        <motion.g
+          animate={{
+            scale: isDark ? 0.5 : 1,
+            opacity: isDark ? 0 : 1,
+          }}
+          transition={{ ease: "easeInOut", duration: 0.35 }}
+        >
+          <path pathLength="1" d="M16 6.4V1.3" />
+          <path pathLength="1" d="M26.3 15.8h5.1" />
+          <path pathLength="1" d="m22.6 9 3.7-3.6" />
+          <path pathLength="1" d="M9.4 9 5.7 5.4" />
+          <path pathLength="1" d="M5.7 15.8H.6" />
+        </motion.g>
+      </svg>
+    </button>
+  );
+};
+
+//..................................................... //
+export const ThemeToggleButton5 = ({
+  className = "",
+}: {
+  className?: string;
+}) => {
+  const [isDark, setIsDark] = useState(false);
+  return (
+    <button
+      type="button"
+      className={cn(
+        "rounded-full transition-all duration-300 active:scale-95",
+        isDark ? "bg-black text-white" : "bg-white text-black",
+        className,
+      )}
+      onClick={() => setIsDark(!isDark)}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+        fill="currentColor"
+        viewBox="0 0 32 32"
+      >
+        <clipPath id="skiper-btn-4">
+          <motion.path
+            animate={{ y: isDark ? 5 : 0, x: isDark ? -20 : 0 }}
+            transition={{ ease: "easeInOut", duration: 0.35 }}
+            d="M0-5h55v37h-55zm32 12a1 1 0 0025 0 1 1 0 00-25 0"
+          />
+        </clipPath>
+        <g clipPath="url(#skiper-btn-4)">
+          <circle cx="16" cy="16" r="15" />
+        </g>
+      </svg>
+    </button>
+  );
+};
+
+/**
+ * Theme Toggle Animations — React + Framer Motion Recreation
+ * Inspired by and adapted from https://toggles.dev/ (Open Source CSS Theme Toggles by Alfie Jones)
+ * This implementation is rebuilt in React and Framer Motion, avoiding external toggle packages.
+ *
+ * Attribution: https://toggles.dev/
+ *
+ * License & Usage:
+ * - Free to use and modify in both personal and commercial projects.
+ * - Attribution to Skiper UI is required when using the free version.
+ * - No attribution required with Skiper UI Pro.
+ *
+ * Feedback and contributions are welcome.
+ *
+ * Author: @gurvinder-singh02
+ * Website: https://gxuri.me
+ * Twitter: https://x.com/Gur__vi
+ */

--- a/workers/jb-dexos/src/content/memo.md
+++ b/workers/jb-dexos/src/content/memo.md
@@ -53,5 +53,6 @@ We are especially interested in speaking with:
 * **Circle** for native stablecoin settlement
 * **DoubleZero** for primary open-fiber networking
 * **Jump Trading** for liquidity provision
+* **Chainalysis** for compliance and on-chain analytics
 
 Early partners can help shape the foundation layer of 24/7 global markets and secure a leadership position as this infrastructure matures.


### PR DESCRIPTION
## Summary

A batch of theme/UX changes to the DEXos memo:

- **Warm editorial palette** — cream paper + ink-brown in light mode, warm charcoal + warm off-white in dark mode (all surfaces/borders/accents retuned to warm amber hues). Memo prose switched to `prose-stone`.
- **New theme toggle** — the `@skiper-ui/skiper4` circular sun/moon button, wired to `next-themes` via `@skiper-ui/skiper26`'s `useThemeToggle` so switching plays a **full-page circle-blur reveal** transition (View Transitions API; `variant: circle`, `blur: on`). Falls back to an instant switch where the API is unavailable.
- **Default appearance** stays `system` (new visitors follow their OS).
- **Footer** type shrunk one step (name `xl`, role/companies `base`).
- **Ask list** — added **Chainalysis** (compliance and on-chain analytics).

Adds `framer-motion`; components pulled via shadcn from the `@skiper-ui` registry (no pnpm-lock, deps installed with bun).

## Verification

- `bun run build` — compiles, `/` still statically prerendered.
- `opennextjs-cloudflare preview` (**workerd**) — HTTP 200, toggle + content present.
- In-browser — toggle switches theme with the circle transition; light + dark both render correctly.

## Note

`skiper4.tsx` is a 5-button demo; its circular sun/moon design is embedded in the wired `theme-toggle.tsx`. The file is kept as the registry source but isn't imported into the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)