### PR TITLE
feat(jb-dexos): dynamic Open Graph image at /api/og

### DIFF
--- a/workers/jb-dexos/src/app/api/og/route.tsx
+++ b/workers/jb-dexos/src/app/api/og/route.tsx
@@ -1,0 +1,66 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "nodejs";
+
+// Dynamic Open Graph image for DEXos — https://vercel.com/docs/og-image-generation
+export async function GET() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          background: "#0a0a0a",
+          color: "#faf6ee",
+          padding: "80px",
+          fontFamily: "sans-serif",
+        }}
+      >
+        <div
+          style={{
+            fontSize: 40,
+            fontWeight: 700,
+            letterSpacing: "0.3em",
+            textTransform: "uppercase",
+            color: "#b8ad99",
+          }}
+        >
+          DEXos
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
+          <div
+            style={{
+              fontSize: 76,
+              fontWeight: 800,
+              lineHeight: 1.05,
+              letterSpacing: "-0.02em",
+            }}
+          >
+            A 24/7 Global Trading Operating System
+          </div>
+          <div style={{ fontSize: 34, color: "#b8ad99", fontWeight: 600 }}>
+            The next evolution in capital-market infrastructure
+          </div>
+        </div>
+        <div style={{ display: "flex", gap: 48, fontSize: 28 }}>
+          <div style={{ display: "flex", flexDirection: "column" }}>
+            <span style={{ fontWeight: 800, fontSize: 40 }}>188.6M</span>
+            <span style={{ color: "#b8ad99" }}>orders/s per link</span>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column" }}>
+            <span style={{ fontWeight: 800, fontSize: 40 }}>16</span>
+            <span style={{ color: "#b8ad99" }}>global validators</span>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column" }}>
+            <span style={{ fontWeight: 800, fontSize: 40 }}>24/7</span>
+            <span style={{ color: "#b8ad99" }}>continuous markets</span>
+          </div>
+        </div>
+      </div>
+    ),
+    { width: 1200, height: 630 },
+  );
+}

--- a/workers/jb-dexos/src/app/layout.tsx
+++ b/workers/jb-dexos/src/app/layout.tsx
@@ -9,10 +9,28 @@ const nunito = Nunito({
   display: "swap",
 });
 
+const title = "DEXos — A 24/7 Global Trading Operating System";
+const description =
+  "The next evolution of capital markets: a truly 24/7, globally decentralized, high-performance trading operating system.";
+
 export const metadata: Metadata = {
-  title: "DEXos — A 24/7 Global Trading Operating System",
-  description:
-    "The next evolution of capital markets: a truly 24/7, globally decentralized, high-performance trading operating system.",
+  metadataBase: new URL("https://dexos.joeblau.com"),
+  title,
+  description,
+  openGraph: {
+    title,
+    description,
+    url: "https://dexos.joeblau.com",
+    siteName: "DEXos",
+    type: "website",
+    images: [{ url: "/api/og", width: 1200, height: 630, alt: "DEXos" }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title,
+    description,
+    images: ["/api/og"],
+  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## Summary

Adds a dynamic Open Graph / Twitter card image for DEXos, per [Vercel's OG image generation](https://vercel.com/docs/og-image-generation).

- **`/api/og`** — a `next/og` `ImageResponse` route rendering a 1200×630 preview (DEXos title, "next evolution in capital-market infrastructure", and three stats: 188.6M orders/s, 16 validators, 24/7) in the warm/dark brand style.
- **Metadata** — wired into `layout.tsx` `openGraph` + `twitter` with `metadataBase` so the image resolves to an absolute URL.

## Cloudflare note

The **edge runtime breaks the OpenNext Cloudflare build** (`route cannot use the edge runtime`). The route uses **`runtime = "nodejs"`**, which OpenNext supports and which renders correctly on workerd.

## Verification

- `opennextjs-cloudflare build` succeeds.
- **workerd preview:** `/api/og` returns **HTTP 200, `image/png`, 1200×630** (51 KB); the home page emits `og:image`/`twitter:image` pointing at `https://dexos.joeblau.com/api/og`.
- Rendered PNG visually checked — title, subtitle, and stats all correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)