### PR TITLE
feat(swap): whole-card hover tint and full-area denomination tap target

### DIFF
--- a/packages/unified-ui/src/components/swap-from.tsx
+++ b/packages/unified-ui/src/components/swap-from.tsx
@@ -6,6 +6,7 @@ import type { ReactNode } from "react";
 import type { Mode } from "../types";
 import { cn } from "../lib/utils";
 import { CryptoAddress } from "./crypto-address";
+import { HapticButton } from "./haptic-button";
 import {
 	AMOUNT_FIELD_TRANSITION,
 	AmountInput,
@@ -62,9 +63,15 @@ export function SwapFrom({
 	const height = box.height ?? undefined;
 
 	return (
-		<section className="rounded-3xl bg-card px-4 pb-3 pt-4">
+		<section className="group relative rounded-3xl bg-card px-4 pb-3 pt-4">
+			{/* Whole-card hover tint: the picker and amount are separate controls,
+			    but the seamless card highlights as one unit. Don't add your own
+			    hover background to the picker trigger. */}
+			<div
+				aria-hidden
+				className="pointer-events-none absolute inset-0 rounded-3xl transition-colors group-hover:bg-foreground/[0.03]"
+			/>
 			{picker}
-			<div className="-mx-4 border-t-2 border-background" />
 			<div
 				className={cn("flex flex-col justify-center", AMOUNT_FIELD_TRANSITION)}
 				style={{ height }}
@@ -79,17 +86,32 @@ export function SwapFrom({
 							renderQr={renderQr}
 						/>
 					) : (
-						<div className="flex flex-col items-center gap-2 p-2">
-							<AmountInput
-								value={amount}
-								prefix={mode === "usd" ? "$" : undefined}
-								ariaLabel={amountAriaLabel}
-							/>
-							<Pill onClick={onToggleMode}>
-								<span className="opacity-50">=</span>{" "}
-								<ConversionValue mode={mode} usd={usd} units={units} symbol={symbol ?? ""} />
-								<ArrowUpDown className="size-3.5" />
-							</Pill>
+						<div className="relative">
+							{/* Full-area tap target behind a pass-through content layer:
+							    tapping anywhere on the amount flips the denomination. The
+							    Pill stays the accessible control, so this is a11y-hidden. */}
+							<div className="absolute inset-0">
+								<HapticButton
+									type="button"
+									onClick={onToggleMode}
+									tabIndex={-1}
+									aria-hidden
+									wrapperClassName="grid size-full"
+									className="size-full cursor-pointer"
+								/>
+							</div>
+							<div className="pointer-events-none relative flex flex-col items-center gap-2 p-2">
+								<AmountInput
+									value={amount}
+									prefix={mode === "usd" ? "$" : undefined}
+									ariaLabel={amountAriaLabel}
+								/>
+								<Pill onClick={onToggleMode}>
+									<span className="opacity-50">=</span>{" "}
+									<ConversionValue mode={mode} usd={usd} units={units} symbol={symbol ?? ""} />
+									<ArrowUpDown className="size-3.5" />
+								</Pill>
+							</div>
 						</div>
 					)}
 				</div>

--- a/packages/unified-ui/src/components/swap-to.tsx
+++ b/packages/unified-ui/src/components/swap-to.tsx
@@ -4,6 +4,7 @@ import { ArrowUpDown } from "lucide-react";
 import type { ReactNode } from "react";
 
 import type { Mode } from "../types";
+import { HapticButton } from "./haptic-button";
 import {
 	AMOUNT_FIELD_TRANSITION,
 	AmountInput,
@@ -49,23 +50,44 @@ export function SwapTo({
 	const height = box.height == null ? undefined : collapsed ? 0 : box.height;
 
 	return (
-		<section className="rounded-3xl bg-card px-4 pb-0 pt-6">
+		<section className="group relative rounded-3xl bg-card px-4 pb-0 pt-6">
+			{/* Whole-card hover tint: the picker and amount are separate controls,
+			    but the seamless card highlights as one unit. Don't add your own
+			    hover background to the picker trigger. */}
+			<div
+				aria-hidden
+				className="pointer-events-none absolute inset-0 rounded-3xl transition-colors group-hover:bg-foreground/[0.03]"
+			/>
 			{picker}
 			<div className={AMOUNT_FIELD_TRANSITION} style={{ height }}>
 				<div ref={box.ref}>
-					<div className="-mx-4 border-t-2 border-background" />
-					<div className="flex flex-col items-center gap-2 p-2">
-						<AmountInput
-							value={trim(mode === "token" ? amount : usd)}
-							prefix={mode === "usd" ? "$" : undefined}
-							muted
-							ariaLabel={amountAriaLabel}
-						/>
-						<Pill onClick={onToggleMode}>
-							<span className="opacity-50">=</span>{" "}
-							<ConversionValue mode={mode} usd={usd} units={amount} symbol={symbol ?? ""} />
-							<ArrowUpDown className="size-3.5" />
-						</Pill>
+					<div className="relative">
+						{/* Full-area tap target behind a pass-through content layer:
+						    tapping anywhere on the amount flips the denomination. The
+						    Pill stays the accessible control, so this is a11y-hidden. */}
+						<div className="absolute inset-0">
+							<HapticButton
+								type="button"
+								onClick={onToggleMode}
+								tabIndex={-1}
+								aria-hidden
+								wrapperClassName="grid size-full"
+								className="size-full cursor-pointer"
+							/>
+						</div>
+						<div className="pointer-events-none relative flex flex-col items-center gap-2 p-2">
+							<AmountInput
+								value={trim(mode === "token" ? amount : usd)}
+								prefix={mode === "usd" ? "$" : undefined}
+								muted
+								ariaLabel={amountAriaLabel}
+							/>
+							<Pill onClick={onToggleMode}>
+								<span className="opacity-50">=</span>{" "}
+								<ConversionValue mode={mode} usd={usd} units={amount} symbol={symbol ?? ""} />
+								<ArrowUpDown className="size-3.5" />
+							</Pill>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/workers/jb-swap/src/components/swap-from.tsx
+++ b/workers/jb-swap/src/components/swap-from.tsx
@@ -3,6 +3,7 @@
 import { ArrowUpDown } from "lucide-react";
 
 import { CryptoAddress } from "@/components/crypto-address";
+import { HapticButton } from "@/components/haptic-button";
 import {
 	AMOUNT_FIELD_TRANSITION,
 	AmountInput,
@@ -69,7 +70,13 @@ export function SwapFrom({
 	const height = box.height ?? undefined;
 
 	return (
-		<section className="rounded-3xl bg-card px-4 pb-3 pt-4">
+		<section className="group relative rounded-3xl bg-card px-4 pb-3 pt-4">
+			{/* Whole-card hover tint: the top picker and bottom amount are separate
+			    controls, but the seamless card highlights as one unit. */}
+			<div
+				aria-hidden
+				className="pointer-events-none absolute inset-0 rounded-3xl transition-colors group-hover:bg-foreground/[0.03]"
+			/>
 			<TokenBox
 				variant="from"
 				selected={token}
@@ -81,9 +88,8 @@ export function SwapFrom({
 				onDisconnect={onDisconnect}
 				genAddress={genAddress}
 				onToggleGenAddress={onToggleGenAddress}
-				triggerClassName="-mx-4 -mt-4 w-[calc(100%+2rem)] rounded-t-3xl px-4 pb-4 pt-4 hover:bg-foreground/[0.03]"
+				triggerClassName="-mx-4 -mt-4 w-[calc(100%+2rem)] rounded-t-3xl px-4 pb-4 pt-4"
 			/>
-			<div className="-mx-4 border-t-2 border-background" />
 			<div
 				className={cn("flex flex-col justify-center", AMOUNT_FIELD_TRANSITION)}
 				style={{ height }}
@@ -100,21 +106,36 @@ export function SwapFrom({
 							arena={token?.logo}
 						/>
 					) : (
-						<div className="flex flex-col items-center gap-2 p-2">
-							<AmountInput
-								value={amount}
-								prefix={mode === "usd" ? "$" : undefined}
-							/>
-							<Pill onClick={onToggleMode}>
-								<span className="opacity-50">=</span>{" "}
-								<ConversionValue
-									mode={mode}
-									usd={usd}
-									units={units}
-									symbol={token?.symbol ?? ""}
+						<div className="relative">
+							{/* Full-area tap target behind a pass-through content layer:
+							    tapping anywhere on the amount flips the denomination. The
+							    Pill stays the accessible control, so this is a11y-hidden. */}
+							<div className="absolute inset-0">
+								<HapticButton
+									type="button"
+									onClick={onToggleMode}
+									tabIndex={-1}
+									aria-hidden
+									wrapperClassName="grid size-full"
+									className="size-full cursor-pointer"
 								/>
-								<ArrowUpDown className="size-3.5" />
-							</Pill>
+							</div>
+							<div className="pointer-events-none relative flex flex-col items-center gap-2 p-2">
+								<AmountInput
+									value={amount}
+									prefix={mode === "usd" ? "$" : undefined}
+								/>
+								<Pill onClick={onToggleMode}>
+									<span className="opacity-50">=</span>{" "}
+									<ConversionValue
+										mode={mode}
+										usd={usd}
+										units={units}
+										symbol={token?.symbol ?? ""}
+									/>
+									<ArrowUpDown className="size-3.5" />
+								</Pill>
+							</div>
 						</div>
 					)}
 				</div>

--- a/workers/jb-swap/src/components/swap-to.tsx
+++ b/workers/jb-swap/src/components/swap-to.tsx
@@ -2,6 +2,7 @@
 
 import { ArrowUpDown } from "lucide-react";
 
+import { HapticButton } from "@/components/haptic-button";
 import {
 	AMOUNT_FIELD_TRANSITION,
 	AmountInput,
@@ -61,7 +62,13 @@ export function SwapTo({
 	const height = box.height == null ? undefined : collapsed ? 0 : box.height;
 
 	return (
-		<section className="rounded-3xl bg-card px-4 pb-0 pt-6">
+		<section className="group relative rounded-3xl bg-card px-4 pb-0 pt-6">
+			{/* Whole-card hover tint: the top picker and bottom amount are separate
+			    controls, but the seamless card highlights as one unit. */}
+			<div
+				aria-hidden
+				className="pointer-events-none absolute inset-0 rounded-3xl transition-colors group-hover:bg-foreground/[0.03]"
+			/>
 			<TokenBox
 				variant="to"
 				selected={token}
@@ -72,7 +79,7 @@ export function SwapTo({
 				feeLoading={feeLoading}
 				onOpenSlippage={onOpenSlippage}
 				triggerClassName={cn(
-					"-mx-4 -mt-6 w-[calc(100%+2rem)] px-4 pb-4 pt-6 hover:bg-foreground/[0.03]",
+					"-mx-4 -mt-6 w-[calc(100%+2rem)] px-4 pb-4 pt-6",
 					collapsed ? "rounded-3xl" : "rounded-t-3xl",
 				)}
 			/>
@@ -81,23 +88,37 @@ export function SwapTo({
 			    total height never changes. */}
 			<div className={AMOUNT_FIELD_TRANSITION} style={{ height }}>
 				<div ref={box.ref}>
-					<div className="-mx-4 border-t-2 border-background" />
-					<div className="flex flex-col items-center gap-2 p-2">
-						<AmountInput
-							value={trim(mode === "token" ? amount : usd)}
-							prefix={mode === "usd" ? "$" : undefined}
-							muted
-						/>
-						<Pill onClick={onToggleMode}>
-							<span className="opacity-50">=</span>{" "}
-							<ConversionValue
-								mode={mode}
-								usd={usd}
-								units={amount}
-								symbol={token?.symbol ?? ""}
+					<div className="relative">
+						{/* Full-area tap target behind a pass-through content layer:
+						    tapping anywhere on the amount flips the denomination. The
+						    Pill stays the accessible control, so this is a11y-hidden. */}
+						<div className="absolute inset-0">
+							<HapticButton
+								type="button"
+								onClick={onToggleMode}
+								tabIndex={-1}
+								aria-hidden
+								wrapperClassName="grid size-full"
+								className="size-full cursor-pointer"
 							/>
-							<ArrowUpDown className="size-3.5" />
-						</Pill>
+						</div>
+						<div className="pointer-events-none relative flex flex-col items-center gap-2 p-2">
+							<AmountInput
+								value={trim(mode === "token" ? amount : usd)}
+								prefix={mode === "usd" ? "$" : undefined}
+								muted
+							/>
+							<Pill onClick={onToggleMode}>
+								<span className="opacity-50">=</span>{" "}
+								<ConversionValue
+									mode={mode}
+									usd={usd}
+									units={amount}
+									symbol={token?.symbol ?? ""}
+								/>
+								<ArrowUpDown className="size-3.5" />
+							</Pill>
+						</div>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
## Summary

- Move the hover highlight from the picker trigger to the whole swap card. The picker and amount are separate controls but read as one seamless surface, so they now tint together.
- Drop the internal `border-t-2` divider that split the picker from the amount.
- Tapping anywhere on the amount area flips the denomination (USD ↔ token), via a full-area `HapticButton` layered behind a `pointer-events-none` content layer. The `Pill` remains the accessible control, so the overlay is `aria-hidden` / `tabIndex={-1}`.

Applied to both `SwapFrom` and `SwapTo`, in `packages/unified-ui` and `workers/jb-swap`.

## Test plan

- [ ] Hovering anywhere on either swap card tints the full card, not just the picker row
- [ ] Clicking the amount area (not just the Pill) toggles the denomination
- [ ] Keyboard tab order still reaches the Pill and skips the overlay
- [ ] `SwapTo` collapse animation still measures correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)