### PR TITLE
feat(jb-swap): add Robinhood Chain and pin priority chains after volume sort

### DIFF
--- a/workers/jb-swap/src/components/token-drawer.tsx
+++ b/workers/jb-swap/src/components/token-drawer.tsx
@@ -11,7 +11,11 @@ import { QrScanner } from "@/components/qr-scanner";
 import { TokenAmount } from "@/components/token-amount";
 import { ConnectWalletControl } from "@/components/wallet-connect";
 import { useTranslations } from "@/i18n/locale-provider";
-import { relayChains, relayTokens } from "@/lib/relay/token-list";
+import {
+	pinPriorityChains,
+	relayChains,
+	relayTokens,
+} from "@/lib/relay/token-list";
 import { useHeldTokens } from "@/lib/use-held-tokens";
 import { useVolumeRanking } from "@/lib/use-volume-ranking";
 import { cn } from "@/lib/utils";
@@ -413,9 +417,11 @@ export function TokenBox({
 	// sectioning, this is just the ranked list.
 	const displayList = hot.length > 0 ? [...hot, ...rest] : ranked;
 
-	// Chain filter chips, reordered by aggregate proxy volume (copy, no mutation
-	// of the shared relayChains const).
-	const sortedChains = sortChains(relayChains, direction);
+	// Chain filter chips: ranked by aggregate proxy volume, then the pinned
+	// chains lifted back to the front (copy, no mutation of the shared
+	// relayChains const). Pin last so volume ranking can't bury a pinned chain
+	// once /api/volume resolves.
+	const sortedChains = pinPriorityChains(sortChains(relayChains, direction));
 
 	const filteredRef = useRef(displayList);
 	filteredRef.current = displayList;

--- a/workers/jb-swap/src/data/relay-token-list.json
+++ b/workers/jb-swap/src/data/relay-token-list.json
@@ -1,6 +1,6 @@
 {
 	"name": "Relay Supported Tokens",
-	"timestamp": "2026-06-14T22:26:25.785Z",
+	"timestamp": "2026-07-20T19:11:29.808Z",
 	"version": {
 		"major": 1,
 		"minor": 0,
@@ -15,6 +15,19 @@
 	"tags": {},
 	"logoURI": "https://assets.relay.link/icons/1/light.png",
 	"tokens": [
+		{
+			"chainId": 1,
+			"address": "0x98a878b1cd98131b271883b390f68d2c90674665",
+			"name": "apxUSD",
+			"symbol": "apxUSD",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Ethereum"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/102172243/large/apxUSD.png?1772448502"
+		},
 		{
 			"chainId": 1,
 			"address": "0x00000000efe302beaa2b3e6e1b18d08d69a9012a",
@@ -95,16 +108,16 @@
 		},
 		{
 			"chainId": 1,
-			"address": "0xe556aba6fe6036275ec1f87eda296be72c811bce",
-			"name": "Neutrl USD",
-			"symbol": "NUSD",
+			"address": "0x230f1e241c621d5af670dad83ebcdd18971e2995",
+			"name": "Nesa",
+			"symbol": "nes",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
 				"verified": false,
 				"chainName": "Ethereum"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/70027/large/NUSD-200x200.png?1760452629"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/102174093/large/nesa.png?1782284722"
 		},
 		{
 			"chainId": 1,
@@ -121,6 +134,19 @@
 		},
 		{
 			"chainId": 1,
+			"address": "0x19ebb35279a16207ec4ba82799cc64715065f7f6",
+			"name": "Hastra PRIME",
+			"symbol": "PRIME",
+			"decimals": 6,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Ethereum"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/71002/large/Frame_427319702.png?1765093510"
+		},
+		{
+			"chainId": 1,
 			"address": "0x6c3ea9036406852006290770bedfcaba0e23a0e8",
 			"name": "PayPal USD",
 			"symbol": "PYUSD",
@@ -131,6 +157,19 @@
 				"chainName": "Ethereum"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/31212/large/PYUSD_Logo_%282%29.png?1696530039"
+		},
+		{
+			"chainId": 1,
+			"address": "0x8292bb45bf1ee4d140127049757c2e0ff06317ed",
+			"name": "RLUSD",
+			"symbol": "RLUSD",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": true,
+				"chainName": "Ethereum"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/39651/large/RLUSD_200x200_%281%29.png?1727376633"
 		},
 		{
 			"chainId": 1,
@@ -147,19 +186,6 @@
 		},
 		{
 			"chainId": 1,
-			"address": "0xa3931d71877c0e7a3148cb7eb4463524fec27fbd",
-			"name": "Savings USDS",
-			"symbol": "sUSDS",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Ethereum"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/52721/large/sUSDS_Coin.png?1734086971"
-		},
-		{
-			"chainId": 1,
 			"address": "0x18084fba666a33d37592fa2633fd49a74dd93a88",
 			"name": "tBTC v2",
 			"symbol": "tBTC",
@@ -170,6 +196,19 @@
 				"chainName": "Ethereum"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/11224/large/0x18084fba666a33d37592fa2633fd49a74dd93a88.png?1696511155"
+		},
+		{
+			"chainId": 1,
+			"address": "0x23238f20b894f29041f48d88ee91131c395aaa71",
+			"name": "USDat",
+			"symbol": "USDat",
+			"decimals": 6,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Ethereum"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/102172645/large/usdat.png?1774503009"
 		},
 		{
 			"chainId": 1,
@@ -225,19 +264,6 @@
 		},
 		{
 			"chainId": 1,
-			"address": "0xc139190f447e929f090edeb554d95abb8b18ac1c",
-			"name": "USDtb",
-			"symbol": "USDtb",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Ethereum"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/52804/large/USDtbSmall.png?1734344946"
-		},
-		{
-			"chainId": 1,
 			"address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
 			"name": "Wrapped BTC",
 			"symbol": "WBTC",
@@ -250,30 +276,17 @@
 			"logoURI": "https://coin-images.coingecko.com/coins/images/7598/large/wrapped_bitcoin_wbtc.png?1696507857"
 		},
 		{
-			"chainId": 1,
-			"address": "0x77e06c9eccf2e797fd462a92b6d7642ef85b0a44",
-			"name": "Wrapped TAO",
-			"symbol": "wTAO",
-			"decimals": 9,
+			"chainId": 10,
+			"address": "0x76fb31fb4af56892a25e32cfc43de717950c9278",
+			"name": "Aave",
+			"symbol": "AAVE",
+			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
 				"verified": true,
-				"chainName": "Ethereum"
+				"chainName": "Optimism"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/29087/large/wtao.png?1696528051"
-		},
-		{
-			"chainId": 1,
-			"address": "0x68749665ff8d2d112fa859aa293f07a622782f38",
-			"name": "Tether Gold",
-			"symbol": "XAUt",
-			"decimals": 6,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Ethereum"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/10481/large/Tether_Gold.png?1696510471"
+			"logoURI": "https://assets.coingecko.com/coins/images/12645/thumb/AAVE.png?1601374110"
 		},
 		{
 			"chainId": 10,
@@ -287,19 +300,6 @@
 				"chainName": "Optimism"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/16271/large/aleth.png?1696515869"
-		},
-		{
-			"chainId": 10,
-			"address": "0x03569cc076654f82679c4ba2124d64774781b01d",
-			"name": "BOLD Stablecoin",
-			"symbol": "BOLD",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Optimism"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/56069/large/BOLD_logo.png?1748265087"
 		},
 		{
 			"chainId": 10,
@@ -394,16 +394,16 @@
 		},
 		{
 			"chainId": 10,
-			"address": "0x296f55f8fb28e498b858d0bcda06d955b2cb3f97",
-			"name": "StargateToken",
-			"symbol": "STG",
+			"address": "0x8700daec35af8ff88c16bdf0418774cb3d7599b4",
+			"name": "Synthetix Network Token",
+			"symbol": "SNX",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
 				"verified": true,
 				"chainName": "Optimism"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/24413/large/STG_LOGO.png?1696523595"
+			"logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F/logo.png"
 		},
 		{
 			"chainId": 10,
@@ -446,19 +446,6 @@
 		},
 		{
 			"chainId": 10,
-			"address": "0x7f5c764cbc14f9669b88837ca1490cca17c31607",
-			"name": "USDCoin (bridged)",
-			"symbol": "USDC.e",
-			"decimals": 6,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Optimism"
-			},
-			"logoURI": "https://ethereum-optimism.github.io/data/USDC/logo.png"
-		},
-		{
-			"chainId": 10,
 			"address": "0x9560e827af36c94d2ac33a39bce1fe78631088db",
 			"name": "Velodrome Finance",
 			"symbol": "VELO",
@@ -485,16 +472,16 @@
 		},
 		{
 			"chainId": 10,
-			"address": "0xef4461891dfb3ac8572ccf7c794664a8dd927945",
-			"name": "WalletConnect",
-			"symbol": "WCT",
+			"address": "0x5a7facb970d094b6c7ff1df0ea68d99e6e73cbff",
+			"name": "Wrapped eETH",
+			"symbol": "weETH",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
-				"verified": true,
+				"verified": false,
 				"chainName": "Optimism"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/50390/large/wc-token1.png?1727569464"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/33033/large/weETH.png?1701438396"
 		},
 		{
 			"chainId": 10,
@@ -536,6 +523,19 @@
 			"logoURI": "https://assets.coingecko.com/coins/images/18834/large/wstETH.png?1633565443"
 		},
 		{
+			"chainId": 10,
+			"address": "0x6985884c4392d348587b19cb9eaaf157f13271cd",
+			"name": "LayerZero",
+			"symbol": "ZRO",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": true,
+				"chainName": "Optimism"
+			},
+			"logoURI": "https://assets.coingecko.com/coins/images/28206/standard/ftxG9_TJ_400x400.jpeg?1696527208"
+		},
+		{
 			"chainId": 25,
 			"address": "0x0e517979c2c1c1522ddb0c73905e0d39b3f990c0",
 			"name": "ADA",
@@ -550,16 +550,16 @@
 		},
 		{
 			"chainId": 25,
-			"address": "0xd896aa25da8e3832d68d1c05fee9c851d42f1dc1",
-			"name": "AurumTrust",
-			"symbol": "AUT",
+			"address": "0x444075ea64d69bf5002ae1a7f44642e46f8b56d4",
+			"name": "CROnos Army",
+			"symbol": "CA",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
 				"verified": false,
 				"chainName": "Cronos"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/56090/large/AurumTrust.jpg?1748374552"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/69410/large/icon_big_coingecko_XIn0E9W7_%281%29.jpg?1758526254"
 		},
 		{
 			"chainId": 25,
@@ -589,6 +589,19 @@
 		},
 		{
 			"chainId": 25,
+			"address": "0x7a7c9db510ab29a2fc362a4c34260becb5ce3446",
+			"name": "Crypto.com Wrapped Staked ETH",
+			"symbol": "CDCETH",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Cronos"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/33537/large/CDCETH-1.png?1702366745"
+		},
+		{
+			"chainId": 25,
 			"address": "0x0000000000000000000000000000000000000000",
 			"name": "Cronos",
 			"symbol": "CRO",
@@ -599,32 +612,6 @@
 				"chainName": "Cronos"
 			},
 			"logoURI": "https://assets.coingecko.com/coins/images/7310/standard/cro_token_logo.png?1696507599"
-		},
-		{
-			"chainId": 25,
-			"address": "0xed70e1b02a63fafd5ece7c0a2a1b12d4b424b4a8",
-			"name": "Croakey",
-			"symbol": "CROAK",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Cronos"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/37503/large/croak.jpg?1714578830"
-		},
-		{
-			"chainId": 25,
-			"address": "0xf2001b145b43032aaf5ee2884e456ccd805f677d",
-			"name": "Dai Stablecoin",
-			"symbol": "DAI",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Cronos"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/39819/large/dai.png?1724190900"
 		},
 		{
 			"chainId": 25,
@@ -667,32 +654,6 @@
 		},
 		{
 			"chainId": 25,
-			"address": "0x75689264a5e2dab1b27ddfb2b10592872139659a",
-			"name": "LOAF",
-			"symbol": "LOAF",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Cronos"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/38486/large/2024-06-07_16.12.53.jpg?1717749626"
-		},
-		{
-			"chainId": 25,
-			"address": "0x3b41b27e74dd366ce27cb389dc7877d4e1516d4d",
-			"name": "Mistery",
-			"symbol": "MERY",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Cronos"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/36620/large/Mistery_Fam_%281%29.png?1711980099"
-		},
-		{
-			"chainId": 25,
 			"address": "0x0aeba21655185583367f19d0c882dfc654c6dd54",
 			"name": "Obsidian",
 			"symbol": "OBS",
@@ -719,6 +680,19 @@
 		},
 		{
 			"chainId": 25,
+			"address": "0x13c0ff45d019a5888db92631f18556211001883d",
+			"name": "President Platy",
+			"symbol": "Platy",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Cronos"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/37781/large/EOP_logo.png?1779089089"
+		},
+		{
+			"chainId": 25,
 			"address": "0xdd73dea10abc2bff99c60882ec5b2b81bb1dc5b2",
 			"name": "Tectonic Governance Token",
 			"symbol": "TONIC",
@@ -732,9 +706,22 @@
 		},
 		{
 			"chainId": 25,
-			"address": "0xc21223249ca28397b4b6541dffaecc539bff0c59",
+			"address": "0x3d7f2c478aafdb65542bcb44bceec05849999d2d",
 			"name": "USD Coin",
 			"symbol": "USDC",
+			"decimals": 6,
+			"extensions": {
+				"vmType": "evm",
+				"verified": true,
+				"chainName": "Cronos"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/6319/large/usdc.png?1696506694"
+		},
+		{
+			"chainId": 25,
+			"address": "0xc21223249ca28397b4b6541dffaecc539bff0c59",
+			"name": "USDCoin (bridged)",
+			"symbol": "USDC.e",
 			"decimals": 6,
 			"extensions": {
 				"vmType": "evm",
@@ -755,6 +742,19 @@
 				"chainName": "Cronos"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/35025/large/USDT.png?1707233700"
+		},
+		{
+			"chainId": 25,
+			"address": "0xdb7d0a1ec37de1de924f8e8adac6ed338d4404e9",
+			"name": "VenoToken",
+			"symbol": "VNO",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": true,
+				"chainName": "Cronos"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/28799/large/Veno_Token_dark.png?1696527777"
 		},
 		{
 			"chainId": 25,
@@ -797,42 +797,68 @@
 		},
 		{
 			"chainId": 56,
-			"address": "0x3d4f0513e8a29669b960f9dbca61861548a9a760",
-			"name": "Banana For Scale",
-			"symbol": "$BANANA",
+			"address": "0x5dbde81fce337ff4bcaaee4ca3466c00aecae274",
+			"name": "Alaya Governance Token",
+			"symbol": "AGT",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
 				"verified": true,
 				"chainName": "BNB"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/52230/large/Banana_token_image.png?1732801941"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/55830/large/alaya-ai-logo.jpg?1747390654"
 		},
 		{
 			"chainId": 56,
-			"address": "0xcae117ca6bc8a341d2e7207f30e180f0e5618b9d",
-			"name": "ARK",
-			"symbol": "ARK",
+			"address": "0x2c3a8ee94ddd97244a93bc48298f97d2c412f7db",
+			"name": "AKE",
+			"symbol": "AKE",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
 				"verified": true,
 				"chainName": "BNB"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/68794/large/200x200.png?1756618572"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/68410/large/akedo.png?1755678461"
 		},
 		{
 			"chainId": 56,
-			"address": "0xcf3232b85b43bca90e51d38cc06cc8bb8c8a3e36",
-			"name": "Beat Token",
-			"symbol": "Beat",
+			"address": "0x6bdcce4a559076e37755a78ce0c06214e59e4444",
+			"name": "B",
+			"symbol": "B",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": true,
+				"chainName": "BNB"
+			},
+			"logoURI": "https://assets.geckoterminal.com/1nmtn1wmesju79qcupq98it8iql7"
+		},
+		{
+			"chainId": 56,
+			"address": "0x3aee7602b612de36088f3ffed8c8f10e86ebf2bf",
+			"name": "Lorenzo Governance Token",
+			"symbol": "BANK",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": true,
+				"chainName": "BNB"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/55250/large/lorenzo.jpg?1744963693"
+		},
+		{
+			"chainId": 56,
+			"address": "0x1d28d989f9e3ccb8b15d0cec601734514f958e4d",
+			"name": "Based Token",
+			"symbol": "BASED",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
 				"verified": false,
 				"chainName": "BNB"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/70428/large/audiera.png?1761964064"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/71361/large/based-logo-200x200.png?1774599745"
 		},
 		{
 			"chainId": 56,
@@ -849,29 +875,16 @@
 		},
 		{
 			"chainId": 56,
-			"address": "0x81d3a238b02827f62b9f390f947d36d4a5bf89d2",
-			"name": "Yei Finance",
-			"symbol": "CLO",
+			"address": "0x7130d2a12b9bcbfae4f2634d864a1ee1ce3ead9c",
+			"name": "BTCB Token",
+			"symbol": "BTCB",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
-				"verified": false,
+				"verified": true,
 				"chainName": "BNB"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/69987/large/yei.png?1760271689"
-		},
-		{
-			"chainId": 56,
-			"address": "0x0a8d6c86e1bce73fe4d0bd531e1a567306836ea5",
-			"name": "ChainOpera AI",
-			"symbol": "COAI",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "BNB"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/69447/large/coai.png?1758625501"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/14108/large/Binance-bitcoin.png?1696513829"
 		},
 		{
 			"chainId": 56,
@@ -888,94 +901,81 @@
 		},
 		{
 			"chainId": 56,
-			"address": "0xf39e4b21c84e737df08e2c3b32541d856f508e48",
-			"name": "Yooldo Games",
-			"symbol": "ESPORTS",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "BNB"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/67430/large/yooldo.jpg?1752747394"
-		},
-		{
-			"chainId": 56,
-			"address": "0xaa036928c9c0df07d525b55ea8ee690bb5a628c1",
-			"name": "EVAA",
-			"symbol": "EVAA",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "BNB"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/69601/large/evaa.png?1759214696"
-		},
-		{
-			"chainId": 56,
-			"address": "0xac23b90a79504865d52b49b327328411a23d4db2",
-			"name": "Falcon Finance",
-			"symbol": "FF",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "BNB"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/69121/large/ff.png?1757573403"
-		},
-		{
-			"chainId": 56,
-			"address": "0x61fac5f038515572d6f42d4bcb6b581642753d50",
-			"name": "INFINIT",
-			"symbol": "IN",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "BNB"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/67941/large/infinit.jpg?1754390008"
-		},
-		{
-			"chainId": 56,
-			"address": "0xea37a8de1de2d9d10772eeb569e28bfa5cb17707",
-			"name": "JANCTION",
-			"symbol": "JCT",
+			"address": "0x6261963ebe9ff014aad10ecc3b0238d4d04e8353",
+			"name": "Hana Token",
+			"symbol": "HANA",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
 				"verified": false,
 				"chainName": "BNB"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/70608/large/janction.png?1762738430"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/67597/large/hana.jpg?1753245208"
 		},
 		{
 			"chainId": 56,
-			"address": "0x5feccd17c393caf1001d18164236a37e731fcb9d",
-			"name": "OpenGradient",
-			"symbol": "OPG",
+			"address": "0x7ec43cf65f1663f820427c62a5780b8f2e25593a",
+			"name": "LAB",
+			"symbol": "LAB",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": true,
+				"chainName": "BNB"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/70014/large/lab.png?1760352822"
+		},
+		{
+			"chainId": 56,
+			"address": "0x3131f6b80c26936ab03f7d9d29eb4ddf36ac3fb5",
+			"name": "Nesa",
+			"symbol": "NES",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
 				"verified": false,
 				"chainName": "BNB"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/102172863/large/coingecko_logo.png?1776349115"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/102174093/large/nesa.png?1782284722"
 		},
 		{
 			"chainId": 56,
-			"address": "0x4d41a5d412f4ef44a35b9f53b06db65ede249493",
-			"name": "QAIT",
-			"symbol": "QAIT",
-			"decimals": 8,
+			"address": "0xa9ee28c80f960b889dfbd1902055218cba016f75",
+			"name": "NVIDIA (Ondo Tokenized)",
+			"symbol": "NVDAon",
+			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
 				"verified": false,
 				"chainName": "BNB"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/102173522/large/sealcoin.jpg?1779950602"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/68623/large/nvdaon_160x160.png?1756130268"
+		},
+		{
+			"chainId": 56,
+			"address": "0x0e4f6209ed984b21edea43ace6e09559ed051d48",
+			"name": "Orochi Network Token",
+			"symbol": "ON",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "BNB"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/70231/large/orochi_network.png?1761129486"
+		},
+		{
+			"chainId": 56,
+			"address": "0x205812cdbed920aff76c6580abd681a46d11efc7",
+			"name": "Invesqo QQQ",
+			"symbol": "QQQB",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "BNB"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/102174259/large/bstocks_qqqb.png?1782837726"
 		},
 		{
 			"chainId": 56,
@@ -992,42 +992,29 @@
 		},
 		{
 			"chainId": 56,
-			"address": "0x997a58129890bbda032231a52ed1ddc845fc18e1",
-			"name": "SIREN",
-			"symbol": "SIREN",
+			"address": "0x40b8129b786d766267a7a118cf8c07e31cdb6fde",
+			"name": "Unibase",
+			"symbol": "UB",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
 				"verified": true,
 				"chainName": "BNB"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/54479/large/siren.png?1739960056"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/69108/large/unibase.png?1757501820"
 		},
 		{
 			"chainId": 56,
-			"address": "0x92aa03137385f18539301349dcfc9ebc923ffb10",
-			"name": "SKYAI",
-			"symbol": "SKYAI",
+			"address": "0x000008d2175f9aeaddb2430c26f8a6f73c5a0000",
+			"name": "Unitas",
+			"symbol": "UP",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
-				"verified": true,
+				"verified": false,
 				"chainName": "BNB"
 			},
-			"logoURI": "https://assets.geckoterminal.com/md2wxfjtvlpjxmf9q6h9s5egxcr1"
-		},
-		{
-			"chainId": 56,
-			"address": "0x9123400446a56176eb1b6be9ee5cf703e409f492",
-			"name": "TRADOOR",
-			"symbol": "TRADOOR",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "BNB"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/68862/large/tradoor.png?1756809006"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/71531/large/Logo_Mark_200.png?1772722048"
 		},
 		{
 			"chainId": 56,
@@ -1056,6 +1043,19 @@
 			"logoURI": "https://coin-images.coingecko.com/coins/images/39963/large/usdt.png?1724952731"
 		},
 		{
+			"chainId": 56,
+			"address": "0x6907a5986c4950bdaf2f81828ec0737ce787519f",
+			"name": "Zama",
+			"symbol": "ZAMA",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "BNB"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/70921/large/zama.png?1764591992"
+		},
+		{
 			"chainId": 100,
 			"address": "0x177127622c4a00f3d409b75571e12cb3c8973d3c",
 			"name": "CoW Protocol Token from Mainnet",
@@ -1067,6 +1067,19 @@
 				"chainName": "Gnosis"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/24384/large/CoW-token_logo.png?1719524382"
+		},
+		{
+			"chainId": 100,
+			"address": "0x54e4cb2a4fa0ee46e3d9a98d13bea119666e09f6",
+			"name": "Bridged EURC (Gnosis)",
+			"symbol": "EURC.e",
+			"decimals": 6,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Gnosis"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/36068/large/eurc.png?1765522631"
 		},
 		{
 			"chainId": 100,
@@ -1148,19 +1161,6 @@
 		},
 		{
 			"chainId": 100,
-			"address": "0xfa57aa7beed63d03aaf85ffd1753f5f6242588fb",
-			"name": "MtPelerin Shares",
-			"symbol": "MPS",
-			"decimals": 0,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Gnosis"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/11471/large/mps-icon.png?1767375345"
-		},
-		{
-			"chainId": 100,
 			"address": "0xce11e14225575945b8e6dc0d4f2dd4c570f79d9f",
 			"name": "Autonolas from Mainnet",
 			"symbol": "OLAS",
@@ -1171,6 +1171,19 @@
 				"chainName": "Gnosis"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/31099/large/OLAS-token.png?1696529930"
+		},
+		{
+			"chainId": 100,
+			"address": "0x37b60f4e9a31a64ccc0024dce7d0fd07eaa0f7b3",
+			"name": "Pinakion on xDai",
+			"symbol": "PNK",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Gnosis"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/3833/large/kleros.png?1696504500"
 		},
 		{
 			"chainId": 100,
@@ -1187,29 +1200,16 @@
 		},
 		{
 			"chainId": 100,
-			"address": "0x2086f52651837600180de173b09470f54ef74910",
-			"name": "Balancer Stable USD",
-			"symbol": "staBAL3",
-			"decimals": 18,
+			"address": "0xddafbb505ad214d7b80b1f830fccc89b60fb7a83",
+			"name": "USD//C on xDai",
+			"symbol": "USDC",
+			"decimals": 6,
 			"extensions": {
 				"vmType": "evm",
-				"verified": false,
+				"verified": true,
 				"chainName": "Gnosis"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/32112/large/bal3.png?1696561317"
-		},
-		{
-			"chainId": 100,
-			"address": "0x84e2c67cbefae6b5148fca7d02b341b12ff4b5bb",
-			"name": "Swash Token",
-			"symbol": "SWASH",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Gnosis"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/18774/large/Swash_icon_GP.png?1712869197"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/35300/large/USDC_Icon.png?1708083625"
 		},
 		{
 			"chainId": 100,
@@ -1223,19 +1223,6 @@
 				"chainName": "Gnosis"
 			},
 			"logoURI": "https://ethereum-optimism.github.io/data/USDC/logo.png"
-		},
-		{
-			"chainId": 100,
-			"address": "0xddafbb505ad214d7b80b1f830fccc89b60fb7a83",
-			"name": "USD//C on xDai",
-			"symbol": "USDC",
-			"decimals": 6,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Gnosis"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/35300/large/USDC_Icon.png?1708083625"
 		},
 		{
 			"chainId": 100,
@@ -1262,6 +1249,19 @@
 				"chainName": "Gnosis"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/68209/large/wsteth.png?1755082121"
+		},
+		{
+			"chainId": 100,
+			"address": "0x8e5bbbb09ed1ebde8674cda39a0c169401db4252",
+			"name": "Wrapped BTC on xDai",
+			"symbol": "WBTC",
+			"decimals": 8,
+			"extensions": {
+				"vmType": "evm",
+				"verified": true,
+				"chainName": "Gnosis"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/39595/large/wbtc.png?1723016785"
 		},
 		{
 			"chainId": 100,
@@ -1317,16 +1317,29 @@
 		},
 		{
 			"chainId": 130,
-			"address": "0x94025780a1ab58868d9b2dbbb775f44b32e8e6e5",
-			"name": "BetSwirl v2",
-			"symbol": "BETS",
-			"decimals": 18,
+			"address": "0x97fadb3d000b953360fd011e173f12cddb5d70fa",
+			"name": "dogwifhat",
+			"symbol": "$WIF",
+			"decimals": 6,
 			"extensions": {
 				"vmType": "evm",
 				"verified": false,
 				"chainName": "Unichain"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/26618/large/icon_200.png?1696525691"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/33566/large/dogwifhat.jpg?1702499428"
+		},
+		{
+			"chainId": 130,
+			"address": "0xbbe97f3522101e5b6976cbf77376047097ba837f",
+			"name": "Bonk",
+			"symbol": "Bonk",
+			"decimals": 5,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Unichain"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/28600/large/bonk.jpg?1696527587"
 		},
 		{
 			"chainId": 130,
@@ -1356,19 +1369,6 @@
 		},
 		{
 			"chainId": 130,
-			"address": "0x80eede496655fb9047dd39d9f418d5483ed600df",
-			"name": "Frax USD",
-			"symbol": "frxUSD",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Unichain"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/53963/large/frxUSD.png?1737792154"
-		},
-		{
-			"chainId": 130,
 			"address": "0x03c2868c6d7fd27575426f395ee081498b1120dd",
 			"name": "Rigo Token",
 			"symbol": "GRG",
@@ -1395,6 +1395,19 @@
 		},
 		{
 			"chainId": 130,
+			"address": "0xbe51a5e8fa434f09663e8fb4cce79d0b2381afad",
+			"name": "Jupiter",
+			"symbol": "JUP",
+			"decimals": 6,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Unichain"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/34188/large/jup.png?1704266489"
+		},
+		{
+			"chainId": 130,
 			"address": "0x1217bfe6c773eec6cc4a38b5dc45b92292b6e189",
 			"name": "OpenUSDT",
 			"symbol": "oUSDT",
@@ -1418,6 +1431,19 @@
 				"chainName": "Unichain"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/20764/large/reth.png?1696520159"
+		},
+		{
+			"chainId": 130,
+			"address": "0xc3eacf0612346366db554c991d7858716db09f58",
+			"name": "KelpDao Restaked ETH",
+			"symbol": "rsETH",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": true,
+				"chainName": "Unichain"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/67283/large/rseth.jpg?1752298197"
 		},
 		{
 			"chainId": 130,
@@ -1538,19 +1564,6 @@
 		},
 		{
 			"chainId": 130,
-			"address": "0x64445f0aecc51e94ad52d8ac56b7190e764e561a",
-			"name": "Wrapped Frax",
-			"symbol": "WFRAX",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Unichain"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/55432/large/wfrax_64.png?1745993624"
-		},
-		{
-			"chainId": 130,
 			"address": "0xc02fe7317d4eb8753a02c35fe019786854a92001",
 			"name": "Wrapped liquid staked Ether 2.0",
 			"symbol": "wstETH",
@@ -1561,19 +1574,6 @@
 				"chainName": "Unichain"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/18834/large/wstETH.png?1696518295"
-		},
-		{
-			"chainId": 130,
-			"address": "0x81908bbaad3f6fc74093540ab2e9b749bb62aa0d",
-			"name": "Venus XVS",
-			"symbol": "XVS",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Unichain"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/12677/large/XVS_Token.jpg?1727454303"
 		},
 		{
 			"chainId": 137,
@@ -1603,6 +1603,19 @@
 		},
 		{
 			"chainId": 137,
+			"address": "0x6a92b1e99de09f71cd96bc91f934826d96b8b26e",
+			"name": "AS Token",
+			"symbol": "AS",
+			"decimals": 9,
+			"extensions": {
+				"vmType": "evm",
+				"verified": true,
+				"chainName": "Polygon"
+			},
+			"logoURI": "https://assets.geckoterminal.com/ejfgaym76uo51l8fyfccqs746wd4"
+		},
+		{
+			"chainId": 137,
 			"address": "0x1bdf71ede1a4777db1eebe7232bcda20d6fc1610",
 			"name": "WhaleBit",
 			"symbol": "CES",
@@ -1629,29 +1642,29 @@
 		},
 		{
 			"chainId": 137,
-			"address": "0xac0f66379a6d7801d7726d5a943356a172549adb",
-			"name": "Geodnet Token",
-			"symbol": "GEOD",
-			"decimals": 18,
+			"address": "0x14913815bcfde78baead2111f463d038ac9c2949",
+			"name": "eUSD",
+			"symbol": "eUSD",
+			"decimals": 6,
 			"extensions": {
 				"vmType": "evm",
-				"verified": true,
+				"verified": false,
 				"chainName": "Polygon"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/31608/large/Circular_White.png?1696530424"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/71602/large/eUSD.png?1768507474"
 		},
 		{
 			"chainId": 137,
-			"address": "0xf4c3fac9c98aa62474998e299495b699dfdb00eb",
-			"name": "HandlPay",
-			"symbol": "HANDL",
+			"address": "0x80eede496655fb9047dd39d9f418d5483ed600df",
+			"name": "Frax USD",
+			"symbol": "frxUSD",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
 				"verified": false,
 				"chainName": "Polygon"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/71168/large/icon-200x200.png?1766173866"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/53963/large/frxUSD.png?1737792154"
 		},
 		{
 			"chainId": 137,
@@ -1681,19 +1694,6 @@
 		},
 		{
 			"chainId": 137,
-			"address": "0x954a082de9f404b60edb7c4bef8afc289a5d8866",
-			"name": "Navacoin",
-			"symbol": "NAVA",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Polygon"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/102172748/large/8wdm6njl5tik3mkv99fr89cv29q5.?1775226386"
-		},
-		{
-			"chainId": 137,
 			"address": "0x0000000000000000000000000000000000000000",
 			"name": "POL",
 			"symbol": "POL",
@@ -1720,42 +1720,42 @@
 		},
 		{
 			"chainId": 137,
-			"address": "0xb5c064f955d8e7f38fe0460c556a72987494ee17",
-			"name": "QuickSwap",
-			"symbol": "QUICK",
+			"address": "0x43c73b90e0c2a355784dcf0da12f477729b31e77",
+			"name": "Soil",
+			"symbol": "SOIL",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
-				"verified": true,
+				"verified": false,
 				"chainName": "Polygon"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/25393/large/quickswap.png?1696524525"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/32050/large/SOIL_sygnet_dark_blue.png?1696530847"
 		},
 		{
 			"chainId": 137,
-			"address": "0x98965474ecbec2f532f1f780ee37b0b05f77ca55",
-			"name": "SUPER TRUST",
-			"symbol": "SUT",
-			"decimals": 18,
+			"address": "0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32",
+			"name": "Telcoin",
+			"symbol": "TEL",
+			"decimals": 2,
 			"extensions": {
 				"vmType": "evm",
 				"verified": true,
 				"chainName": "Polygon"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/55122/large/sut-logo.png?1743842563"
+			"logoURI": "https://assets.coingecko.com/coins/images/1899/large/tel.png?1547036203"
 		},
 		{
 			"chainId": 137,
-			"address": "0x3bf668fe1ec79a84ca8481cead5dbb30d61cc685",
-			"name": "teleBTC",
-			"symbol": "TELEBTC",
-			"decimals": 8,
+			"address": "0xd574b191b5a00262ff19953d3ce25543ab7c8098",
+			"name": "Etherfuse TESOURO",
+			"symbol": "TESOURO",
+			"decimals": 6,
 			"extensions": {
 				"vmType": "evm",
-				"verified": true,
+				"verified": false,
 				"chainName": "Polygon"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/67366/large/telebtc.jpg?1752572372"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/52383/large/stable.jpg?1733259572"
 		},
 		{
 			"chainId": 137,
@@ -1889,16 +1889,29 @@
 		},
 		{
 			"chainId": 143,
-			"address": "0xad96c3dffcd6374294e2573a7fbba96097cc8d7c",
-			"name": "Pixie Dust",
-			"symbol": "DUST",
+			"address": "0x834df4c1d8f51be24322e39e4766697be015512f",
+			"name": "Etherfuse CETES",
+			"symbol": "CETES",
+			"decimals": 6,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Monad"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/37855/large/cetes.png?1715788161"
+		},
+		{
+			"chainId": 143,
+			"address": "0x350035555e10d9afaf1566aaebfced5ba6c27777",
+			"name": "Chog",
+			"symbol": "CHOG",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
 				"verified": false,
 				"chainName": "Monad"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/71148/large/dust_200.png?1765996628"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/70930/large/chog.png?1764628221"
 		},
 		{
 			"chainId": 143,
@@ -1915,19 +1928,6 @@
 		},
 		{
 			"chainId": 143,
-			"address": "0x81a224f8a62f52bde942dbf23a56df77a10b7777",
-			"name": "emonad",
-			"symbol": "emo",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Monad"
-			},
-			"logoURI": "https://assets.geckoterminal.com/9v47soos8hfp9lm77w6u9wsl1wfp"
-		},
-		{
-			"chainId": 143,
 			"address": "0x1111b3ded9f1fe1801ad4ebef8e2788183a24111",
 			"name": "Newrails Euro",
 			"symbol": "EURW",
@@ -1941,29 +1941,16 @@
 		},
 		{
 			"chainId": 143,
-			"address": "0x11ed3b12d99d508f926c870fb44f472001842c96",
-			"name": "Ignis",
-			"symbol": "IGN",
+			"address": "0xfc421ad3c883bf9e7c4f42de845c4e4405799e73",
+			"name": "Gho Token",
+			"symbol": "GHO",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
 				"verified": false,
 				"chainName": "Monad"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/102173673/large/IGNLOGO.png?1780836328"
-		},
-		{
-			"chainId": 143,
-			"address": "0x1001ff13bf368aa4fa85f21043648079f00e1001",
-			"name": "LeverUp",
-			"symbol": "LV",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Monad"
-			},
-			"logoURI": "https://assets.geckoterminal.com/qsmov7glrm5ti2g7fjjlodv5vc8b"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/30663/large/gho-token-logo.png?1720517092"
 		},
 		{
 			"chainId": 143,
@@ -2003,6 +1990,19 @@
 				"chainName": "Monad"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/70837/large/SHMONAD_ICON_%281%29.png?1764108788"
+		},
+		{
+			"chainId": 143,
+			"address": "0xab6e5a0c3799d020c790d34f7b2c02639e238af7",
+			"name": "Syrup USDC",
+			"symbol": "syrupUSDC",
+			"decimals": 6,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Monad"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/54658/large/syrupUSDC.png?1761824955"
 		},
 		{
 			"chainId": 143,
@@ -2110,29 +2110,16 @@
 		},
 		{
 			"chainId": 146,
-			"address": "0x2d0e0814e62d80056181f5cd932274405966e4f0",
-			"name": "Beets",
-			"symbol": "BEETS",
+			"address": "0xe51ee9868c1f0d6cd968a8b8c8376dc2991bfe44",
+			"name": "PaintSwap",
+			"symbol": "BRUSH",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
 				"verified": true,
 				"chainName": "Sonic"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/53249/large/beets.png?1735873104"
-		},
-		{
-			"chainId": 146,
-			"address": "0x871a101dcf22fe4fe37be7b654098c801cba1c88",
-			"name": "Beefy Sonic",
-			"symbol": "beS",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Sonic"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/55186/large/beS.png?1744440042"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/18579/large/ps-cmc-200x200.png?1707862125"
 		},
 		{
 			"chainId": 146,
@@ -2175,16 +2162,16 @@
 		},
 		{
 			"chainId": 146,
-			"address": "0x6881b80ea7c858e4aeef63893e18a8a36f3682f3",
-			"name": "NAVI",
-			"symbol": "NAVI",
-			"decimals": 18,
+			"address": "0x70e7f1d907e30efb18fe1dd8a1d75c09a98177d3",
+			"name": "JEFE TOKEN",
+			"symbol": "JEFE",
+			"decimals": 9,
 			"extensions": {
 				"vmType": "evm",
-				"verified": true,
+				"verified": false,
 				"chainName": "Sonic"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/28547/large/navi.jpg?1736302094"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/102173214/large/JEFE_200.png?1778396341"
 		},
 		{
 			"chainId": 146,
@@ -2211,6 +2198,19 @@
 				"chainName": "Sonic"
 			},
 			"logoURI": "https://assets.relay.link/icons/currencies/s.png"
+		},
+		{
+			"chainId": 146,
+			"address": "0xbb30e76d9bb2cc9631f7fc5eb8e87b5aff32bfbd",
+			"name": "Sonic BTC",
+			"symbol": "scBTC",
+			"decimals": 8,
+			"extensions": {
+				"vmType": "evm",
+				"verified": true,
+				"chainName": "Sonic"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/54997/large/scBTC_32.png?1743095543"
 		},
 		{
 			"chainId": 146,
@@ -2526,19 +2526,6 @@
 		},
 		{
 			"chainId": 288,
-			"address": "0x71879254030c385c0047b83968da5436f82cd690",
-			"name": "Bridged USDC (Lucid)",
-			"symbol": "USDC.e",
-			"decimals": 6,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Boba Network"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/71731/large/L-USDC_Logo-transparent.png?1769098948"
-		},
-		{
-			"chainId": 288,
 			"address": "0x5de1677344d3cb0d7d465c10b72a8f60699c062d",
 			"name": "Tether USD",
 			"symbol": "USDT",
@@ -2630,16 +2617,29 @@
 		},
 		{
 			"chainId": 324,
-			"address": "0xa995ad25ce5eb76972ab356168f5e1d9257e4d05",
-			"name": "Koi",
-			"symbol": "KOI",
+			"address": "0xb0c2bdc425fd01c33d8514f8be016070212bdc6a",
+			"name": "LONGMAO",
+			"symbol": "LMAO",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
 				"verified": false,
 				"chainName": "zkSync Era"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/35766/large/Koi_logo.png?1709782399"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/35213/large/rsz_longmaopfpp.png?1707898201"
+		},
+		{
+			"chainId": 324,
+			"address": "0x5165ec33b491d7b67260b3143f96bb4ac4736398",
+			"name": "Long",
+			"symbol": "LONG",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "zkSync Era"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/36497/large/Logo_Long_square.png?1717541650"
 		},
 		{
 			"chainId": 324,
@@ -2656,6 +2656,19 @@
 		},
 		{
 			"chainId": 324,
+			"address": "0x787c09494ec8bcb24dcaf8659e7d5d69979ee508",
+			"name": "Maverick Token",
+			"symbol": "MAV",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "zkSync Era"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/30850/large/MAV_Logo.png?1696529701"
+		},
+		{
+			"chainId": 324,
 			"address": "0xbd4372e44c5ee654dd838304006e1f0f69983154",
 			"name": "Nodle Token",
 			"symbol": "NODL",
@@ -2666,32 +2679,6 @@
 				"chainName": "zkSync Era"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/27019/large/nodle.png?1696526071"
-		},
-		{
-			"chainId": 324,
-			"address": "0x941fc398d9faebdd9f311011541045a1d66c748e",
-			"name": "NOP App",
-			"symbol": "NOP",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "zkSync Era"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/36376/large/191.png?1711342125"
-		},
-		{
-			"chainId": 324,
-			"address": "0xdd9f72afed3631a6c85b5369d84875e6c42f1827",
-			"name": "Symbiosis",
-			"symbol": "SIS",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "zkSync Era"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/20805/large/SymbiosisFinance_logo-150x150.jpeg?1696520198"
 		},
 		{
 			"chainId": 324,
@@ -2734,6 +2721,19 @@
 		},
 		{
 			"chainId": 324,
+			"address": "0xe75a17b4f5c4f844688d5670b684515d7c785e63",
+			"name": "VenoToken",
+			"symbol": "VNO",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "zkSync Era"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/28799/large/Veno_Token_dark.png?1696527777"
+		},
+		{
+			"chainId": 324,
 			"address": "0xbbeb516fb02a01611cbbe0453fe3c580d7281011",
 			"name": "Wrapped BTC",
 			"symbol": "WBTC",
@@ -2747,16 +2747,16 @@
 		},
 		{
 			"chainId": 324,
-			"address": "0xc1fa6e2e8667d9be0ca938a54c7e0285e9df924a",
-			"name": "Wrapped eETH",
-			"symbol": "weETH",
+			"address": "0xd78abd81a3d57712a3af080dc4185b698fe9ac5a",
+			"name": "Venus XVS",
+			"symbol": "XVS",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
 				"verified": false,
 				"chainName": "zkSync Era"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/33033/large/weETH.png?1701438396"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/12677/large/XVS_Token.jpg?1727454303"
 		},
 		{
 			"chainId": 324,
@@ -2798,19 +2798,6 @@
 			"logoURI": "https://assets.coingecko.com/coins/images/38043/large/ZKTokenBlack.png?17186145029"
 		},
 		{
-			"chainId": 324,
-			"address": "0xbfb4b5616044eded03e5b1ad75141f0d9cb1499b",
-			"name": "zkDoge",
-			"symbol": "ZKDOGE",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "zkSync Era"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/29619/large/zkdoge.png?1696528555"
-		},
-		{
 			"chainId": 360,
 			"address": "0x0000000000000000000000000000000000000000",
 			"name": "Ether",
@@ -2835,19 +2822,6 @@
 				"chainName": "Shape"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/102172929/large/shape.png?1776672257"
-		},
-		{
-			"chainId": 480,
-			"address": "0x7047b80cb47527e864029d3cfe1899534dc15402",
-			"name": "Bowser",
-			"symbol": "BOWSER",
-			"decimals": 9,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "World Chain"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/50784/large/BOWSER_200.jpg?1729193270"
 		},
 		{
 			"chainId": 480,
@@ -2900,6 +2874,19 @@
 				"chainName": "World Chain"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/69748/large/Logo.jpg?1759482957"
+		},
+		{
+			"chainId": 480,
+			"address": "0x18bc5bcc660cf2b9ce3cd51a404afe1a0cbd3c22",
+			"name": "IDRX",
+			"symbol": "IDRX",
+			"decimals": 2,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "World Chain"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/34883/large/IDRX_BLUE_COIN_200x200.png?1734983273"
 		},
 		{
 			"chainId": 480,
@@ -3202,19 +3189,6 @@
 		},
 		{
 			"chainId": 747,
-			"address": "0x7f27352d5f83db87a5a3e00f4b07cc2138d8ee52",
-			"name": "Bridged USDC (Celer)",
-			"symbol": "USDC.e",
-			"decimals": 6,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Flow EVM"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/50488/large/usdc.png?1727927821"
-		},
-		{
-			"chainId": 747,
 			"address": "0x2aabea2058b5ac2d339b163c6ab6f2b6d53aabed",
 			"name": "USD Flow",
 			"symbol": "USDF",
@@ -3254,6 +3228,19 @@
 		},
 		{
 			"chainId": 999,
+			"address": "0x053f6755320d06b8fd6675581b0475b2e32399b1",
+			"name": "Based Token",
+			"symbol": "BASED",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "HyperEVM"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/71361/large/based-logo-200x200.png?1774599745"
+		},
+		{
+			"chainId": 999,
 			"address": "0x02c6a2fa58cc01a18b8d9e00ea48d65e4df26c70",
 			"name": "feUSD",
 			"symbol": "feUSD",
@@ -3267,6 +3254,19 @@
 		},
 		{
 			"chainId": 999,
+			"address": "0xa320d9f65ec992eff38622c63627856382db726c",
+			"name": "HFUN",
+			"symbol": "HFUN",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "HyperEVM"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/38401/large/hfun_small.png?1717458896"
+		},
+		{
+			"chainId": 999,
 			"address": "0xfd739d4e423301ce9385c1fb8850539d657c296d",
 			"name": "Kinetiq Staked HYPE",
 			"symbol": "kHYPE",
@@ -3277,6 +3277,19 @@
 				"chainName": "HyperEVM"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/67388/large/khype.png?1752632397"
+		},
+		{
+			"chainId": 999,
+			"address": "0x618275f8efe54c2afa87bfb9f210a52f0ff89364",
+			"name": "Kittenswap",
+			"symbol": "KITTEN",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "HyperEVM"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/67152/large/kitten.jpg?1751892796"
 		},
 		{
 			"chainId": 999,
@@ -3306,16 +3319,16 @@
 		},
 		{
 			"chainId": 999,
-			"address": "0x7bbcf1b600565ae023a1806ef637af4739de3255",
-			"name": "PRFI",
-			"symbol": "PRFI",
+			"address": "0x9b498c3c8a0b8cd8ba1d9851d40d186f1872b44e",
+			"name": "Purr",
+			"symbol": "PURR",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
 				"verified": false,
 				"chainName": "HyperEVM"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/55355/large/Prime_Numbers_Icon_%281%29.png?1745589445"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/37125/large/PURR_CG.png?1713368828"
 		},
 		{
 			"chainId": 999,
@@ -3384,6 +3397,19 @@
 		},
 		{
 			"chainId": 999,
+			"address": "0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34",
+			"name": "USDeOFT",
+			"symbol": "USDe",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": true,
+				"chainName": "HyperEVM"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/66151/large/usde.jpg?1748491903"
+		},
+		{
+			"chainId": 999,
 			"address": "0x111111a1a0667d36bd57c0a9f569b98057111111",
 			"name": "USDH",
 			"symbol": "USDH",
@@ -3397,16 +3423,16 @@
 		},
 		{
 			"chainId": 999,
-			"address": "0xb50a96253abdf803d85efcdce07ad8becbc52bd5",
-			"name": "Hyper USD",
-			"symbol": "USDHL",
+			"address": "0xe2d2959f89b6389deb624bf076fe7d9e5401f377",
+			"name": "Monetrix USD",
+			"symbol": "USDM",
 			"decimals": 6,
 			"extensions": {
 				"vmType": "evm",
 				"verified": false,
 				"chainName": "HyperEVM"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/66679/large/usdhl.jpg?1750242294"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/102174243/large/monetrix.png?1782722620"
 		},
 		{
 			"chainId": 999,
@@ -3423,45 +3449,6 @@
 		},
 		{
 			"chainId": 999,
-			"address": "0xb5ee887259f792e613edbd20dde8970c10fefda1",
-			"name": "ValiDAO",
-			"symbol": "VDO",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "HyperEVM"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/33748/large/200x200.png?1712694763"
-		},
-		{
-			"chainId": 999,
-			"address": "0x8888888fdaac0e7cf8c6523c8955bf7954c216fa",
-			"name": "vHYPE",
-			"symbol": "vHYPE",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "HyperEVM"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/70200/large/vhype.png?1761010927"
-		},
-		{
-			"chainId": 999,
-			"address": "0x9ba2edc44e0a4632eb4723e81d4142353e1bb160",
-			"name": "Kinetiq Earn Vault",
-			"symbol": "vkHYPE",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "HyperEVM"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/69439/large/vkhype.png?1758596795"
-		},
-		{
-			"chainId": 999,
 			"address": "0x5555555555555555555555555555555555555555",
 			"name": "Wrapped HYPE",
 			"symbol": "WHYPE",
@@ -3475,19 +3462,6 @@
 		},
 		{
 			"chainId": 999,
-			"address": "0x94e8396e0869c9f2200760af0621afd240e1cf38",
-			"name": "Staked HYPE Shares",
-			"symbol": "wstHYPE",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "HyperEVM"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/54722/large/hyperliquid.png?1741232793"
-		},
-		{
-			"chainId": 999,
 			"address": "0xf4d9235269a96aadafc9adae454a0618ebe37949",
 			"name": "XAUt0",
 			"symbol": "XAUt0",
@@ -3498,19 +3472,6 @@
 				"chainName": "HyperEVM"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/66560/large/XAUt0_Token_Icon_Gold.png?1749747942"
-		},
-		{
-			"chainId": 1088,
-			"address": "0x79bbf4508b1391af3a0f4b30bb5fc4aa9ab0e07c",
-			"name": "HeyAnon",
-			"symbol": "Anon",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Metis"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/52961/large/AAI__ANON_SQ_Wb_250x250.png?1740500195"
 		},
 		{
 			"chainId": 1088,
@@ -3550,19 +3511,6 @@
 				"chainName": "Metis"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/24751/large/heraLogo-200px.png?1721043422"
-		},
-		{
-			"chainId": 1088,
-			"address": "0x17c09cfc96c865cf546d73365cedb6dc66986963",
-			"name": "JEWEL",
-			"symbol": "JEWEL",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Metis"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/18570/large/jewel_token_x2.png?1702076846"
 		},
 		{
 			"chainId": 1088,
@@ -3747,32 +3695,6 @@
 			"logoURI": "https://ethereum-optimism.github.io/data/USDC/logo.png"
 		},
 		{
-			"chainId": 1424,
-			"address": "0x39cd9ef9e511ec008247ad5da01245d84a9521be",
-			"name": "USD Coin",
-			"symbol": "USDC",
-			"decimals": 6,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Perennial"
-			},
-			"logoURI": "https://ethereum-optimism.github.io/data/USDC/logo.png"
-		},
-		{
-			"chainId": 1514,
-			"address": "0xfe82012ecce57a188e5f9f3fc1cb2d335c58f1f5",
-			"name": "Aria Premiere Launch",
-			"symbol": "APL",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Story"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/66927/large/download.png?1751093687"
-		},
-		{
 			"chainId": 1514,
 			"address": "0xc9cbbd8f211300dd0e7a3933b7aeedac6f61dd52",
 			"name": "Aria",
@@ -3781,22 +3703,22 @@
 			"extensions": {
 				"vmType": "evm",
 				"verified": false,
-				"chainName": "Story"
+				"chainName": "Data"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/70388/large/logo-abberation-token-white.png?1762454816"
 		},
 		{
 			"chainId": 1514,
 			"address": "0x0000000000000000000000000000000000000000",
-			"name": "IP",
-			"symbol": "IP",
+			"name": "DATA",
+			"symbol": "DATA",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
 				"verified": true,
-				"chainName": "Story"
+				"chainName": "Data"
 			},
-			"logoURI": "https://assets.relay.link/icons/currencies/ip.png"
+			"logoURI": "https://assets.relay.link/icons/currencies/data.png"
 		},
 		{
 			"chainId": 1514,
@@ -3807,7 +3729,7 @@
 			"extensions": {
 				"vmType": "evm",
 				"verified": true,
-				"chainName": "Story"
+				"chainName": "Data"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/68997/large/0x543374350269cce6651358769512875faa4cccff.png?1757225559"
 		},
@@ -3820,7 +3742,7 @@
 			"extensions": {
 				"vmType": "evm",
 				"verified": true,
-				"chainName": "Story"
+				"chainName": "Data"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/68054/large/1000440957.jpg?1754637180"
 		},
@@ -3833,22 +3755,9 @@
 			"extensions": {
 				"vmType": "evm",
 				"verified": false,
-				"chainName": "Story"
+				"chainName": "Data"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/53984/large/WhatsApp_Image_2025-01-22_at_23.29.41.jpeg?1737876448"
-		},
-		{
-			"chainId": 1514,
-			"address": "0xb5461c1fd0312cd4bf037058f8a391e6a42f9639",
-			"name": "Staked APL",
-			"symbol": "stAPL",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Story"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/67815/large/APL_logo.jpg?1753940903"
 		},
 		{
 			"chainId": 1514,
@@ -3859,7 +3768,7 @@
 			"extensions": {
 				"vmType": "evm",
 				"verified": true,
-				"chainName": "Story"
+				"chainName": "Data"
 			},
 			"logoURI": "https://ethereum-optimism.github.io/data/USDC/logo.png"
 		},
@@ -3872,9 +3781,22 @@
 			"extensions": {
 				"vmType": "evm",
 				"verified": true,
-				"chainName": "Story"
+				"chainName": "Data"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/54378/large/image.png?1739437755"
+		},
+		{
+			"chainId": 1868,
+			"address": "0x570f09ac53b96929e3868f71864e36ff6b1b67d7",
+			"name": "Arcas",
+			"symbol": "ARCAS",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": true,
+				"chainName": "Soneium"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/17404/large/Arcas_Logo.png?1737199437"
 		},
 		{
 			"chainId": 1868,
@@ -3901,19 +3823,6 @@
 				"chainName": "Soneium"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/71031/large/Kyo.png?1765377840"
-		},
-		{
-			"chainId": 1868,
-			"address": "0x9317841c2e9f6bcb44119c184152cfb1ef79034a",
-			"name": "Lootcoin",
-			"symbol": "LOOT",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Soneium"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/71197/large/lootcoin-logo.jpg?1766302463"
 		},
 		{
 			"chainId": 1868,
@@ -3969,16 +3878,16 @@
 		},
 		{
 			"chainId": 1868,
-			"address": "0xcc0966d8418d412c599a6421b760a847eb169a8c",
-			"name": "SolvBTC Babylon",
-			"symbol": "SolvBTC.BBN",
+			"address": "0xaffeb8576b927050f5a3b6fba43f360d2883a118",
+			"name": "SolvBTC Jupiter",
+			"symbol": "SolvBTC.JUP",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
 				"verified": false,
 				"chainName": "Soneium"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/39384/large/xSolvBTC.png?1744170824"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/54834/large/solvBTC_Jupiter.png?1741969449"
 		},
 		{
 			"chainId": 1868,
@@ -4137,19 +4046,6 @@
 			"logoURI": "https://coin-images.coingecko.com/coins/images/54279/large/Yay!_Stone200w.png?1739438931"
 		},
 		{
-			"chainId": 1923,
-			"address": "0x0000000000000000000000000000000000000000",
-			"name": "Ether",
-			"symbol": "ETH",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "SwellChain"
-			},
-			"logoURI": "https://assets.relay.link/icons/1/light.png"
-		},
-		{
 			"chainId": 2020,
 			"address": "0x97a9107c1793bc407d6f527b77e7fff4d812bece",
 			"name": "Axie Infinity Shard",
@@ -4161,19 +4057,6 @@
 				"chainName": "Ronin"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/13029/large/axie_infinity_logo.png?1696512817"
-		},
-		{
-			"chainId": 2020,
-			"address": "0x1a89ecd466a23e98f07111b0510a2d6c1cd5e400",
-			"name": "Banana",
-			"symbol": "BANANA",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Ronin"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/17521/large/banana-token-cg.png?1696517059"
 		},
 		{
 			"chainId": 2020,
@@ -4229,6 +4112,19 @@
 		},
 		{
 			"chainId": 2020,
+			"address": "0x0176eea5ec1bf7420617a80a046547793ad4c147",
+			"name": "KANSTAR",
+			"symbol": "KANSTAR",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Ronin"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/53999/large/KANSTAR_ICON.PNG?1737889150"
+		},
+		{
+			"chainId": 2020,
 			"address": "0xc6046fa4b8961b0e9d823bb3f2dde8fe161d547d",
 			"name": "KDR",
 			"symbol": "KDR",
@@ -4255,16 +4151,16 @@
 		},
 		{
 			"chainId": 2020,
-			"address": "0x18d2bdef572c67127e218c425f546fe64430a92c",
-			"name": "Lumi Finance USD",
-			"symbol": "LUAUSD",
+			"address": "0x3902228d6a3d2dc44731fd9d45fee6a61c722d0b",
+			"name": "ChainLink Token",
+			"symbol": "LINK",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
 				"verified": false,
 				"chainName": "Ronin"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/33503/large/LUAUSD.png?1702038709"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/877/large/Chainlink_Logo_500.png?1760023405"
 		},
 		{
 			"chainId": 2020,
@@ -4476,16 +4372,16 @@
 		},
 		{
 			"chainId": 2741,
-			"address": "0x1cd6edb761ed1d68c3cc3c5b9b3e9460887fd139",
-			"name": "DITH'S CAT",
-			"symbol": "CYCLOPS",
+			"address": "0x02b31475af969ea987dfe799c56451d532a146ee",
+			"name": "ABSCHAD",
+			"symbol": "CHAD",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
-				"verified": true,
+				"verified": false,
 				"chainName": "Abstract"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/68217/large/CYCLOPS_ORIGINAL_PICTURE.jpeg?1755093642"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/68255/large/DKyE8s47_400x400.jpg?1755201604"
 		},
 		{
 			"chainId": 2741,
@@ -4502,19 +4398,6 @@
 		},
 		{
 			"chainId": 2741,
-			"address": "0x5e1f9a9bd16deb2a44c9723a72d99f759a30d907",
-			"name": "Froth",
-			"symbol": "FROTH",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Abstract"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/52318/large/froth.png?1733077044"
-		},
-		{
-			"chainId": 2741,
 			"address": "0xc25714e79b694eee7e8e8d21dae332a797d28ac0",
 			"name": "gBLUE",
 			"symbol": "gBLUE",
@@ -4525,6 +4408,19 @@
 				"chainName": "Abstract"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/71351/large/gblue256.png?1767495320"
+		},
+		{
+			"chainId": 2741,
+			"address": "0x605895c31ae716fae8280504f96286d8dbda7f4a",
+			"name": "AbsGlorp",
+			"symbol": "Glorp",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Abstract"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/68344/large/pfp.png?1755410849"
 		},
 		{
 			"chainId": 2741,
@@ -4567,16 +4463,16 @@
 		},
 		{
 			"chainId": 2741,
-			"address": "0xc6b3c271946e5013380fb7322d5bc67f81e02481",
-			"name": "LOL Land",
-			"symbol": "LOL",
+			"address": "0xce2fbf6edfa8b759c4e0c80d73f1aff2a93b054b",
+			"name": "PudgyStrategy",
+			"symbol": "PDGYSTR",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
 				"verified": false,
 				"chainName": "Abstract"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/70430/large/Lol_Token_Icon.PNG?1761982208"
+			"logoURI": "https://assets.geckoterminal.com/65jir39r7s238q4z8t98wv7ipnss"
 		},
 		{
 			"chainId": 2741,
@@ -4684,6 +4580,19 @@
 		},
 		{
 			"chainId": 4217,
+			"address": "0x20c0000000000000000000009a4a4b17e0dc6651",
+			"name": "AllUnity EUR",
+			"symbol": "EURAU",
+			"decimals": 6,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Tempo"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/68076/large/EURAU_blue.png?1782278504"
+		},
+		{
+			"chainId": 4217,
 			"address": "0x20c0000000000000000000000000000000000000",
 			"name": "Path USD",
 			"symbol": "PathUSD",
@@ -4746,19 +4655,6 @@
 				"chainName": "MegaETH"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/102173059/large/duck.jpg?1777555120"
-		},
-		{
-			"chainId": 4326,
-			"address": "0x0000000000000000000000000000000000000000",
-			"name": "Ether",
-			"symbol": "ETH",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "MegaETH"
-			},
-			"logoURI": "https://assets.relay.link/icons/1/light.png"
 		},
 		{
 			"chainId": 4326,
@@ -4891,17 +4787,264 @@
 			"logoURI": "https://coin-images.coingecko.com/coins/images/102173060/large/sigma_bunny.jpg?1777555311"
 		},
 		{
-			"chainId": 5000,
-			"address": "0x00000000efe302beaa2b3e6e1b18d08d69a9012a",
-			"name": "AUSD",
-			"symbol": "AUSD",
-			"decimals": 6,
+			"chainId": 4663,
+			"address": "0xf2915d1e3c1b0c769d0c756ec43f1c1f6c99cd03",
+			"name": "Arrow",
+			"symbol": "ARROW",
+			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
 				"verified": false,
-				"chainName": "Mantle"
+				"chainName": "Robinhood Chain"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/39284/large/Circle_Agora_White_on_Olive_1080px.png?1722961274"
+			"logoURI": "https://assets.geckoterminal.com/43zbrz8v0ejqxxstwmt88xt8kkt1"
+		},
+		{
+			"chainId": 4663,
+			"address": "0xaf4c10fef50059d1e3e8ab1c80e46db6a76098b4",
+			"name": "Bowyer App by Virtuals",
+			"symbol": "BOWYER",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Robinhood Chain"
+			},
+			"logoURI": "https://assets.geckoterminal.com/3jkwzwiyv769b9o2cumpl1o5c7ne"
+		},
+		{
+			"chainId": 4663,
+			"address": "0x020bfc650a365f8bb26819deaabf3e21291018b4",
+			"name": "Cash Cat",
+			"symbol": "CASHCAT",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Robinhood Chain"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/102174280/large/cashcat-logo.jpg?1782922765"
+		},
+		{
+			"chainId": 4663,
+			"address": "0x1abf16f660ccbaa22ce8646deb1b63635d582228",
+			"name": "Fonz on Pons",
+			"symbol": "FONZ",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Robinhood Chain"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/102174658/large/fonz.jpg?1784446665"
+		},
+		{
+			"chainId": 4663,
+			"address": "0x7fe995a80075df3dc8ae11a9b82c7fe4202cd87f",
+			"name": "Thinking Cat",
+			"symbol": "HMM",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Robinhood Chain"
+			},
+			"logoURI": "https://assets.geckoterminal.com/fmu02lq7zai1iyp4qqwfnmu5wr1v"
+		},
+		{
+			"chainId": 4663,
+			"address": "0x8e62f281f282686fca6dcb39288069a93fc23f1c",
+			"name": "Hoodrat",
+			"symbol": "HOODRAT",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Robinhood Chain"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/102174350/large/hoodrat_400x400.jpg?1783361154"
+		},
+		{
+			"chainId": 4663,
+			"address": "0xd7321801caae694090694ff55a9323139f043b88",
+			"name": "The Juggernaut",
+			"symbol": "JUGGERNAUT",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Robinhood Chain"
+			},
+			"logoURI": "https://assets.geckoterminal.com/85cjg6du87ljb72yga9i14m42cb2"
+		},
+		{
+			"chainId": 4663,
+			"address": "0xb47f4702deb124cb4eb6286be83c9d84277c6239",
+			"name": "Karma by Virtuals",
+			"symbol": "KARMA",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Robinhood Chain"
+			},
+			"logoURI": "https://assets.geckoterminal.com/3jy9qsd8qu9527llxncb5532ri2c"
+		},
+		{
+			"chainId": 4663,
+			"address": "0x8ed8ab093d29e9ccbc26bb38df09910ae1d69125",
+			"name": "Nuggies",
+			"symbol": "NUG",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Robinhood Chain"
+			},
+			"logoURI": "https://assets.geckoterminal.com/wkioabj0q2i25rcbq7f78ok0ybau"
+		},
+		{
+			"chainId": 4663,
+			"address": "0x39dbed3a2bd333467115de45665cc57f813c4571",
+			"name": "Pons",
+			"symbol": "PONS",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Robinhood Chain"
+			},
+			"logoURI": "https://assets.geckoterminal.com/jhitvkisdq8fhxvimdkpcw7y3dx5"
+		},
+		{
+			"chainId": 4663,
+			"address": "0xe934e36a439c94017b64a3fece66af12099abf50",
+			"name": "StonkBroker",
+			"symbol": "STONKBROKER",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Robinhood Chain"
+			},
+			"logoURI": "https://assets.geckoterminal.com/9gwu14e3hpizobkefg65k66l70wu"
+		},
+		{
+			"chainId": 4663,
+			"address": "0x45242320dbb855eea8fd36804c6487e10e97fcf9",
+			"name": "TENDIES",
+			"symbol": "TENDIES",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Robinhood Chain"
+			},
+			"logoURI": "https://assets.geckoterminal.com/x1o0qj8dm7mlay3licerc1y75hr4"
+		},
+		{
+			"chainId": 4663,
+			"address": "0x5fc5360d0400a0fd4f2af552add042d716f1d168",
+			"name": "Global Dollar",
+			"symbol": "USDG",
+			"decimals": 6,
+			"extensions": {
+				"vmType": "evm",
+				"verified": true,
+				"chainName": "Robinhood Chain"
+			},
+			"logoURI": "https://assets.coingecko.com/coins/images/51281/standard/GDN_USDG_Token_200x200.png"
+		},
+		{
+			"chainId": 4663,
+			"address": "0x164d9da79722c5294369e79807980e0bff257777",
+			"name": "utopiadet",
+			"symbol": "utopia",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Robinhood Chain"
+			},
+			"logoURI": "https://assets.geckoterminal.com/vkoksjd43j74j4x3jxva13yl9k4l"
+		},
+		{
+			"chainId": 4663,
+			"address": "0x8ff92566f2e81bdd68edfaa8cde73942a723796b",
+			"name": "ProjectVex",
+			"symbol": "VEX",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Robinhood Chain"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/102174375/large/vex.jpg?1783487786"
+		},
+		{
+			"chainId": 4663,
+			"address": "0xc6911796042b15d7fa4f6cde69e245ddcd3d9c31",
+			"name": "Virtuals Protocol",
+			"symbol": "VIRTUAL",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Robinhood Chain"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/34057/large/LOGOMARK.png?1708356054"
+		},
+		{
+			"chainId": 4663,
+			"address": "0xc35968c7f5475bb03a43c7382526f4118e01c0de",
+			"name": "Robinvista",
+			"symbol": "VISTA",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Robinhood Chain"
+			},
+			"logoURI": "https://assets.geckoterminal.com/zyadtlnqzwoufadtwxbe4y31s8yv"
+		},
+		{
+			"chainId": 4663,
+			"address": "0x8ecea3d0e648db646d824aa51eedeb16ac3d6878",
+			"name": "wire bot",
+			"symbol": "wire",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Robinhood Chain"
+			},
+			"logoURI": "https://assets.geckoterminal.com/cuy40m3sqh9boqn7pdlzirdt299x"
+		},
+		{
+			"chainId": 4663,
+			"address": "0xf8bc08092c06db6148114dcf82af881f1085f92b",
+			"name": "Sherwood Protocol",
+			"symbol": "WOOD",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Robinhood Chain"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/102174574/large/4vvnmslrns3stkpsmbsnsv4cu5ae.?1784094690"
+		},
+		{
+			"chainId": 4663,
+			"address": "0x62c71cd34a52c30d894419cbcc55db2afa8032ea",
+			"name": "YOLO",
+			"symbol": "YOLO",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Robinhood Chain"
+			},
+			"logoURI": "https://assets.geckoterminal.com/fzvhldxmvphx85ls235mclk6bf3x"
 		},
 		{
 			"chainId": 5000,
@@ -4983,6 +5126,19 @@
 		},
 		{
 			"chainId": 5000,
+			"address": "0x58538e6a46e07434d7e7375bc268d3cb839c0133",
+			"name": "ENA",
+			"symbol": "ENA",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Mantle"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/36530/large/ethena.png?1711701436"
+		},
+		{
+			"chainId": 5000,
 			"address": "0xc96de26018a54d51c097160568752c4e3bd6c364",
 			"name": "Fire Bitcoin",
 			"symbol": "FBTC",
@@ -5035,19 +5191,6 @@
 		},
 		{
 			"chainId": 5000,
-			"address": "0x45db70e1c808dae42f9c4dfea74ba5e6a113bdc1",
-			"name": "OpenGradient",
-			"symbol": "OPG",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Mantle"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/102172863/large/coingecko_logo.png?1776349115"
-		},
-		{
-			"chainId": 5000,
 			"address": "0x26a6b0dcdcfb981362afa56d581e4a7dba3be140",
 			"name": "Puff",
 			"symbol": "PUFF",
@@ -5071,19 +5214,6 @@
 				"chainName": "Mantle"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/71138/large/Scor_logo.jpg?1765957578"
-		},
-		{
-			"chainId": 5000,
-			"address": "0x211cc4dd073734da055fbf44a2b4667d5e5fe5d2",
-			"name": "Staked USDe",
-			"symbol": "sUSDe",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Mantle"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/67307/large/susde.jpg?1752375850"
 		},
 		{
 			"chainId": 5000,
@@ -5126,6 +5256,19 @@
 		},
 		{
 			"chainId": 5000,
+			"address": "0x201eba5cc46d216ce6dc03f6a759e8e766e956ae",
+			"name": "Tether USD",
+			"symbol": "USDT",
+			"decimals": 6,
+			"extensions": {
+				"vmType": "evm",
+				"verified": true,
+				"chainName": "Mantle"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/35069/large/logo.png?1707291114"
+		},
+		{
+			"chainId": 5000,
 			"address": "0x779ded0c9e1022225f8e0630b35a9b54be713736",
 			"name": "USDT0",
 			"symbol": "USDT0",
@@ -5136,6 +5279,19 @@
 				"chainName": "Mantle"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/53705/large/usdt0.jpg?1737086183"
+		},
+		{
+			"chainId": 5000,
+			"address": "0xd81a4adea9932a6bdba0bdbc8c5fd4c78e5a09f1",
+			"name": "VOOI",
+			"symbol": "VOOI",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Mantle"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/70365/large/VOOI_Token_Logo.png?1764177739"
 		},
 		{
 			"chainId": 5000,
@@ -5161,7 +5317,7 @@
 				"verified": true,
 				"chainName": "Somnia"
 			},
-			"logoURI": "https://assets.coingecko.com/coins/images/68061/large/somniacg.png?1754641117"
+			"logoURI": "https://assets.relay.link/icons/currencies/somi.png"
 		},
 		{
 			"chainId": 5330,
@@ -5230,42 +5386,29 @@
 		},
 		{
 			"chainId": 8453,
-			"address": "0xcb111e6a2a3bde90856d299d61341ac302167d23",
-			"name": "Coinbase Wrapped MEGA",
-			"symbol": "cbMEGA",
+			"address": "0x2ae3f1ec7f1f5012cfeab0185bfc7aa3cf0dec22",
+			"name": "Coinbase Wrapped Staked ETH",
+			"symbol": "cbETH",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
-				"verified": false,
+				"verified": true,
 				"chainName": "Base"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/102173020/large/megaeth.png?1777256235"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/27008/large/cbeth.png?1709186989"
 		},
 		{
 			"chainId": 8453,
-			"address": "0x9126236476efba9ad8ab77855c60eb5bf37586eb",
-			"name": "Checkmate",
-			"symbol": "CHECK",
-			"decimals": 18,
+			"address": "0xcb585250f852c6c6bf90434ab21a00f02833a4af",
+			"name": "Coinbase Wrapped XRP",
+			"symbol": "cbXRP",
+			"decimals": 6,
 			"extensions": {
 				"vmType": "evm",
-				"verified": false,
+				"verified": true,
 				"chainName": "Base"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/69231/large/VgVwfk9E_400x400.png?1761800742"
-		},
-		{
-			"chainId": 8453,
-			"address": "0x11030f79109269d796fd0fb956d6244e502757f7",
-			"name": "CTR",
-			"symbol": "CTR",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Base"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/102173169/large/CTR.png?1778226916"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/66267/large/Coinbase_Wrapped_XPR_%28cbXRP%29.png?1749023398"
 		},
 		{
 			"chainId": 8453,
@@ -5308,42 +5451,42 @@
 		},
 		{
 			"chainId": 8453,
-			"address": "0xc0634090f2fe6c6d75e61be2b949464abb498973",
-			"name": "Keeta",
-			"symbol": "KTA",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Base"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/54723/large/2025-03-05_22.53.06.jpg?1741234207"
-		},
-		{
-			"chainId": 8453,
-			"address": "0x7ba6f01772924a82d9626c126347a28299e98c98",
-			"name": "Metronome Synth ETH",
-			"symbol": "msETH",
+			"address": "0x14d6c649292c5c9790c5196d1a9ea039307947a1",
+			"name": "GULD",
+			"symbol": "GULD",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
 				"verified": false,
 				"chainName": "Base"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/67512/large/metronome_mseth.png?1753017508"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/102173593/large/250x250_GULD_icon.png?1780327048"
 		},
 		{
 			"chainId": 8453,
-			"address": "0x526728dbc96689597f85ae4cd716d4f7fccbae9d",
-			"name": "Metronome Synth USD",
-			"symbol": "msUSD",
+			"address": "0x9b5e262cf9bb04869ab40b19af91d2dc85761722",
+			"name": "Nock",
+			"symbol": "NOCK",
+			"decimals": 16,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Base"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/68474/large/GrCcG9N9_400x400.jpg?1755845184"
+		},
+		{
+			"chainId": 8453,
+			"address": "0x182fa643e5f29d5eca75e7b9cf9336a3fe4620b2",
+			"name": "o1.exchange",
+			"symbol": "O",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
-				"verified": true,
+				"verified": false,
 				"chainName": "Base"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/67504/large/metronome_msusd.png?1753015705"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/102173974/large/o1.png?1781654491"
 		},
 		{
 			"chainId": 8453,
@@ -5422,6 +5565,19 @@
 				"chainName": "Base"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/39963/large/usdt.png?1724952731"
+		},
+		{
+			"chainId": 8453,
+			"address": "0x9b8df6e244526ab5f6e6400d331db28c8fdddb55",
+			"name": "Solana (Universal)",
+			"symbol": "uSOL",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": true,
+				"chainName": "Base"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/39987/large/UA-SOL_1.png?1725027946"
 		},
 		{
 			"chainId": 8453,
@@ -5555,19 +5711,6 @@
 		},
 		{
 			"chainId": 34443,
-			"address": "0x12d8ce035c5de3ce39b1fdd4c1d5a745eaba3b8c",
-			"name": "Ankr Staked ETH",
-			"symbol": "ankrETH",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Mode"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/13403/large/aETHc.png?1696513165"
-		},
-		{
-			"chainId": 34443,
 			"address": "0x66eed5ff1701e6ed8470dc391f05e27b1d0657eb",
 			"name": "BMX",
 			"symbol": "BMX",
@@ -5672,6 +5815,45 @@
 		},
 		{
 			"chainId": 34443,
+			"address": "0x211cc4dd073734da055fbf44a2b4667d5e5fe5d2",
+			"name": "Staked USDe",
+			"symbol": "sUSDe",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Mode"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/33669/large/sUSDe-Symbol-Color.png?1716307680"
+		},
+		{
+			"chainId": 34443,
+			"address": "0x6b2a01a5f79deb4c2f3c0eda7b01df456fbd726a",
+			"name": "uniBTC",
+			"symbol": "uniBTC",
+			"decimals": 8,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Mode"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/39599/large/uniBTC_200px.png?1723064455"
+		},
+		{
+			"chainId": 34443,
+			"address": "0x102d758f688a4c1c5a80b116bd945d4455460282",
+			"name": "Stargate USD₮0 (Bridged)",
+			"symbol": "USD₮0",
+			"decimals": 6,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Mode"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/69528/large/usdt0.jpg?1758873945"
+		},
+		{
+			"chainId": 34443,
 			"address": "0xd988097fb8612cc24eec14542bc03424c656005f",
 			"name": "Bridged USDC",
 			"symbol": "USDC",
@@ -5763,19 +5945,6 @@
 		},
 		{
 			"chainId": 42161,
-			"address": "0xba5ddd1f9d7f570dc94a51479a000e3bce967196",
-			"name": "Aave",
-			"symbol": "AAVE",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Arbitrum"
-			},
-			"logoURI": "https://assets.coingecko.com/coins/images/12645/thumb/AAVE.png?1601374110"
-		},
-		{
-			"chainId": 42161,
 			"address": "0x912ce59144191c1204e64559fe8253a0e49e6548",
 			"name": "Arbitrum",
 			"symbol": "ARB",
@@ -5786,19 +5955,6 @@
 				"chainName": "Arbitrum"
 			},
 			"logoURI": "https://arbitrum.foundation/logo.png"
-		},
-		{
-			"chainId": 42161,
-			"address": "0x97e66d3c4d5bcd7c64e3e55af28544c9addf9281",
-			"name": "Capx",
-			"symbol": "CAPX",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Arbitrum"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/70528/large/capx_logo_icon_-_circle.png?1762334471"
 		},
 		{
 			"chainId": 42161,
@@ -5815,16 +5971,16 @@
 		},
 		{
 			"chainId": 42161,
-			"address": "0x0c1c1c109fe34733fca54b82d7b46b75cfb71f6e",
-			"name": "Chip",
-			"symbol": "CHIP",
+			"address": "0xda10009cbd5d07dd0cecc66161fc93d7c9000da1",
+			"name": "Dai Stablecoin",
+			"symbol": "DAI",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
-				"verified": false,
+				"verified": true,
 				"chainName": "Arbitrum"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/102171777/large/usdai_400x400.jpg?1769613270"
+			"logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
 		},
 		{
 			"chainId": 42161,
@@ -5854,6 +6010,19 @@
 		},
 		{
 			"chainId": 42161,
+			"address": "0x11e969e9b3f89cb16d686a03cd8508c9fc0361af",
+			"name": "Axelar Wrapped LAVA",
+			"symbol": "LAVA",
+			"decimals": 6,
+			"extensions": {
+				"vmType": "evm",
+				"verified": true,
+				"chainName": "Arbitrum"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/37354/large/lava_logo.png?1714098423"
+		},
+		{
+			"chainId": 42161,
 			"address": "0xf97f4df75117a78c1a5a0dbb814af92458539fb4",
 			"name": "ChainLink Token",
 			"symbol": "LINK",
@@ -5864,19 +6033,6 @@
 				"chainName": "Arbitrum"
 			},
 			"logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png"
-		},
-		{
-			"chainId": 42161,
-			"address": "0xb23bb8c2c6cb9169eeac8f2bd42fcf333a1a8c55",
-			"name": "NOXCAT",
-			"symbol": "NOX",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Arbitrum"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/102172661/large/%E8%B5%84%E6%BA%90_11_2x_1.png?1774539921"
 		},
 		{
 			"chainId": 42161,
@@ -5906,19 +6062,6 @@
 		},
 		{
 			"chainId": 42161,
-			"address": "0x1337420ded5adb9980cfc35f8f2b054ea86f8ab1",
-			"name": "Subsquid",
-			"symbol": "SQD",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Arbitrum"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/37869/large/New_Logo_SQD_Icon.png?1720048443"
-		},
-		{
-			"chainId": 42161,
 			"address": "0x0b2b2b2076d95dda7817e785989fe353fe955ef9",
 			"name": "Staked USDai",
 			"symbol": "sUSDai",
@@ -5942,6 +6085,19 @@
 				"chainName": "Arbitrum"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/11224/large/0x18084fba666a33d37592fa2633fd49a74dd93a88.png?1696511155"
+		},
+		{
+			"chainId": 42161,
+			"address": "0x0a1a1a107e45b7ced86833863f482bc5f4ed82ef",
+			"name": "USDai",
+			"symbol": "USDai",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Arbitrum"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/55857/large/USDai_Token_Full_Glyph.png?1755229050"
 		},
 		{
 			"chainId": 42161,
@@ -6022,6 +6178,32 @@
 			"logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png"
 		},
 		{
+			"chainId": 42161,
+			"address": "0x35751007a407ca6feffe80b3cb397736d2cf4dbe",
+			"name": "Wrapped eETH",
+			"symbol": "weETH",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": true,
+				"chainName": "Arbitrum"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/33033/large/weETH.png?1701438396"
+		},
+		{
+			"chainId": 42161,
+			"address": "0x5979d7b546e38e414f7e9822514be443a4800529",
+			"name": "Wrapped stETH",
+			"symbol": "WSTETH",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": true,
+				"chainName": "Arbitrum"
+			},
+			"logoURI": "https://assets.coingecko.com/coins/images/18834/large/wstETH.png?1633565443"
+		},
+		{
 			"chainId": 42170,
 			"address": "0xf823c3cd3cebe0a1fa952ba88dc9eef8e0bf46ad",
 			"name": "Arbitrum",
@@ -6088,16 +6270,42 @@
 		},
 		{
 			"chainId": 42220,
-			"address": "0x2e6c05f1f7d1f4eb9a088bf12257f1647682b754",
-			"name": "Axelar Wrapped REGEN",
-			"symbol": "axlREGEN",
-			"decimals": 6,
+			"address": "0x7175504c455076f15c04a2f90a8e352281f492f9",
+			"name": "Celo Australian Dollar",
+			"symbol": "cAUD",
+			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
 				"verified": false,
 				"chainName": "Celo"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/16733/large/REGEN.png?1696516306"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/55375/large/AUDm_%28Mento_Australian_Dollar%29.png?1769111580"
+		},
+		{
+			"chainId": 42220,
+			"address": "0xff4ab19391af240c311c54200a492233052b6325",
+			"name": "Celo Canadian Dollar",
+			"symbol": "cCAD",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Celo"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/55376/large/CADm_%28Mento_Canadian_Dollar%29.png?1769111643"
+		},
+		{
+			"chainId": 42220,
+			"address": "0xb55a79f398e759e43c95b979163f30ec87ee131d",
+			"name": "Celo Swiss Franc",
+			"symbol": "cCHF",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Celo"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/66415/large/CHFm_%28Mento_Swiss_Franc%29.png?1769208716"
 		},
 		{
 			"chainId": 42220,
@@ -6127,6 +6335,19 @@
 		},
 		{
 			"chainId": 42220,
+			"address": "0xccf663b1ff11028f0b19058d0f7b674004a40746",
+			"name": "Celo British Pound",
+			"symbol": "cGBP",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Celo"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/55374/large/GBPm__%28Mento_British_Pound%29.png?1769111439"
+		},
+		{
+			"chainId": 42220,
 			"address": "0xfaea5f3404bba20d3cc2f8c4b0a888f55a3c7313",
 			"name": "Celo Ghanian Cedi",
 			"symbol": "cGHS",
@@ -6153,19 +6374,6 @@
 		},
 		{
 			"chainId": 42220,
-			"address": "0xe8537a3d056da446677b9e9d6c5db704eaab4787",
-			"name": "Celo Brazilian Real",
-			"symbol": "cREAL",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Celo"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/27205/large/creal.png?1696526254"
-		},
-		{
-			"chainId": 42220,
 			"address": "0x765de816845861e75a25fca122bb6898b8b1282a",
 			"name": "Celo Dollar",
 			"symbol": "cUSD",
@@ -6179,16 +6387,16 @@
 		},
 		{
 			"chainId": 42220,
-			"address": "0x9995cc8f20db5896943afc8ee0ba463259c931ed",
-			"name": "Ethix (Wormhole)",
-			"symbol": "ETHIX",
+			"address": "0x4c35853a3b4e647fd266f4de678dcc8fec410bf6",
+			"name": "Celo South African Rand",
+			"symbol": "cZAR",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
 				"verified": false,
 				"chainName": "Celo"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/3031/large/ETHIX_icon_256x256-256.png?1696503766"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/55377/large/cZAR.png?1745667766"
 		},
 		{
 			"chainId": 42220,
@@ -6231,19 +6439,6 @@
 		},
 		{
 			"chainId": 42220,
-			"address": "0xacffae8e57ec6e394eb1b41939a8cf7892dbdc51",
-			"name": "Autonolas",
-			"symbol": "OLAS",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Celo"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/31099/large/OLAS-token.png?1696529930"
-		},
-		{
-			"chainId": 42220,
 			"address": "0x105d4a9306d2e55a71d2eb95b81553ae1dc20d7b",
 			"name": "PUSO",
 			"symbol": "PUSO",
@@ -6254,6 +6449,19 @@
 				"chainName": "Celo"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/50608/large/PUSO_transparent.png?1728473971"
+		},
+		{
+			"chainId": 42220,
+			"address": "0xc668583dcbdc9ae6fa3ce46462758188adfdfc24",
+			"name": "Staked CELO",
+			"symbol": "stCELO",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Celo"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/27088/large/For_larger_icons_%28192x192__512x512__etc%29.png?1696526137"
 		},
 		{
 			"chainId": 42220,
@@ -6296,19 +6504,6 @@
 		},
 		{
 			"chainId": 42220,
-			"address": "0x59d9356e565ab3a36dd77763fc0d87feaf85508c",
-			"name": "Mountain Protocol USD",
-			"symbol": "USDM",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Celo"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/31719/large/usdm.png?1696530540"
-		},
-		{
-			"chainId": 42220,
 			"address": "0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e",
 			"name": "Tether USD",
 			"symbol": "USDT",
@@ -6335,6 +6530,19 @@
 		},
 		{
 			"chainId": 43114,
+			"address": "0xb8d7710f7d8349a506b75dd184f05777c82dad0c",
+			"name": "ArenaToken",
+			"symbol": "ARENA",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": true,
+				"chainName": "Avalanche"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/51173/large/_ARENA_TokenLogo_200x200.png?1730282003"
+		},
+		{
+			"chainId": 43114,
 			"address": "0x00000000efe302beaa2b3e6e1b18d08d69a9012a",
 			"name": "AUSD",
 			"symbol": "AUSD",
@@ -6358,6 +6566,32 @@
 				"chainName": "Avalanche"
 			},
 			"logoURI": "https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/avalanchec/assets/0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7/logo.png"
+		},
+		{
+			"chainId": 43114,
+			"address": "0x24de8771bc5ddb3362db529fc3358f2df3a0e346",
+			"name": "avUSD",
+			"symbol": "avUSD",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": true,
+				"chainName": "Avalanche"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/53527/large/token-avusd.png?1736579003"
+		},
+		{
+			"chainId": 43114,
+			"address": "0xfab550568c688d5d8a52c7d794cb93edc26ec0ec",
+			"name": "Axelar Wrapped USDC",
+			"symbol": "axlUSDC",
+			"decimals": 6,
+			"extensions": {
+				"vmType": "evm",
+				"verified": true,
+				"chainName": "Avalanche"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/26476/large/uausdc_D_3x.png?1696525548"
 		},
 		{
 			"chainId": 43114,
@@ -6426,6 +6660,19 @@
 		},
 		{
 			"chainId": 43114,
+			"address": "0xd586e7f844cea2f87f50152665bcbc2c279d8d70",
+			"name": "Dai Stablecoin",
+			"symbol": "DAI",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": true,
+				"chainName": "Avalanche"
+			},
+			"logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+		},
+		{
+			"chainId": 43114,
 			"address": "0xc891eb4cbdeff6e073e859e987815ed1505c2acd",
 			"name": "Euro Coin",
 			"symbol": "EURC",
@@ -6452,45 +6699,6 @@
 		},
 		{
 			"chainId": 43114,
-			"address": "0xa25eaf2906fa1a3a13edac9b9657108af7b703e3",
-			"name": "GoGoPool Liquid Staking Token",
-			"symbol": "ggAVAX",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Avalanche"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/33543/large/ggavax-token-flat.png?1702383352"
-		},
-		{
-			"chainId": 43114,
-			"address": "0x26debd39d5ed069770406fca10a0e4f8d2c743eb",
-			"name": "GUN",
-			"symbol": "GUN",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Avalanche"
-			},
-			"logoURI": "https://storage.gunbygunz.com/gunz_symbol_320x320.png"
-		},
-		{
-			"chainId": 43114,
-			"address": "0x130966628846bfd36ff31a822705796e8cb8c18d",
-			"name": "Magic Internet Money",
-			"symbol": "MIM",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Avalanche"
-			},
-			"logoURI": "https://assets.coingecko.com/coins/images/16786/thumb/mimlogopng.png?1624979612"
-		},
-		{
-			"chainId": 43114,
 			"address": "0x5e0e90e268bc247cc850c789a0db0d5c7621fb59",
 			"name": "NXPC",
 			"symbol": "NXPC",
@@ -6501,19 +6709,6 @@
 				"chainName": "Avalanche"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/55703/large/wk63iOZz_400x400.png?1747126039"
-		},
-		{
-			"chainId": 43114,
-			"address": "0x60781c2586d68229fde47564546784ab3faca982",
-			"name": "Pangolin",
-			"symbol": "PNG",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Avalanche"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/14023/large/PNG_token.png?1696513750"
 		},
 		{
 			"chainId": 43114,
@@ -6582,16 +6777,16 @@
 		},
 		{
 			"chainId": 43114,
-			"address": "0x2775d5105276781b4b85ba6ea6a6653beed1dd32",
-			"name": "XAUt0",
-			"symbol": "XAUt0",
-			"decimals": 6,
+			"address": "0x0555e30da8f98308edb960aa94c0db47230d2b9c",
+			"name": "Wrapped BTC",
+			"symbol": "WBTC",
+			"decimals": 8,
 			"extensions": {
 				"vmType": "evm",
-				"verified": false,
+				"verified": true,
 				"chainName": "Avalanche"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/66560/large/XAUt0_Token_Icon_Gold.png?1749747942"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/67285/large/wbtc.jpg?1752299240"
 		},
 		{
 			"chainId": 43419,
@@ -6894,6 +7089,19 @@
 		},
 		{
 			"chainId": 59144,
+			"address": "0x67454b41baf8d29751cc64f60e3c62b5634567a4",
+			"name": "TBAG",
+			"symbol": "$TBAG",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Linea"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/69384/large/TokenIcon.png?1758357855"
+		},
+		{
+			"chainId": 59144,
 			"address": "0xeb466342c4d449bc9f53a865d5cb90586f405215",
 			"name": "Axelar Wrapped USDC",
 			"symbol": "axlUSDC",
@@ -6933,6 +7141,19 @@
 		},
 		{
 			"chainId": 59144,
+			"address": "0xacb54d07ca167934f57f829bee2cc665e1a5ebef",
+			"name": "CROAK",
+			"symbol": "CROAK",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": true,
+				"chainName": "Linea"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/38592/large/Croak-for-coingeko.png?1718092516"
+		},
+		{
+			"chainId": 59144,
 			"address": "0x4af15ec2a0bd43db75dd04e62faa3b8ef36b00d5",
 			"name": "Dai Stablecoin",
 			"symbol": "DAI",
@@ -6943,6 +7164,19 @@
 				"chainName": "Linea"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/31272/large/dai-stablecoin.png?1696530095"
+		},
+		{
+			"chainId": 59144,
+			"address": "0xeb1fd1dbb8adda4fa2b5a5c4bce34f6f20d125d2",
+			"name": "Donald Toad Coin",
+			"symbol": "DTC",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Linea"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/51996/large/Donald_Toad_Transparent.png?1732459916"
 		},
 		{
 			"chainId": 59144,
@@ -6998,6 +7232,19 @@
 		},
 		{
 			"chainId": 59144,
+			"address": "0x43e8809ea748eff3204ee01f08872f063e44065f",
+			"name": "Mendi Finance",
+			"symbol": "MENDI",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": true,
+				"chainName": "Linea"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/31418/large/MENDI.png?1720487871"
+		},
+		{
+			"chainId": 59144,
 			"address": "0xaca92e438df0b2401ff60da7e4337b687a2435da",
 			"name": "MetaMask USD",
 			"symbol": "mUSD",
@@ -7024,55 +7271,16 @@
 		},
 		{
 			"chainId": 59144,
-			"address": "0xe4eeb461ad1e4ef8b8ef71a33694ccd84af051c4",
-			"name": "Etherex Liquid Staking Token",
-			"symbol": "REX33",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Linea"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/68282/large/rex33.png?1755242075"
-		},
-		{
-			"chainId": 59144,
-			"address": "0x6ef95b6f3b0f39508e3e04054be96d5ee39ede0d",
-			"name": "Symbiosis",
-			"symbol": "SIS",
+			"address": "0x56aa6d651bfefa9207b35e508716466359bae8ef",
+			"name": "Turtle",
+			"symbol": "TURTLE",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
 				"verified": false,
 				"chainName": "Linea"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/20805/large/SymbiosisFinance_logo-150x150.jpeg?1696520198"
-		},
-		{
-			"chainId": 59144,
-			"address": "0x808d7c71ad2ba3fa531b068a2417c63106bc0949",
-			"name": "StargateToken",
-			"symbol": "STG",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Linea"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/24413/large/STG_LOGO.png?1696523595"
-		},
-		{
-			"chainId": 59144,
-			"address": "0x93f4d0ab6a8b4271f4a28db399b5e30612d21116",
-			"name": "StakeStone Ether",
-			"symbol": "STONE",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Linea"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/33103/large/200_200.png?1702602672"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/69595/large/OUDzqTkE_400x400.png?1759166194"
 		},
 		{
 			"chainId": 59144,
@@ -7128,19 +7336,6 @@
 		},
 		{
 			"chainId": 59144,
-			"address": "0xd2671165570f41bbb3b0097893300b6eb6101e6c",
-			"name": "rsETHWrapper",
-			"symbol": "wrsETH",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Linea"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/37919/large/rseth.png?1715936438"
-		},
-		{
-			"chainId": 59144,
 			"address": "0xb5bedd42000b71fdde22d3ee8a79bd49a568fc8f",
 			"name": "Wrapped liquid staked Ether 2.0",
 			"symbol": "wstETH",
@@ -7193,201 +7388,6 @@
 		},
 		{
 			"chainId": 80094,
-			"address": "0x7838cec5b11298ff6a9513fa385621b765c74174",
-			"name": "Beradrome",
-			"symbol": "BERO",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Berachain"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/54626/large/beradrome_logo.webp?1740746547"
-		},
-		{
-			"chainId": 80094,
-			"address": "0x0f81001ef0a83ecce5ccebf63eb302c70a39a654",
-			"name": "Dolomite",
-			"symbol": "DOLO",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Berachain"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/54710/large/DOLO-small.png?1745398535"
-		},
-		{
-			"chainId": 80094,
-			"address": "0xfcbd14dc51f0a4d49d5e53c2e0950e0bc26d0dce",
-			"name": "Honey",
-			"symbol": "HONEY",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Berachain"
-			},
-			"logoURI": "https://www.geckoterminal.com/_next/image?url=https%3A%2F%2Fcoin-images.coingecko.com%2Fcoins%2Fimages%2F54194%2Flarge%2Fhoney.png%3F1738725085&w=64&q=75"
-		},
-		{
-			"chainId": 80094,
-			"address": "0x9b6761bf2397bb5a6624a856cc84a3a14dcd3fe5",
-			"name": "Infrared BERA",
-			"symbol": "iBERA",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Berachain"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/54671/large/ibera.jpg?1740966414"
-		},
-		{
-			"chainId": 80094,
-			"address": "0xac03caba51e17c86c921e1f6cbfbdc91f8bb2e6b",
-			"name": "Infrared BGT",
-			"symbol": "iBGT",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Berachain"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/54614/large/ibgt.jpg?1740718302"
-		},
-		{
-			"chainId": 80094,
-			"address": "0xa1b644aec990ad6023811ced36e6a2d6d128c7c9",
-			"name": "Infrared Governance Token",
-			"symbol": "IR",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Berachain"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/71127/large/infrared_finance.png?1765894946"
-		},
-		{
-			"chainId": 80094,
-			"address": "0xc0d1ac00a30fa4e30e44afc7313d6312c87e21df",
-			"name": "Kodiak token",
-			"symbol": "KDK",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Berachain"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/71160/large/KDK-Logo-200px.png?1766076667"
-		},
-		{
-			"chainId": 80094,
-			"address": "0xf3530788deb3d21e8fa2c3cbbf93317fb38a0d3c",
-			"name": "Lair",
-			"symbol": "LAIR",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Berachain"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/55181/large/Lair_token.png?1744616096"
-		},
-		{
-			"chainId": 80094,
-			"address": "0xbaadcc2962417c01af99fb2b7c75706b9bd6babe",
-			"name": "Liquid BGT",
-			"symbol": "LBGT",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Berachain"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/54878/large/lbgt.png?1742327918"
-		},
-		{
-			"chainId": 80094,
-			"address": "0xb7e448e5677d212b8c8da7d6312e8afc49800466",
-			"name": "Locks",
-			"symbol": "LOCKS",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Berachain"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/55422/large/Goldilocks_logo_no_text.png?1745919245"
-		},
-		{
-			"chainId": 80094,
-			"address": "0x1ce0a25d13ce4d52071ae7e02cf1f6606f4c79d3",
-			"name": "Nectar",
-			"symbol": "NECT",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Berachain"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/54231/large/NECT_%281%29.png?1738861282"
-		},
-		{
-			"chainId": 80094,
-			"address": "0xec901da9c68e90798bbbb74c11406a32a70652c3",
-			"name": "StakeStone Ether",
-			"symbol": "STONE",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Berachain"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/33103/large/200_200.png?1702602672"
-		},
-		{
-			"chainId": 80094,
-			"address": "0x118d2ceee9785eaf70c15cd74cd84c9f8c3eec9a",
-			"name": "POL Staked WBERA",
-			"symbol": "sWBERA",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Berachain"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/68010/large/swbera.png?1754573891"
-		},
-		{
-			"chainId": 80094,
-			"address": "0xc3827a4bc8224ee2d116637023b124ced6db6e90",
-			"name": "uniBTC",
-			"symbol": "uniBTC",
-			"decimals": 8,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Berachain"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/39599/large/uniBTC_200px.png?1723064455"
-		},
-		{
-			"chainId": 80094,
-			"address": "0x779ded0c9e1022225f8e0630b35a9b54be713736",
-			"name": "USD₮0",
-			"symbol": "USD₮0",
-			"decimals": 6,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Berachain"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/53705/large/usdt0.jpg?1737086183"
-		},
-		{
-			"chainId": 80094,
 			"address": "0x549943e04f40284185054145c6e4e9568c1d3241",
 			"name": "USD Coin",
 			"symbol": "USDC",
@@ -7400,69 +7400,17 @@
 			"logoURI": "https://ethereum-optimism.github.io/data/USDC/logo.png"
 		},
 		{
-			"chainId": 80094,
-			"address": "0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34",
-			"name": "USDe",
-			"symbol": "USDe",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Berachain"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/33613/large/usde.png?1733810059"
-		},
-		{
-			"chainId": 80094,
-			"address": "0x6969696969696969696969696969696969696969",
-			"name": "Wrapped Bera",
-			"symbol": "WBERA",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Berachain"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/54219/large/BERA_%282%29.png?1738848488"
-		},
-		{
-			"chainId": 80094,
-			"address": "0x0555e30da8f98308edb960aa94c0db47230d2b9c",
-			"name": "Wrapped BTC",
-			"symbol": "WBTC",
-			"decimals": 8,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Berachain"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/54335/large/wbtc.jpg?1739334808"
-		},
-		{
 			"chainId": 81457,
-			"address": "0x764933fbad8f5d04ccd088602096655c2ed9879f",
-			"name": "Any Inu (non-ITS)",
-			"symbol": "AI",
+			"address": "0x129ed667bf8c065fe5f66c9b44b7cb0126d85cc3",
+			"name": "AIWAIFU",
+			"symbol": "$WAI",
 			"decimals": 18,
 			"extensions": {
 				"vmType": "evm",
 				"verified": false,
 				"chainName": "Blast"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/34126/large/anyinulogo200.png?1704174269"
-		},
-		{
-			"chainId": 81457,
-			"address": "0x54e7780089aee73ef98b8238b0866a517914254e",
-			"name": "Aso Finance",
-			"symbol": "ASO",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Blast"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/38883/large/image_-_2024-06-25T182500.895.png?1719377959"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/50441/large/Logo.png?1727768050"
 		},
 		{
 			"chainId": 81457,
@@ -7476,19 +7424,6 @@
 				"chainName": "Blast"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/69736/large/usdc.jpg?1759466653"
-		},
-		{
-			"chainId": 81457,
-			"address": "0xb582dc28968c725d2868130752afa0c13ebf9b1a",
-			"name": "Blast Pepe",
-			"symbol": "BEPE",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Blast"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/35658/large/logo_200.png?1709446390"
 		},
 		{
 			"chainId": 81457,
@@ -7583,19 +7518,6 @@
 		},
 		{
 			"chainId": 81457,
-			"address": "0x818a92bc81aad0053d72ba753fb5bc3d0c5c0923",
-			"name": "Juice",
-			"symbol": "JUICE",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Blast"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/36503/large/juice-logo-purple-200x200_%281%29.png?1711619018"
-		},
-		{
-			"chainId": 81457,
 			"address": "0x000000daa580e54635a043d2773f2c698593836a",
 			"name": "Oh No",
 			"symbol": "OHNO",
@@ -7606,6 +7528,19 @@
 				"chainName": "Blast"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/36488/large/ohno.jpeg?1711563729"
+		},
+		{
+			"chainId": 81457,
+			"address": "0x9e20461bc2c4c980f62f1b279d71734207a6a356",
+			"name": "OmniCat",
+			"symbol": "OMNI",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Blast"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/33917/large/omnicatlogo.png?1717544778"
 		},
 		{
 			"chainId": 81457,
@@ -7632,6 +7567,32 @@
 				"chainName": "Blast"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/35676/large/pump_%281%29.jpg?1709520871"
+		},
+		{
+			"chainId": 81457,
+			"address": "0x4186bfc76e2e237523cbc30fd220fe055156b41f",
+			"name": "KelpDao Restaked ETH",
+			"symbol": "rsETH",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Blast"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/33800/large/Icon___Dark.png?1702991855"
+		},
+		{
+			"chainId": 81457,
+			"address": "0x08ccb86a31270fd97d927a4e17934c6262a68b7e",
+			"name": "SquadSwap",
+			"symbol": "SQUAD",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Blast"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/34653/large/SquadSwap_Logo_-_main.png?1705599291"
 		},
 		{
 			"chainId": 81457,
@@ -7764,71 +7725,6 @@
 			"logoURI": "https://coin-images.coingecko.com/coins/images/2518/large/weth.png?1696503332"
 		},
 		{
-			"chainId": 167000,
-			"address": "0xc8f4518ed4bab9a972808a493107926ce8237068",
-			"name": "Curve.Fi USD Stablecoin",
-			"symbol": "crvUSD",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Taiko"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/30118/large/crvusd.jpg?1746670973"
-		},
-		{
-			"chainId": 167000,
-			"address": "0x0000000000000000000000000000000000000000",
-			"name": "Ether",
-			"symbol": "ETH",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Taiko"
-			},
-			"logoURI": "https://assets.relay.link/icons/1/light.png"
-		},
-		{
-			"chainId": 167000,
-			"address": "0xa9d23408b9ba935c230493c40c73824df71a0975",
-			"name": "Taiko Token",
-			"symbol": "TAIKO",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Taiko"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/38058/large/icon.png?1717626867"
-		},
-		{
-			"chainId": 167000,
-			"address": "0x07d83526730c7438048d55a4fc0b850e2aab6f0b",
-			"name": "USD Coin",
-			"symbol": "USDC",
-			"decimals": 6,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Taiko"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/38472/large/usdc.png?1717648197"
-		},
-		{
-			"chainId": 167000,
-			"address": "0x19e26b0638bf63aa9fa4d14c6baf8d52ebe86c5c",
-			"name": "Bridged USDC (Stargate)",
-			"symbol": "USDC.e",
-			"decimals": 6,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "Taiko"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/69316/large/usdc.jpg?1758186473"
-		},
-		{
 			"chainId": 534352,
 			"address": "0xeb466342c4d449bc9f53a865d5cb90586f405215",
 			"name": "Axelar Wrapped USDC",
@@ -7921,19 +7817,6 @@
 		},
 		{
 			"chainId": 534352,
-			"address": "0x1467b62a6ae5cdcb10a6a8173cfe187dd2c5a136",
-			"name": "Symbiosis",
-			"symbol": "SIS",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Scroll"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/20805/large/SymbiosisFinance_logo-150x150.jpeg?1696520198"
-		},
-		{
-			"chainId": 534352,
 			"address": "0x95a52ec1d60e74cd3eb002fe54a2c74b185a4c16",
 			"name": "Skydrome",
 			"symbol": "SKY",
@@ -7944,6 +7827,19 @@
 				"chainName": "Scroll"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/33902/large/icon_200x200.png?1703237670"
+		},
+		{
+			"chainId": 534352,
+			"address": "0x8731d54e9d02c286767d56ac03e8037c07e01e98",
+			"name": "StargateToken",
+			"symbol": "STG",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Scroll"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/24413/large/STG_LOGO.png?1696523595"
 		},
 		{
 			"chainId": 534352,
@@ -7973,6 +7869,19 @@
 		},
 		{
 			"chainId": 534352,
+			"address": "0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34",
+			"name": "USDe",
+			"symbol": "USDe",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": true,
+				"chainName": "Scroll"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/33613/large/usde.png?1733810059"
+		},
+		{
+			"chainId": 534352,
 			"address": "0xf55bec9cafdbe8730f096aa55dad6d22d44099df",
 			"name": "Tether USD",
 			"symbol": "USDT",
@@ -7983,6 +7892,19 @@
 				"chainName": "Scroll"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/32610/large/usdt_%281%29.png?1698733524"
+		},
+		{
+			"chainId": 534352,
+			"address": "0x3b005fefc63ca7c8d25ee21fba3787229ba4cf03",
+			"name": "USX",
+			"symbol": "USX",
+			"decimals": 18,
+			"extensions": {
+				"vmType": "evm",
+				"verified": false,
+				"chainName": "Scroll"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/71020/large/usx.png?1765270693"
 		},
 		{
 			"chainId": 534352,
@@ -8037,17 +7959,17 @@
 			"logoURI": "https://coin-images.coingecko.com/coins/images/32615/large/wsteth.png?1698735772"
 		},
 		{
-			"chainId": 534352,
-			"address": "0x2147a89fb4608752807216d5070471c09a0dce32",
-			"name": "Z Protocol",
-			"symbol": "ZP",
-			"decimals": 18,
+			"chainId": 543210,
+			"address": "0x6a6394f47dd0baf794808f2749c09bd4ee874e70",
+			"name": "USD Coin",
+			"symbol": "USDC",
+			"decimals": 6,
 			"extensions": {
 				"vmType": "evm",
-				"verified": false,
-				"chainName": "Scroll"
+				"verified": true,
+				"chainName": "ZERO"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/36011/large/about_img01.png?1710324761"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/6319/large/usdc.png?1696506694"
 		},
 		{
 			"chainId": 685689,
@@ -8245,30 +8167,17 @@
 			"logoURI": "https://assets.relay.link/icons/1/light.png"
 		},
 		{
-			"chainId": 21000000,
-			"address": "0x0000000000000000000000000000000000000000",
-			"name": "Bitcorn",
-			"symbol": "BTCN",
-			"decimals": 18,
+			"chainId": 224235520,
+			"address": "EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c",
+			"name": "Gram",
+			"symbol": "GRAM",
+			"decimals": 9,
 			"extensions": {
-				"vmType": "evm",
+				"vmType": "tonvm",
 				"verified": true,
-				"chainName": "Corn"
+				"chainName": "TON"
 			},
-			"logoURI": "https://assets.coingecko.com/coins/images/53914/large/bitcorn_logo_200.png"
-		},
-		{
-			"chainId": 21000000,
-			"address": "0xdf0b24095e15044538866576754f3c964e902ee6",
-			"name": "USD Coin",
-			"symbol": "USDC",
-			"decimals": 6,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Corn"
-			},
-			"logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/18852.png"
+			"logoURI": "https://assets.relay.link/icons/currencies/ton.png"
 		},
 		{
 			"chainId": 666666666,
@@ -8285,6 +8194,19 @@
 		},
 		{
 			"chainId": 728126428,
+			"address": "T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb",
+			"name": "TRX",
+			"symbol": "TRX",
+			"decimals": 6,
+			"extensions": {
+				"vmType": "tvm",
+				"verified": true,
+				"chainName": "Tron"
+			},
+			"logoURI": "https://static.tronscan.org/production/logo/trx.png"
+		},
+		{
+			"chainId": 728126428,
 			"address": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
 			"name": "Tether USD",
 			"symbol": "USDT",
@@ -8298,16 +8220,55 @@
 		},
 		{
 			"chainId": 792703809,
-			"address": "CARDSccUMFKoPRZxt5vt3ksUbxEFEcnZ3H2pd3dKxYjp",
-			"name": "Collector Crypt",
-			"symbol": "CARDS",
+			"address": "9cRCn9rGT8V2imeM2BaKs13yhMEais3ruM3rPvTGpump",
+			"name": "The Black Bull",
+			"symbol": "ANSEM",
+			"decimals": 6,
+			"extensions": {
+				"vmType": "svm",
+				"verified": false,
+				"chainName": "Solana"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/102174035/large/IMG_9497.jpeg?1782005339"
+		},
+		{
+			"chainId": 792703809,
+			"address": "CWZ6BsdnjkDVTGkmL6bGbJXXig6ceef12KvyGQW14cMt",
+			"name": "AntFun BlockChain",
+			"symbol": "ANTFUN",
+			"decimals": 6,
+			"extensions": {
+				"vmType": "svm",
+				"verified": false,
+				"chainName": "Solana"
+			},
+			"logoURI": "https://assets.geckoterminal.com/5v9mnq9wr03qar6cqme7fhdt4oli"
+		},
+		{
+			"chainId": 792703809,
+			"address": "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263",
+			"name": "Bonk",
+			"symbol": "BONK",
+			"decimals": 5,
+			"extensions": {
+				"vmType": "svm",
+				"verified": true,
+				"chainName": "Solana"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/28600/large/bonk.jpg?1696527587"
+		},
+		{
+			"chainId": 792703809,
+			"address": "CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH",
+			"name": "CASH",
+			"symbol": "CASH",
 			"decimals": 6,
 			"extensions": {
 				"vmType": "svm",
 				"verified": true,
 				"chainName": "Solana"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/68728/large/cards-logo.jpeg?1756534539"
+			"logoURI": "https://assets.geckoterminal.com/1w73jgxln12ugw66ofii4zojhsbg"
 		},
 		{
 			"chainId": 792703809,
@@ -8324,6 +8285,19 @@
 		},
 		{
 			"chainId": 792703809,
+			"address": "XsueG8BtpquVJX9LVLLEGuViXUungE6WmK5YZ3p3bd1",
+			"name": "Circle xStock",
+			"symbol": "CRCLx",
+			"decimals": 8,
+			"extensions": {
+				"vmType": "svm",
+				"verified": false,
+				"chainName": "Solana"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/66918/large/CRCLx.png?1751052233"
+		},
+		{
+			"chainId": 792703809,
 			"address": "98sMhvDwXj1RQi5c5Mndm3vPe9cBqPrbLaufMXFNMh5g",
 			"name": "HYPE",
 			"symbol": "HYPE",
@@ -8337,55 +8311,29 @@
 		},
 		{
 			"chainId": 792703809,
-			"address": "yoA2CoHk6HRNtFuTP1kVt5xkcvG7mr5raQ5zuNxpump",
-			"name": "Islands",
-			"symbol": "Islands",
+			"address": "Ge87EtsjwRQbHaqQmKRno69RFTwh9bfSsm99XNxTpump",
+			"name": "Jimothy The Raccoon",
+			"symbol": "Jimothy",
 			"decimals": 6,
 			"extensions": {
 				"vmType": "svm",
 				"verified": false,
 				"chainName": "Solana"
 			},
-			"logoURI": "https://assets.geckoterminal.com/m74ubil0diur5u20my8rg83z5gyd"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/102174627/large/ds1bxricdzevh41l96amz78ormrh.?1784284675"
 		},
 		{
 			"chainId": 792703809,
-			"address": "FeR8VBqNRSUD5NtXAj2n3j1dAHkZHfyDktKuLXD4pump",
-			"name": "jelly-my-jelly",
-			"symbol": "jellyjelly",
-			"decimals": 6,
-			"extensions": {
-				"vmType": "svm",
-				"verified": true,
-				"chainName": "Solana"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/54087/large/jellyjelly-logo.webp?1738218050"
-		},
-		{
-			"chainId": 792703809,
-			"address": "Tqj8yFmagrg7oorpQkVGYR52r96RFTamvWfth9bpump",
-			"name": "Kintara",
-			"symbol": "KINS",
+			"address": "MUxEsUKSMACyw5fZf68wxf5FLnZVhtU9CwH8uNNGay1",
+			"name": "Micron Technology - Backpack Securities",
+			"symbol": "MU",
 			"decimals": 6,
 			"extensions": {
 				"vmType": "svm",
 				"verified": false,
 				"chainName": "Solana"
 			},
-			"logoURI": "https://assets.geckoterminal.com/fqh1kyqexcnpjt8420afe6bjhb00"
-		},
-		{
-			"chainId": 792703809,
-			"address": "BCdwQBAn8dYB5YjTsoB6TdHAWokxv28k2oZUodERpump",
-			"name": "Manifesting",
-			"symbol": "MANIFEST",
-			"decimals": 6,
-			"extensions": {
-				"vmType": "svm",
-				"verified": false,
-				"chainName": "Solana"
-			},
-			"logoURI": "https://assets.geckoterminal.com/2rmo9sk0d8lqtf03ebvup8uika6g"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/102174045/large/PNG_image.png?1782139114"
 		},
 		{
 			"chainId": 792703809,
@@ -8402,19 +8350,6 @@
 		},
 		{
 			"chainId": 792703809,
-			"address": "WskzsKqEW3ZsmrhPAevfVZb6PuuLzWov9mJWZsfDePC",
-			"name": "PUNDU",
-			"symbol": "PUNDU",
-			"decimals": 9,
-			"extensions": {
-				"vmType": "svm",
-				"verified": false,
-				"chainName": "Solana"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/36990/large/CTMV1dZU_400x400.jpg?1712998068"
-		},
-		{
-			"chainId": 792703809,
 			"address": "2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo",
 			"name": "PayPal USD",
 			"symbol": "PYUSD",
@@ -8425,6 +8360,19 @@
 				"chainName": "Solana"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/31212/large/PYUSD_Logo_%282%29.png?1696530039"
+		},
+		{
+			"chainId": 792703809,
+			"address": "SKHYhSjuRWHgikq8eRKbtBbpABgJSkd7ytQV14i9EQ3",
+			"name": "SK Hynix - Backpack Securities",
+			"symbol": "SKHY",
+			"decimals": 6,
+			"extensions": {
+				"vmType": "svm",
+				"verified": false,
+				"chainName": "Solana"
+			},
+			"logoURI": "https://coin-images.coingecko.com/coins/images/102174381/large/images_%281%29.png?1783504523"
 		},
 		{
 			"chainId": 792703809,
@@ -8441,19 +8389,6 @@
 		},
 		{
 			"chainId": 792703809,
-			"address": "SPCXxcqXj6e5dJDVNovHN8744zkbhM2bYudU45BimGb",
-			"name": "SpaceX - Backpack Securities",
-			"symbol": "SPCX",
-			"decimals": 6,
-			"extensions": {
-				"vmType": "svm",
-				"verified": false,
-				"chainName": "Solana"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/102173747/large/HbrI04tM_400x400.jpg?1781237061"
-		},
-		{
-			"chainId": 792703809,
 			"address": "XsoCS1TfEyfFhfvj8EtZ528L3CaKBDBRqRapnBbDF2W",
 			"name": "SP500 xStock",
 			"symbol": "SPYx",
@@ -8464,19 +8399,6 @@
 				"chainName": "Solana"
 			},
 			"logoURI": "https://assets.geckoterminal.com/n4v52jml1wat1wb8evlh5cqpbd73"
-		},
-		{
-			"chainId": 792703809,
-			"address": "5UUH9RTDiSpq6HKS6bp4NdU9PNJpXRXuiw6ShBTBhgH2",
-			"name": "TROLL",
-			"symbol": "TROLL",
-			"decimals": 6,
-			"extensions": {
-				"vmType": "svm",
-				"verified": true,
-				"chainName": "Solana"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/55282/large/trolllogo.png?1745215015"
 		},
 		{
 			"chainId": 792703809,
@@ -8493,26 +8415,13 @@
 		},
 		{
 			"chainId": 792703809,
-			"address": "USD1ttGY1N17NEEHLmELoaybftRBUSErhqYiQzvEmuB",
-			"name": "World Liberty Financial USD",
-			"symbol": "USD1",
-			"decimals": 6,
-			"extensions": {
-				"vmType": "svm",
-				"verified": false,
-				"chainName": "Solana"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/54977/large/USD1_1000x1000_transparent.png?1749297002"
-		},
-		{
-			"chainId": 792703809,
 			"address": "2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH",
 			"name": "Global Dollar",
 			"symbol": "USDG",
 			"decimals": 6,
 			"extensions": {
 				"vmType": "svm",
-				"verified": false,
+				"verified": true,
 				"chainName": "Solana"
 			},
 			"logoURI": "https://coin-images.coingecko.com/coins/images/51281/large/GDN_USDG_Token_200x200.png?1730484111"
@@ -8544,56 +8453,17 @@
 			"logoURI": "https://coin-images.coingecko.com/coins/images/70472/large/zcash.png?1762156993"
 		},
 		{
-			"chainId": 888888888,
-			"address": "0x0000000000000000000000000000000000000000",
-			"name": "Ether",
-			"symbol": "ETH",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Ancient8"
-			},
-			"logoURI": "https://assets.relay.link/icons/1/light.png"
-		},
-		{
-			"chainId": 888888888,
-			"address": "0x4200000000000000000000000000000000000006",
-			"name": "Wrapped Ether",
-			"symbol": "WETH",
-			"decimals": 18,
-			"extensions": {
-				"vmType": "evm",
-				"verified": true,
-				"chainName": "Ancient8"
-			},
-			"logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
-		},
-		{
-			"chainId": 1380012617,
-			"address": "0xfbda5f676cb37624f28265a144a48b0d6e87d3b6",
-			"name": "Bridged USDC (Stargate)",
-			"symbol": "USDC.e",
+			"chainId": 792703809,
+			"address": "8x5VqbHA8D7NkD52uNuS5nnt3PwA8pLD34ymskeSo2Wn",
+			"name": "zerebro",
+			"symbol": "ZEREBRO",
 			"decimals": 6,
 			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "RARI"
+				"vmType": "svm",
+				"verified": true,
+				"chainName": "Solana"
 			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/69316/large/usdc.jpg?1758186473"
-		},
-		{
-			"chainId": 1380012617,
-			"address": "0x362fae9a75b27bbc550aac28a7c1f96c8d483120",
-			"name": "Tether USD",
-			"symbol": "USDT",
-			"decimals": 6,
-			"extensions": {
-				"vmType": "evm",
-				"verified": false,
-				"chainName": "RARI"
-			},
-			"logoURI": "https://coin-images.coingecko.com/coins/images/70631/large/usdt.jpg?1762857609"
+			"logoURI": "https://coin-images.coingecko.com/coins/images/51289/large/zerebro_2.png?1730588883"
 		}
 	]
 }

--- a/workers/jb-swap/src/lib/relay/token-list.test.ts
+++ b/workers/jb-swap/src/lib/relay/token-list.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+	pinPriorityChains,
 	RELAY_TOKEN_LIST,
+	relayChains,
 	relayTokens,
 	toTokenRow,
 	type UniswapToken,
@@ -70,5 +72,45 @@ describe("relay token list", () => {
 	test("relayTokens derives 1:1 from the list with zeroed holdings", () => {
 		expect(relayTokens.length).toBe(RELAY_TOKEN_LIST.tokens.length);
 		expect(relayTokens.every((r) => r.amount === "0" && r.usd === "$0")).toBe(true);
+	});
+
+	test("Robinhood Chain is present in the generated list", () => {
+		const robinhood = relayChains.find((c) => c.chainId === 4663);
+		expect(robinhood?.name).toBe("Robinhood Chain");
+	});
+});
+
+describe("pinPriorityChains", () => {
+	const opt = (chainId: number) => ({ chainId, name: `c${chainId}`, icon: "" });
+
+	test("lifts pinned chains to the front in CHAIN_PRIORITY order", () => {
+		// Deliberately reversed: pinned chains must be reordered, not just moved.
+		const out = pinPriorityChains([opt(999), opt(4663), opt(8453), opt(1)]);
+		expect(out.map((c) => c.chainId)).toEqual([1, 8453, 4663, 999]);
+	});
+
+	test("preserves the incoming order of unpinned chains", () => {
+		const out = pinPriorityChains([opt(777), opt(999), opt(888), opt(1)]);
+		expect(out.map((c) => c.chainId)).toEqual([1, 777, 999, 888]);
+	});
+
+	test("skips pinned chains absent from the input", () => {
+		const out = pinPriorityChains([opt(8453), opt(999)]);
+		expect(out.map((c) => c.chainId)).toEqual([8453, 999]);
+	});
+
+	test("survives a volume sort that would otherwise bury a pinned chain", () => {
+		// Simulates post-hydration ranking: Robinhood dead last by volume.
+		const ranked = [opt(999), opt(888), opt(1), opt(4663)];
+		expect(pinPriorityChains(ranked).map((c) => c.chainId)).toEqual([
+			1, 4663, 999, 888,
+		]);
+	});
+
+	test("returns a new array and does not mutate the input", () => {
+		const input = [opt(999), opt(1)];
+		const out = pinPriorityChains(input);
+		expect(out).not.toBe(input);
+		expect(input.map((c) => c.chainId)).toEqual([999, 1]);
 	});
 });

--- a/workers/jb-swap/src/lib/relay/token-list.ts
+++ b/workers/jb-swap/src/lib/relay/token-list.ts
@@ -60,8 +60,22 @@ export interface RelayChainOption {
 	icon: string;
 }
 
-/** Popular chains surfaced first in the filter row; the rest follow by id. */
-const CHAIN_PRIORITY = [1, 8453, 42161, 10, 137, 792703809, 56, 43114, 130];
+/**
+ * Chains pinned to the head of the filter row, in this order. These lead
+ * regardless of measured volume — see {@link pinPriorityChains}.
+ */
+const CHAIN_PRIORITY = [
+	1, // Ethereum
+	8453, // Base
+	42161, // Arbitrum
+	10, // Optimism
+	4663, // Robinhood Chain
+	137, // Polygon
+	792703809, // Solana
+	56, // BNB
+	43114, // Avalanche
+	130, // Unichain
+];
 
 /** Every chain present in the token list, for the drawer's chain filter chips. */
 export const relayChains: RelayChainOption[] = (() => {
@@ -75,12 +89,27 @@ export const relayChains: RelayChainOption[] = (() => {
 			});
 		}
 	}
-	return Array.from(seen.values()).sort((a, b) => {
-		const ra = CHAIN_PRIORITY.indexOf(a.chainId);
-		const rb = CHAIN_PRIORITY.indexOf(b.chainId);
-		if (ra !== -1 || rb !== -1) {
-			return (ra === -1 ? Infinity : ra) - (rb === -1 ? Infinity : rb);
-		}
-		return a.chainId - b.chainId;
-	});
+	return Array.from(seen.values()).sort((a, b) => a.chainId - b.chainId);
 })();
+
+/**
+ * Lift {@link CHAIN_PRIORITY} chains to the front, preserving the incoming
+ * order for everything else.
+ *
+ * This is applied *after* the volume sort, not before: volume ranking would
+ * otherwise bury a pinned chain the moment `/api/volume` resolves, so a chain
+ * pinned pre-hydration would visibly jump to the back a second after mount.
+ * Pinned chains absent from `chains` are skipped. Returns a new array.
+ */
+export function pinPriorityChains(
+	chains: RelayChainOption[],
+): RelayChainOption[] {
+	const byId = new Map(chains.map((c) => [c.chainId, c]));
+	const pinned: RelayChainOption[] = [];
+	for (const id of CHAIN_PRIORITY) {
+		const hit = byId.get(id);
+		if (hit) pinned.push(hit);
+	}
+	const pinnedIds = new Set(pinned.map((c) => c.chainId));
+	return [...pinned, ...chains.filter((c) => !pinnedIds.has(c.chainId))];
+}


### PR DESCRIPTION
## Summary

Adds Robinhood Chain (4663) to the chain filter chips and pins it near the front, behind Ethereum / Base / Arbitrum / Optimism.

**Regenerated the token list.** The chips are built from `src/data/relay-token-list.json`, generated by `bun run build:tokens`. It was last generated 2026-06-14 and predates Robinhood Chain, so the chain could not be added by hand. Regenerating adds Robinhood (20 tokens), ZERO and TON, and drops six chains Relay no longer serves (1424, 1923, 167000, 21000000, 888888888, 1380012617). This is most of the diff.

**Fixed pinning so it actually holds.** `CHAIN_PRIORITY` was applied while building `relayChains`, but `token-drawer.tsx` re-sorts the chips by aggregate 24h volume once `/api/volume` resolves (~1s after mount), discarding that order entirely. Adding a new low-volume chain to the array would have shown it near the front on first paint and then visibly demoted it to the back. Priority is now applied as an overlay *after* the volume sort via `pinPriorityChains`, so pinned chains lead regardless of measured volume.

Side effect: the pre-existing pins (Ethereum, Base, Arbitrum, Optimism, Polygon, Solana, BNB, Avalanche, Unichain) now hold their order post-hydration too, which is what the original comment claimed but did not do. This also drops the old comparator, whose `Infinity - Infinity` branch was a latent `NaN`.

## Test plan

- [x] `bun test` — 310 pass, 0 fail (11 in `token-list.test.ts`, 5 new for `pinPriorityChains` covering order, absent pins, non-mutation, and the post-volume-sort case)
- [x] `bun run build` — 7/7 tasks pass
- [ ] Robinhood chip appears in position 5 in both From and To drawers, and stays there after volume data loads
- [ ] Selecting Robinhood filters to its 20 tokens

## Known gap, not addressed here

`balances.ts` has a separate hardcoded 15-chain allowlist (`CHAINS` + `RPC_URLS`) for reading wallet balances. Robinhood is not in it, so a connected wallet will not show Robinhood token balances — the chain is selectable and swappable, but balances read as zero. Adding it needs a viem chain definition and a CORS-permitting RPC, which felt out of scope for this PR. Happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)