### PR TITLE
fix(jb-swap): convert Max/Test to the active denomination

### DIFF
--- a/packages/unified-ui/src/components/swap-card.tsx
+++ b/packages/unified-ui/src/components/swap-card.tsx
@@ -4,6 +4,7 @@ import { motion } from "framer-motion";
 import { ArrowUpDown } from "lucide-react";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 
+import { price } from "../lib/format";
 import { cn } from "../lib/utils";
 import type {
 	GenerateAddressConfig,
@@ -19,7 +20,11 @@ import { AppleBorderGradient } from "./apple-border-gradient";
 import { AppMenuShell } from "./app-menu-shell";
 import { HapticButton } from "./haptic-button";
 import { MobileKeypad } from "./keypad";
-import { applyAmountKey, sanitizePastedAmount } from "./swap-field";
+import {
+	applyAmountKey,
+	sanitizePastedAmount,
+	unitsToMode,
+} from "./swap-field";
 import { SwapFrom } from "./swap-from";
 import { SwapTo } from "./swap-to";
 import { TokenTrigger } from "./token-trigger";
@@ -159,6 +164,13 @@ export function SwapCard({
 		genAddress ? "rounded-3xl" : "rounded-t-3xl",
 	);
 
+	// Max / Test report holdings in token units; fromAmount is denominated by
+	// fromMode, so convert before handing it up.
+	const setAmountFromUnits = (units: string) =>
+		onFromAmountChange(
+			unitsToMode(units, fromMode, fromToken ? price(fromToken) : 0),
+		);
+
 	// ── Token picker slots ────────────────────────────────────────────────────
 	const fromApi: PickerSlotApi = {
 		variant: "from",
@@ -170,7 +182,7 @@ export function SwapCard({
 		onActivate: () => setFromOpen(true),
 		walletAddress,
 		generateAddress: canGenerateAddress ? generateAddress : undefined,
-		onSetAmount: onFromAmountChange,
+		onSetAmount: setAmountFromUnits,
 		labels: triggerLabels?.from ?? {},
 	};
 	const toApi: PickerSlotApi = {
@@ -198,7 +210,7 @@ export function SwapCard({
 			triggerClassName={FROM_TRIGGER_CLASS}
 			walletAddress={walletAddress}
 			onActivate={fromApi.onActivate}
-			onSetAmount={onFromAmountChange}
+			onSetAmount={setAmountFromUnits}
 			labels={triggerLabels?.from}
 		/>
 	);

--- a/packages/unified-ui/src/components/swap-field.tsx
+++ b/packages/unified-ui/src/components/swap-field.tsx
@@ -17,6 +17,26 @@ export function trimUsd(n: number) {
 	return String(Number(n.toFixed(2)));
 }
 
+/**
+ * Convert a raw *token unit* string into whatever denomination `mode` is
+ * showing, for the Max / Test shortcuts.
+ *
+ * Those shortcuts report holdings in token units, but the editable amount is
+ * denominated by the active mode — storing units verbatim while in USD mode
+ * makes them read as dollars (a 0.004220 ETH balance renders as "$0.00").
+ *
+ * Floors to the cent instead of rounding: Max must never resolve back to more
+ * units than the wallet holds, and `toFixed(2)` rounds half-up, which would
+ * push it just past the balance. Sub-cent holdings therefore floor to "0" —
+ * USD mode only has two decimals to work with. Returns "0" if the price is
+ * unknown, since there is no honest dollar figure to show.
+ */
+export function unitsToMode(units: string, mode: Mode, price: number) {
+	if (mode !== "usd") return units;
+	if (!(price > 0)) return "0";
+	return String(Math.floor((Number(units) || 0) * price * 100) / 100);
+}
+
 /** Keep only digits and a single decimal point; strip leading zeros. */
 export function sanitizeAmount(raw: string) {
 	let v = raw.replace(/[^0-9.]/g, "");

--- a/workers/jb-swap/src/components/swap-card.tsx
+++ b/workers/jb-swap/src/components/swap-card.tsx
@@ -14,6 +14,7 @@ import {
 	sanitizeAmount,
 	trim,
 	trimUsd,
+	unitsToMode,
 } from "@/components/swap-field";
 import { SwapFrom } from "@/components/swap-from";
 import { SwapTo } from "@/components/swap-to";
@@ -170,6 +171,11 @@ export function SwapCard() {
 	};
 	const toggleToMode = () =>
 		setToMode((m) => (m === "token" ? "usd" : "token"));
+
+	// Max / Test report holdings in token units; fromAmount is denominated by
+	// fromMode, so convert before storing.
+	const setAmountFromUnits = (units: string) =>
+		setFromAmount(unitsToMode(units, fromMode, fromPrice));
 
 	// Changing the default denomination in the menu switches BOTH inputs at once.
 	// Convert the editable FROM amount so its displayed value stays equivalent.
@@ -341,7 +347,7 @@ export function SwapCard() {
 				token={fromToken}
 				onSelectToken={setFromToken}
 				amount={fromAmount}
-				onSetAmount={setFromAmount}
+				onSetAmount={setAmountFromUnits}
 				mode={fromMode}
 				onToggleMode={toggleFromMode}
 				usd={fromUsd}

--- a/workers/jb-swap/src/components/swap-field.test.ts
+++ b/workers/jb-swap/src/components/swap-field.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+
+import { unitsToMode } from "./swap-field";
+
+describe("unitsToMode", () => {
+	test("passes token units through untouched in token mode", () => {
+		expect(unitsToMode("0.004220", "token", 1892)).toBe("0.004220");
+	});
+
+	test("ignores price entirely in token mode", () => {
+		expect(unitsToMode("1.5", "token", 0)).toBe("1.5");
+	});
+
+	test("converts units to dollars in usd mode", () => {
+		expect(unitsToMode("2", "usd", 1000)).toBe("2000");
+	});
+
+	test("regression: Max on a 0.004220 ETH balance is not $0.00", () => {
+		// Reported bug: the raw unit string was stored while in usd mode, so the
+		// balance read back as $0.00422 -> "$0.00" and 0.00000223 ETH.
+		const out = unitsToMode("0.004220", "usd", 1892);
+		expect(out).not.toBe("0.00422");
+		expect(Number(out)).toBeCloseTo(7.98, 2);
+	});
+
+	test("floors to the cent so Max never exceeds the balance", () => {
+		// 0.005 * 1899.9 = 9.4995 -> rounding gives 9.50, which converts back to
+		// more units than are held. Flooring keeps it under.
+		const out = unitsToMode("0.005", "usd", 1899.9);
+		expect(out).toBe("9.49");
+		expect(Number(out) / 1899.9).toBeLessThanOrEqual(0.005);
+	});
+
+	test("sub-cent holdings floor to 0 — usd mode has two decimals", () => {
+		expect(unitsToMode("0.000001", "usd", 1892)).toBe("0");
+	});
+
+	test("returns 0 in usd mode when the price is unknown", () => {
+		expect(unitsToMode("0.004220", "usd", 0)).toBe("0");
+	});
+
+	test("treats a non-numeric unit string as zero rather than NaN", () => {
+		expect(unitsToMode("", "usd", 1892)).toBe("0");
+		expect(unitsToMode("abc", "usd", 1892)).toBe("0");
+	});
+});

--- a/workers/jb-swap/src/components/swap-field.tsx
+++ b/workers/jb-swap/src/components/swap-field.tsx
@@ -17,6 +17,26 @@ export function trimUsd(n: number) {
 	return String(Number(n.toFixed(2)));
 }
 
+/**
+ * Convert a raw *token unit* string into whatever denomination `mode` is
+ * showing, for the Max / Test shortcuts.
+ *
+ * Those shortcuts report holdings in token units, but the editable amount is
+ * denominated by the active mode — storing units verbatim while in USD mode
+ * makes them read as dollars (a 0.004220 ETH balance renders as "$0.00").
+ *
+ * Floors to the cent instead of rounding: Max must never resolve back to more
+ * units than the wallet holds, and `toFixed(2)` rounds half-up, which would
+ * push it just past the balance. Sub-cent holdings therefore floor to "0" —
+ * USD mode only has two decimals to work with. Returns "0" if the price is
+ * unknown, since there is no honest dollar figure to show.
+ */
+export function unitsToMode(units: string, mode: "token" | "usd", price: number) {
+	if (mode !== "usd") return units;
+	if (!(price > 0)) return "0";
+	return String(Math.floor((Number(units) || 0) * price * 100) / 100);
+}
+
 /** Keep only digits and a single decimal point; strip leading zeros. */
 export function sanitizeAmount(raw: string) {
 	let v = raw.replace(/[^0-9.]/g, "");


### PR DESCRIPTION
## The bug

Tapping **Max** with a connected wallet showed `$0.00` instead of the dollar value of the balance.

`Max` and `Test` report holdings in **token units** (`token.amount`), but the editable `fromAmount` is denominated by `fromMode` (`swap-card.tsx:81-83`). `onSetAmount` was wired straight to `setFromAmount`, so in USD mode the unit string was stored verbatim and read back as dollars.

Reported case: a `0.004220 ETH` balance set `$0.004220`, which renders as `$0.00` and converts to `0.00000223 ETH`. Those two numbers divide out to ~$1892/ETH, which confirms the diagnosis — the balance figure was being interpreted as a dollar figure.

The paste handler at `swap-card.tsx:317` already converted correctly; the shortcuts just didn't use that path.

## The fix

Adds `unitsToMode(units, mode, price)` next to `trim`/`trimUsd` in `swap-field.tsx` and routes `onSetAmount` through it.

**Floors to the cent rather than rounding.** `toFixed(2)` rounds half-up, so Max could produce a dollar figure that converts back to *more* units than the wallet holds and fails the swap — e.g. `0.005 ETH @ $1899.90` rounds to `$9.50`, which is `0.0050002 ETH`. Flooring keeps it under. Two consequences worth knowing:

- Sub-cent holdings floor to `0` in USD mode. USD mode only has two decimals; this is inherent, not new.
- Unknown price returns `0` rather than a fabricated dollar figure.

Mirrored into `packages/unified-ui`, which has the same defect. That package is currently unconsumed, but it carries a copy of `swap-card`.

## Test plan

- [x] `bun test` — 318 pass, 0 fail; 8 new covering token passthrough, USD conversion, the exact reported regression, the floor-vs-round balance case, sub-cent, unknown price, and non-numeric input
- [x] `bun run build` — 7/7 tasks pass
- [ ] Max in USD mode shows the real dollar value; Max in token mode still shows the unit balance
- [ ] Max never produces a quote exceeding the wallet balance

🤖 Generated with [Claude Code](https://claude.com/claude-code)