### PR TITLE
fix(jb-swap): amount area opens the token picker instead of flipping units

### DIFF
--- a/packages/unified-ui/src/components/swap-card.tsx
+++ b/packages/unified-ui/src/components/swap-card.tsx
@@ -301,6 +301,7 @@ export function SwapCard({
 				amount={fromAmount}
 				mode={fromMode}
 				onToggleMode={onToggleFromMode}
+				onActivatePicker={fromApi.onActivate}
 				usd={fromUsd}
 				units={fromUnits}
 				symbol={fromToken?.symbol}
@@ -352,6 +353,7 @@ export function SwapCard({
 				usd={toUsd}
 				mode={toMode}
 				onToggleMode={onToggleToMode}
+				onActivatePicker={toApi.onActivate}
 				symbol={toToken?.symbol}
 				amountAriaLabel={labels?.amountAriaLabel}
 				collapsed={genAddress}

--- a/packages/unified-ui/src/components/swap-from.tsx
+++ b/packages/unified-ui/src/components/swap-from.tsx
@@ -22,6 +22,12 @@ export interface SwapFromProps {
 	amount: string;
 	mode: Mode;
 	onToggleMode: () => void;
+	/**
+	 * Open the token picker. The amount area is a tap target for this, so the
+	 * whole card behaves as one — matching `picker`'s own trigger. Omit to make
+	 * the amount area inert.
+	 */
+	onActivatePicker?: () => void;
 	/** USD value of the entered amount (for the conversion pill). */
 	usd: number;
 	/** Token units of the entered amount (for the conversion pill). */
@@ -48,6 +54,7 @@ export function SwapFrom({
 	amount,
 	mode,
 	onToggleMode,
+	onActivatePicker,
 	usd,
 	units,
 	symbol,
@@ -87,13 +94,15 @@ export function SwapFrom({
 						/>
 					) : (
 						<div className="relative">
-							{/* Full-area tap target behind a pass-through content layer:
-							    tapping anywhere on the amount flips the denomination. The
-							    Pill stays the accessible control, so this is a11y-hidden. */}
+							{/* Full-area tap target behind a pass-through content layer.
+							    The card reads as one surface, so tapping the amount opens
+							    the token picker exactly like tapping the trigger above it —
+							    only the Pill switches denomination. The picker's own
+							    trigger is the accessible control, so this is a11y-hidden. */}
 							<div className="absolute inset-0">
 								<HapticButton
 									type="button"
-									onClick={onToggleMode}
+									onClick={onActivatePicker}
 									tabIndex={-1}
 									aria-hidden
 									wrapperClassName="grid size-full"

--- a/packages/unified-ui/src/components/swap-to.tsx
+++ b/packages/unified-ui/src/components/swap-to.tsx
@@ -23,6 +23,12 @@ export interface SwapToProps {
 	usd: number;
 	mode: Mode;
 	onToggleMode: () => void;
+	/**
+	 * Open the token picker. The amount area is a tap target for this, so the
+	 * whole card behaves as one — matching `picker`'s own trigger. Omit to make
+	 * the amount area inert.
+	 */
+	onActivatePicker?: () => void;
 	/** Selected token symbol (shown in the token-mode conversion pill). */
 	symbol?: string;
 	amountAriaLabel?: string;
@@ -42,6 +48,7 @@ export function SwapTo({
 	usd,
 	mode,
 	onToggleMode,
+	onActivatePicker,
 	symbol,
 	amountAriaLabel,
 	collapsed = false,
@@ -62,13 +69,15 @@ export function SwapTo({
 			<div className={AMOUNT_FIELD_TRANSITION} style={{ height }}>
 				<div ref={box.ref}>
 					<div className="relative">
-						{/* Full-area tap target behind a pass-through content layer:
-						    tapping anywhere on the amount flips the denomination. The
-						    Pill stays the accessible control, so this is a11y-hidden. */}
+						{/* Full-area tap target behind a pass-through content layer.
+						    The card reads as one surface, so tapping the amount opens
+						    the token picker exactly like tapping the trigger above it —
+						    only the Pill switches denomination. The picker's own
+						    trigger is the accessible control, so this is a11y-hidden. */}
 						<div className="absolute inset-0">
 							<HapticButton
 								type="button"
-								onClick={onToggleMode}
+								onClick={onActivatePicker}
 								tabIndex={-1}
 								aria-hidden
 								wrapperClassName="grid size-full"

--- a/workers/jb-swap/src/components/swap-from.tsx
+++ b/workers/jb-swap/src/components/swap-from.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ArrowUpDown } from "lucide-react";
+import { useState } from "react";
 
 import { CryptoAddress } from "@/components/crypto-address";
 import { HapticButton } from "@/components/haptic-button";
@@ -68,6 +69,9 @@ export function SwapFrom({
 }: SwapFromProps) {
 	const box = useMeasuredHeight();
 	const height = box.height ?? undefined;
+	// Lifted out of TokenBox so the amount area below it can open the same
+	// picker — the whole card is one target for that.
+	const [pickerOpen, setPickerOpen] = useState(false);
 
 	return (
 		<section className="group relative rounded-3xl bg-card px-4 pb-3 pt-4">
@@ -88,6 +92,8 @@ export function SwapFrom({
 				onDisconnect={onDisconnect}
 				genAddress={genAddress}
 				onToggleGenAddress={onToggleGenAddress}
+				open={pickerOpen}
+				onOpenChange={setPickerOpen}
 				triggerClassName="-mx-4 -mt-4 w-[calc(100%+2rem)] rounded-t-3xl px-4 pb-4 pt-4"
 			/>
 			<div
@@ -107,13 +113,15 @@ export function SwapFrom({
 						/>
 					) : (
 						<div className="relative">
-							{/* Full-area tap target behind a pass-through content layer:
-							    tapping anywhere on the amount flips the denomination. The
-							    Pill stays the accessible control, so this is a11y-hidden. */}
+							{/* Full-area tap target behind a pass-through content layer.
+							    The card reads as one surface, so tapping the amount opens
+							    the token picker exactly like tapping the trigger above it —
+							    only the Pill switches denomination. The trigger is the
+							    accessible control for this, so the overlay is a11y-hidden. */}
 							<div className="absolute inset-0">
 								<HapticButton
 									type="button"
-									onClick={onToggleMode}
+									onClick={() => setPickerOpen(true)}
 									tabIndex={-1}
 									aria-hidden
 									wrapperClassName="grid size-full"
@@ -125,6 +133,8 @@ export function SwapFrom({
 									value={amount}
 									prefix={mode === "usd" ? "$" : undefined}
 								/>
+								{/* Pill re-enables pointer events internally, so it acts on its
+								    own rather than falling through to the overlay behind it. */}
 								<Pill onClick={onToggleMode}>
 									<span className="opacity-50">=</span>{" "}
 									<ConversionValue

--- a/workers/jb-swap/src/components/swap-to.tsx
+++ b/workers/jb-swap/src/components/swap-to.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ArrowUpDown } from "lucide-react";
+import { useState } from "react";
 
 import { HapticButton } from "@/components/haptic-button";
 import {
@@ -60,6 +61,9 @@ export function SwapTo({
 }: SwapToProps) {
 	const box = useMeasuredHeight();
 	const height = box.height == null ? undefined : collapsed ? 0 : box.height;
+	// Lifted out of TokenBox so the amount area below it can open the same
+	// picker — the whole card is one target for that.
+	const [pickerOpen, setPickerOpen] = useState(false);
 
 	return (
 		<section className="group relative rounded-3xl bg-card px-4 pb-0 pt-6">
@@ -78,6 +82,8 @@ export function SwapTo({
 				fee={fee}
 				feeLoading={feeLoading}
 				onOpenSlippage={onOpenSlippage}
+				open={pickerOpen}
+				onOpenChange={setPickerOpen}
 				triggerClassName={cn(
 					"-mx-4 -mt-6 w-[calc(100%+2rem)] px-4 pb-4 pt-6",
 					collapsed ? "rounded-3xl" : "rounded-t-3xl",
@@ -89,13 +95,15 @@ export function SwapTo({
 			<div className={AMOUNT_FIELD_TRANSITION} style={{ height }}>
 				<div ref={box.ref}>
 					<div className="relative">
-						{/* Full-area tap target behind a pass-through content layer:
-						    tapping anywhere on the amount flips the denomination. The
-						    Pill stays the accessible control, so this is a11y-hidden. */}
+						{/* Full-area tap target behind a pass-through content layer.
+						    The card reads as one surface, so tapping the amount opens
+						    the token picker exactly like tapping the trigger above it —
+						    only the Pill switches denomination. The trigger is the
+						    accessible control for this, so the overlay is a11y-hidden. */}
 						<div className="absolute inset-0">
 							<HapticButton
 								type="button"
-								onClick={onToggleMode}
+								onClick={() => setPickerOpen(true)}
 								tabIndex={-1}
 								aria-hidden
 								wrapperClassName="grid size-full"

--- a/workers/jb-swap/src/components/token-drawer.tsx
+++ b/workers/jb-swap/src/components/token-drawer.tsx
@@ -3,7 +3,7 @@
 import Avatar from "boring-avatars";
 import { AnimatePresence, motion } from "framer-motion";
 import { Flame, FlaskConical, Lock, LogOut, Scan, Search, SlidersHorizontal, X } from "lucide-react";
-import { Fragment, useEffect, useRef, useState } from "react";
+import { Fragment, useCallback, useEffect, useRef, useState } from "react";
 import { Drawer } from "vaul";
 
 import { HapticButton } from "@/components/haptic-button";
@@ -302,6 +302,8 @@ export function TokenBox({
 	onDisconnect,
 	genAddress,
 	onToggleGenAddress,
+	open: openProp,
+	onOpenChange,
 }: {
 	variant: Variant;
 	/** Controlled selected token (owned by the parent so the flip can swap them). */
@@ -322,6 +324,12 @@ export function TokenBox({
 	onDisconnect?: () => void;
 	genAddress?: boolean;
 	onToggleGenAddress?: () => void;
+	/**
+	 * Controlled open state. Omit to let the drawer own it. SwapFrom/SwapTo pass
+	 * it so the amount area below the trigger can open the same picker.
+	 */
+	open?: boolean;
+	onOpenChange?: (open: boolean) => void;
 }) {
 	const t = useTranslations();
 	// Real-time volume-proxy ranking. From = "withdraw" (source side), To =
@@ -329,7 +337,20 @@ export function TokenBox({
 	// identically until a real directional bridge-flow feed exists.
 	const { data: volumeData, sortTokens, sortChains } = useVolumeRanking();
 	const direction = variant === "from" ? "withdraw" : "deposit";
-	const [open, setOpen] = useState(false);
+	// Optionally controlled. `setOpen` is identity-stable and reads its inputs
+	// through refs, so the Cmd+F/Cmd+K effect below (which intentionally does not
+	// re-subscribe on every render) can't capture a stale closure.
+	const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+	const isControlled = openProp !== undefined;
+	const open = isControlled ? openProp : uncontrolledOpen;
+	const controlledRef = useRef(isControlled);
+	controlledRef.current = isControlled;
+	const onOpenChangeRef = useRef(onOpenChange);
+	onOpenChangeRef.current = onOpenChange;
+	const setOpen = useCallback((next: boolean) => {
+		if (!controlledRef.current) setUncontrolledOpen(next);
+		onOpenChangeRef.current?.(next);
+	}, []);
 	const [query, setQuery] = useState("");
 	const [activeChainId, setActiveChainId] = useState<number | null>(null);
 	// "From" lists only the assets the connected wallet holds (multicall


### PR DESCRIPTION
## Summary

Corrects the interaction model introduced in #55.

That PR made the entire amount block a tap target that switched denomination. The result was that two of the card's three regions (the trigger row and the amount block) did different things, while the amount block and the conversion Pill did the *same* thing — and there was no way to reach the token picker from the lower half of the card.

The card reads as one surface, so tapping the amount should do what tapping the trigger does:

| Region | Before (#55) | After |
| --- | --- | --- |
| Token trigger row | Open picker | Open picker |
| Amount block | Switch units | **Open picker** |
| Conversion Pill | Switch units | Switch units |

Only the Pill switches denomination now.

## Implementation

- The amount overlay's `onClick` goes from `onToggleMode` to opening the picker. `Pill` already sets `pointer-events-auto` internally, so it acts on its own rather than falling through to the overlay behind it — no `stopPropagation` needed, since the overlay is a sibling rather than an ancestor.
- `TokenBox`'s `open` state becomes **optionally controlled** (`open` / `onOpenChange`), so `SwapFrom` / `SwapTo` can drive it from the amount area. Omitting both keeps the existing internal-state behavior for any other caller.
- `setOpen` is identity-stable and reads `isControlled` / `onOpenChange` through refs. The Cmd+F / Cmd+K shortcut effect deliberately does not re-subscribe on every render, so a plain closure would have gone stale the moment the component became controlled.
- Mirrored into `packages/unified-ui`, which uses a `picker` slot rather than rendering `TokenBox`. It gains an `onActivatePicker` prop wired to the `onActivate` its `swap-card` already exposes.

## Test plan

- [x] `bun test` — 318 pass, 0 fail
- [x] `bun run build` — 7/7 tasks pass
- [ ] Tapping the amount area opens the token picker on both From and To
- [ ] Tapping the Pill still switches units and does **not** open the picker
- [ ] Cmd+F / Cmd+K still open the From / To pickers (the controlled-state path)
- [ ] Picker still closes correctly, and the To card's collapse animation is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)