### PR TITLE
feat(jb-memo): add validator memo and React Flow diagrams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ next-env.d.ts
 rnd/
 
 
+.gstack/

--- a/bun.lock
+++ b/bun.lock
@@ -75,6 +75,7 @@
       "dependencies": {
         "@opennextjs/cloudflare": "^1.14.4",
         "@radix-ui/react-slot": "^1.2.4",
+        "@xyflow/react": "^12.11.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.42.2",
@@ -1497,25 +1498,29 @@
 
     "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
 
-    "@types/d3-color": ["@types/d3-color@2.0.6", "", {}, "sha512-tbaFGDmJWHqnenvk3QGSvD3RVwr631BjKRD7Sc7VLRgrdX5mk5hTyoeBL6rXZaeoXzmZwIl1D2HPogEdt1rHBg=="],
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
 
     "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
 
     "@types/d3-geo": ["@types/d3-geo@2.0.7", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-RIXlxPdxvX+LAZFv+t78CuYpxYag4zuw9mZc+AwfB8tZpKU90rMEn2il2ADncmeZlb7nER9dDsJpRisA3lRvjA=="],
 
-    "@types/d3-interpolate": ["@types/d3-interpolate@2.0.5", "", { "dependencies": { "@types/d3-color": "^2" } }, "sha512-UINE41RDaUMbulp+bxQMDnhOi51rh5lA2dG+dWZU0UY/IwQiG/u2x8TfnWYU9+xwGdXsJoAvrBYUEQl0r91atg=="],
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
 
     "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
 
     "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
 
-    "@types/d3-selection": ["@types/d3-selection@2.0.5", "", {}, "sha512-71BorcY0yXl12S7lvb01JdaN9TpeUHBDb4RRhSq8U8BEkX/nIk5p7Byho+ZRTsx5nYLMpAbY3qt5EhqFzfGJlw=="],
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
 
     "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
 
     "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
 
     "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
 
     "@types/d3-zoom": ["@types/d3-zoom@2.0.7", "", { "dependencies": { "@types/d3-interpolate": "^2", "@types/d3-selection": "^2" } }, "sha512-JWke4E8ZyrKUQ68ESTWSK16fVb0OYnaiJ+WXJRYxKLn4aXU0o4CLYxMWBEiouUfO3TTCoyroOrGPcBG6u1aAxA=="],
 
@@ -1751,6 +1756,10 @@
 
     "@xtuc/long": ["@xtuc/long@4.2.2", "", {}, "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="],
 
+    "@xyflow/react": ["@xyflow/react@12.11.3", "", { "dependencies": { "@xyflow/system": "0.0.80", "classcat": "^5.0.3", "zustand": "^4.4.0" }, "peerDependencies": { "@types/react": ">=17", "@types/react-dom": ">=17", "react": ">=17", "react-dom": ">=17" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-G3jogHz2GWUtIOkhavUGno2YzY9u6fILIJBttfsBendb0/HWB90JG+sOTAvlIMEwyvq9zgy9V9ZQSwyQjR5QzQ=="],
+
+    "@xyflow/system": ["@xyflow/system@0.0.80", "", { "dependencies": { "@types/d3-drag": "^3.0.7", "@types/d3-interpolate": "^3.0.4", "@types/d3-selection": "^3.0.10", "@types/d3-transition": "^3.0.8", "@types/d3-zoom": "^3.0.8", "d3-drag": "^3.0.0", "d3-interpolate": "^3.0.1", "d3-selection": "^3.0.0", "d3-zoom": "^3.0.0" } }, "sha512-ywc3ZqG91brzWrH1WlwMdIX4goOfrpBy6AbLdVSaof/Xx9l138ijIKRExM6EkMro2F+OImGmSiA/WKcXvKVcfA=="],
+
     "abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
@@ -1965,6 +1974,8 @@
 
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
+    "classcat": ["classcat@5.0.5", "", {}, "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w=="],
+
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
 
     "cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
@@ -2049,7 +2060,7 @@
 
     "d3-dispatch": ["d3-dispatch@2.0.0", "", {}, "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA=="],
 
-    "d3-drag": ["d3-drag@2.0.0", "", { "dependencies": { "d3-dispatch": "1 - 2", "d3-selection": "2" } }, "sha512-g9y9WbMnF5uqB9qKqwIIa/921RYWzlUDv9Jl1/yONQwxbOfszAWTCm8u7HOTgJgRDXiRZN56cHT9pd24dmXs8w=="],
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
 
     "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
 
@@ -2057,7 +2068,7 @@
 
     "d3-geo": ["d3-geo@2.0.2", "", { "dependencies": { "d3-array": "^2.5.0" } }, "sha512-8pM1WGMLGFuhq9S+FpPURxic+gKzjluCD/CHTuUF3mXMeiCo0i6R0tO1s4+GArRFde96SLcW/kOFRjoAosPsFA=="],
 
-    "d3-interpolate": ["d3-interpolate@2.0.1", "", { "dependencies": { "d3-color": "1 - 2" } }, "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ=="],
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
 
     "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
 
@@ -3843,7 +3854,7 @@
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
-    "zustand": ["zustand@5.0.14", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g=="],
+    "zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
@@ -3982,6 +3993,8 @@
     "@privy-io/react-auth/lucide-react": ["lucide-react@0.554.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-St+z29uthEJVx0Is7ellNkgTEhaeSoA42I7JjOCBCrc5X6LYMGSv0P/2uS5HDLTExP5tpiqRD2PyUEOS6s9UXA=="],
 
     "@privy-io/react-auth/viem": ["viem@2.52.0", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.27", "ws": "8.20.1" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-py2QPYe9e1f4DmPJCsXF7zHmyZ0PkJrBxdQZ5dvNXvzy3UzWkUn7dNfC0TMeNm6Qv1tKw3b6qXXExpx6L0oMbw=="],
+
+    "@privy-io/react-auth/zustand": ["zustand@5.0.14", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g=="],
 
     "@puppeteer/browsers/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
@@ -4145,6 +4158,10 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@types/d3-zoom/@types/d3-interpolate": ["@types/d3-interpolate@2.0.5", "", { "dependencies": { "@types/d3-color": "^2" } }, "sha512-UINE41RDaUMbulp+bxQMDnhOi51rh5lA2dG+dWZU0UY/IwQiG/u2x8TfnWYU9+xwGdXsJoAvrBYUEQl0r91atg=="],
+
+    "@types/d3-zoom/@types/d3-selection": ["@types/d3-selection@2.0.5", "", {}, "sha512-71BorcY0yXl12S7lvb01JdaN9TpeUHBDb4RRhSq8U8BEkX/nIk5p7Byho+ZRTsx5nYLMpAbY3qt5EhqFzfGJlw=="],
+
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
@@ -4203,6 +4220,12 @@
 
     "@walletconnect/window-metadata/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
+    "@xyflow/system/@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
+    "@xyflow/system/d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "@xyflow/system/d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
     "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "ajv-formats/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
@@ -4237,15 +4260,21 @@
 
     "connect/finalhandler": ["finalhandler@1.1.2", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~1.0.2", "escape-html": "~1.0.3", "on-finished": "~2.3.0", "parseurl": "~1.3.3", "statuses": "~1.5.0", "unpipe": "~1.0.0" } }, "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA=="],
 
-    "d3-scale/d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+    "d3-drag/d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
 
-    "d3-scale/d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+    "d3-scale/d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
 
     "d3-time/d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
 
     "d3-transition/d3-ease": ["d3-ease@2.0.0", "", {}, "sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ=="],
 
+    "d3-transition/d3-interpolate": ["d3-interpolate@2.0.1", "", { "dependencies": { "d3-color": "1 - 2" } }, "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ=="],
+
     "d3-transition/d3-timer": ["d3-timer@2.0.0", "", {}, "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA=="],
+
+    "d3-zoom/d3-drag": ["d3-drag@2.0.0", "", { "dependencies": { "d3-dispatch": "1 - 2", "d3-selection": "2" } }, "sha512-g9y9WbMnF5uqB9qKqwIIa/921RYWzlUDv9Jl1/yONQwxbOfszAWTCm8u7HOTgJgRDXiRZN56cHT9pd24dmXs8w=="],
+
+    "d3-zoom/d3-interpolate": ["d3-interpolate@2.0.1", "", { "dependencies": { "d3-color": "1 - 2" } }, "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ=="],
 
     "duplexify/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
@@ -4397,6 +4426,8 @@
 
     "porto/ox": ["ox@0.9.17", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.9", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-rKAnhzhRU3Xh3hiko+i1ZxywZ55eWQzeS/Q4HRKLx2PqfHOolisZHErSsJVipGlmQKHW5qwOED/GighEw9dbLg=="],
 
+    "porto/zustand": ["zustand@5.0.14", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g=="],
+
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
@@ -4475,11 +4506,7 @@
 
     "unstorage/lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
 
-    "victory-vendor/@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
-
     "victory-vendor/d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
-
-    "victory-vendor/d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
 
     "wagmi/use-sync-external-store": ["use-sync-external-store@1.4.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw=="],
 
@@ -4811,6 +4838,8 @@
 
     "@solana/web3.js/@solana/codecs-numbers/@solana/errors": ["@solana/errors@2.3.0", "", { "dependencies": { "chalk": "^5.4.1", "commander": "^14.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ=="],
 
+    "@types/d3-zoom/@types/d3-interpolate/@types/d3-color": ["@types/d3-color@2.0.6", "", {}, "sha512-tbaFGDmJWHqnenvk3QGSvD3RVwr631BjKRD7Sc7VLRgrdX5mk5hTyoeBL6rXZaeoXzmZwIl1D2HPogEdt1rHBg=="],
+
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
 
     "@wagmi/connectors/@base-org/account/@noble/hashes": ["@noble/hashes@1.4.0", "", {}, "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg=="],
@@ -4958,8 +4987,6 @@
     "unbzip2-stream/buffer/base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
-
-    "victory-vendor/@types/d3-interpolate/@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
 
     "webpack/eslint-scope/estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
 

--- a/workers/jb-memo/package.json
+++ b/workers/jb-memo/package.json
@@ -16,6 +16,7 @@
 	"dependencies": {
 		"@opennextjs/cloudflare": "^1.14.4",
 		"@radix-ui/react-slot": "^1.2.4",
+		"@xyflow/react": "^12.11.3",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"framer-motion": "^12.42.2",

--- a/workers/jb-memo/src/app/[slug]/page.tsx
+++ b/workers/jb-memo/src/app/[slug]/page.tsx
@@ -8,6 +8,33 @@ import rehypeKatex from "rehype-katex";
 import "katex/dist/katex.min.css";
 import { MEMOS, getMemo } from "@/lib/memos";
 import { ThemeToggle } from "@/components/theme-toggle";
+import type { FlowSpec } from "@/components/flow-diagram";
+import { LazyFlowDiagram } from "@/components/flow-diagram-lazy";
+
+/**
+ * Pulls the JSON out of a ```flow fenced block. react-markdown hands `pre` the
+ * `code` element it wraps, so the spec has to be read back off that child.
+ * Returns null for every other fenced block, which then renders as normal code.
+ */
+function readFlowSpec(children: React.ReactNode): FlowSpec | null {
+  const code = Array.isArray(children) ? children[0] : children;
+  if (!code || typeof code !== "object" || !("props" in code)) return null;
+
+  const { className, children: source } = (
+    code as { props: { className?: string; children?: unknown } }
+  ).props;
+  if (!className?.includes("language-flow") || typeof source !== "string") {
+    return null;
+  }
+
+  try {
+    return JSON.parse(source) as FlowSpec;
+  } catch {
+    // A malformed spec should not take the whole memo down — fall back to
+    // rendering it as the code block it literally is.
+    return null;
+  }
+}
 
 export function generateStaticParams() {
   return MEMOS.map((memo) => ({ slug: memo.slug }));
@@ -81,6 +108,12 @@ export default async function MemoPage({
                 <table {...props}>{children}</table>
               </div>
             ),
+            // A ```flow block is a diagram spec, not a code sample.
+            pre: ({ children, ...props }) => {
+              const spec = readFlowSpec(children);
+              if (spec) return <LazyFlowDiagram spec={spec} />;
+              return <pre {...props}>{children}</pre>;
+            },
           }}
         >
           {memo.content}

--- a/workers/jb-memo/src/components/flow-diagram-lazy.tsx
+++ b/workers/jb-memo/src/components/flow-diagram-lazy.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import type { FlowSpec } from "@/components/flow-diagram";
+
+/**
+ * React Flow is ~55 kB. Loading it lazily keeps that weight off memos that
+ * contain no diagram, since every memo shares the same /[slug] route bundle.
+ * ssr: false because the graph measures the DOM to lay itself out.
+ */
+const FlowDiagram = dynamic(
+  () => import("@/components/flow-diagram").then((mod) => mod.FlowDiagram),
+  {
+    ssr: false,
+    loading: () => <div className="not-prose my-8" style={{ height: 80 }} />,
+  },
+);
+
+export function LazyFlowDiagram({ spec }: { spec: FlowSpec }) {
+  return <FlowDiagram spec={spec} />;
+}

--- a/workers/jb-memo/src/components/flow-diagram.tsx
+++ b/workers/jb-memo/src/components/flow-diagram.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import {
+  Handle,
+  MarkerType,
+  Position,
+  ReactFlow,
+  type Edge,
+  type Node,
+  type NodeProps,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import { cn } from "@/lib/utils";
+
+export type FlowNodeData = {
+  /** Primary label — rendered uppercase, in the site's eyebrow treatment */
+  label: string;
+  /** Optional second line, e.g. a measurement or status */
+  note?: string;
+  /** Draws the node as the emphasized step in the path */
+  accent?: boolean;
+};
+
+export type FlowSpec = {
+  /**
+   * Nodes are placed on a grid, not in pixels, so a memo never has to carry
+   * layout math and every diagram on the site lines up the same way.
+   */
+  nodes: {
+    id: string;
+    label: string;
+    note?: string;
+    accent?: boolean;
+    col: number;
+    row?: number;
+  }[];
+  edges: { id?: string; source: string; target: string; label?: string }[];
+};
+
+/**
+ * Connector lines and their arrowheads. --border is too faint to read as a line
+ * on cream, so this is muted-foreground held back. Inline rather than a
+ * Tailwind class: React Flow renders edges into SVG, where border utilities do
+ * not apply.
+ */
+const EDGE_COLOR = "hsl(var(--muted-foreground) / 0.45)";
+
+const NODE_WIDTH = 120;
+const NODE_HEIGHT = 72;
+const COL_GAP = 32;
+const ROW_GAP = 32;
+/**
+ * Just enough room that the accent node's 2px border is not clipped by the
+ * scroll container. The diagram is otherwise flush with the text column.
+ */
+const PAD = 4;
+
+/**
+ * A single step in a flow. Every color is a theme token, so the diagram reads
+ * as cream-and-ink in light mode and warm charcoal in dark mode without a
+ * second palette.
+ */
+function StepNode({ data }: NodeProps) {
+  const { label, note, accent } = data as FlowNodeData;
+
+  return (
+    <div
+      className={cn(
+        "flex h-[72px] w-[120px] flex-col items-center justify-center gap-1 rounded-sm px-2 text-center",
+        accent
+          ? "border-2 border-foreground bg-accent"
+          : "border border-border bg-card",
+      )}
+    >
+      <Handle
+        type="target"
+        position={Position.Left}
+        className="!h-px !w-px !min-w-0 !border-0 !bg-transparent"
+      />
+      <span
+        className={cn(
+          "text-[11px] font-bold uppercase leading-tight tracking-widest",
+          accent ? "text-foreground" : "text-muted-foreground",
+        )}
+      >
+        {label}
+      </span>
+      {note ? (
+        <span
+          className={cn(
+            "text-[10px] font-semibold uppercase tracking-wider",
+            accent ? "text-foreground" : "text-muted-foreground",
+          )}
+        >
+          {note}
+        </span>
+      ) : null}
+      <Handle
+        type="source"
+        position={Position.Right}
+        className="!h-px !w-px !min-w-0 !border-0 !bg-transparent"
+      />
+    </div>
+  );
+}
+
+const nodeTypes = { step: StepNode };
+
+export function FlowDiagram({ spec }: { spec: FlowSpec }) {
+  const columns = Math.max(...spec.nodes.map((node) => node.col)) + 1;
+  const rows = Math.max(...spec.nodes.map((node) => node.row ?? 0)) + 1;
+
+  // The canvas is sized to its contents and rendered at zoom 1. React Flow's
+  // own fitView is deliberately not used: it runs before custom nodes are
+  // measured and no-ops, leaving the graph pinned to the top-left corner.
+  const width = columns * NODE_WIDTH + (columns - 1) * COL_GAP + PAD * 2;
+  const height = rows * NODE_HEIGHT + (rows - 1) * ROW_GAP + PAD * 2;
+
+  const nodes: Node[] = spec.nodes.map((node) => ({
+    id: node.id,
+    type: "step",
+    // Padding lives in the coordinates, not the viewport: React Flow's
+    // viewport transform stays at identity here, so defaultViewport is not a
+    // reliable way to inset the graph.
+    position: {
+      x: PAD + node.col * (NODE_WIDTH + COL_GAP),
+      y: PAD + (node.row ?? 0) * (NODE_HEIGHT + ROW_GAP),
+    },
+    data: { label: node.label, note: node.note, accent: node.accent },
+    draggable: false,
+    selectable: false,
+    connectable: false,
+  }));
+
+  const edges: Edge[] = spec.edges.map((edge) => ({
+    id: edge.id ?? `${edge.source}-${edge.target}`,
+    source: edge.source,
+    target: edge.target,
+    label: edge.label,
+    type: "smoothstep",
+    style: { stroke: EDGE_COLOR, strokeWidth: 1 },
+    // Open chevron rather than a filled head — lighter, and it matches the
+    // hairline weight of the connectors.
+    markerEnd: {
+      type: MarkerType.Arrow,
+      width: 18,
+      height: 18,
+      strokeWidth: 1.5,
+      color: EDGE_COLOR,
+    },
+    labelStyle: {
+      fill: "hsl(var(--muted-foreground))",
+      fontSize: 10,
+      textTransform: "uppercase",
+      letterSpacing: "0.1em",
+      fontWeight: 600,
+    },
+    labelBgStyle: { fill: "hsl(var(--background))" },
+  }));
+
+  return (
+    // Wide diagrams scroll sideways rather than shrink, matching how this site
+    // already handles wide tables.
+    <div className="not-prose my-8 overflow-x-auto">
+      <div style={{ width, height }}>
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          nodeTypes={nodeTypes}
+          // A memo is a reading surface: the diagram must never capture the
+          // page scroll or drift out of frame under a stray drag.
+          nodesDraggable={false}
+          nodesConnectable={false}
+          elementsSelectable={false}
+          edgesReconnectable={false}
+          panOnDrag={false}
+          panOnScroll={false}
+          zoomOnScroll={false}
+          zoomOnPinch={false}
+          zoomOnDoubleClick={false}
+          preventScrolling={false}
+          proOptions={{ hideAttribution: true }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/workers/jb-memo/src/content/validator.md
+++ b/workers/jb-memo/src/content/validator.md
@@ -1,0 +1,47 @@
+# Hyperliquid Full Validator: Strategy Overview
+
+## Strategy Overview
+
+Custom latency-optimized execution on HIP-3 markets (primarily tokenized equities / indices via Bloxwap). Focus is on reducing end-to-end order-to-fill latency and capturing the fee stack more efficiently than standard retail or semi-pro flows.
+
+## Execution Path
+
+```flow
+{
+  "nodes": [
+    { "id": "order", "label": "Order", "col": 0 },
+    { "id": "routing", "label": "Node Routing", "col": 1 },
+    { "id": "validator", "label": "Full Validator", "note": "~500 ms", "accent": true, "col": 2 },
+    { "id": "hypercore", "label": "HyperCore", "col": 3 }
+  ],
+  "edges": [
+    { "source": "order", "target": "routing" },
+    { "source": "routing", "target": "validator" },
+    { "source": "validator", "target": "hypercore" }
+  ]
+}
+```
+
+## Key Technical Edges
+
+* **HIP-3 path optimization** — measured latency cut from ~5,000 ms → ~500 ms (90%+ reduction) via node-level routing, local book reconstruction, and priority-aware submission.
+* **Fee stack** — 47% lower taker + 100% maker reduction relative to baseline, plus the extra ~20% staking discount from the 10k HYPE.
+* **Execution layer** — sits on HyperCore order books with independent margining per HIP-3 DEX; no custody of the staked HYPE beyond the standard staking account mechanics.
+
+| Metric | Baseline | With validator path |
+| --- | ---: | ---: |
+| Order-to-fill latency | ~5,000 ms | ~500 ms |
+| Taker fees | baseline | 47% lower |
+| Maker fees | baseline | 100% reduction |
+| Staking discount (10k HYPE) | — | ~20% |
+
+## Duration & Terms
+
+* Initial test window: 2–4 weeks.
+* Can extend if the edge holds; otherwise we unwind cleanly.
+* HYPE stays in a staking account under standard Hyperliquid rules (7-day unstaking queue on exit). No lock beyond that.
+* Position sizing and risk limits are conservative; full transparency on fills and PnL available.
+
+## Next Steps
+
+Happy to hop on a quick call or share more granular latency / fee data if useful. Let me know what would help you check internally.

--- a/workers/jb-memo/src/lib/memos.ts
+++ b/workers/jb-memo/src/lib/memos.ts
@@ -1,4 +1,5 @@
 import dexos from "@/content/dexos.md";
+import validator from "@/content/validator.md";
 
 export type Author = {
   name: string;
@@ -40,6 +41,31 @@ export const MEMOS: Memo[] = [
         { value: "188.6M", label: "orders/s per link" },
         { value: "16", label: "global validators" },
         { value: "24/7", label: "continuous markets" },
+      ],
+    },
+    authors: [
+      {
+        name: "Joe Blau",
+        companies: "Uber • Amazon • Virginia Tech",
+        role: "Design Engineer",
+      },
+      { name: "David Blau", companies: "Jump • MIT", role: "Quant Engineer" },
+    ],
+  },
+  {
+    slug: "validator",
+    eyebrow: "Validator",
+    title: "Hyperliquid Full Validator — Strategy Overview",
+    description:
+      "Latency-optimized execution on HIP-3 markets: order-to-fill cut from ~5,000 ms to ~500 ms, with a materially cheaper fee stack.",
+    content: validator,
+    og: {
+      headline: "Hyperliquid Full Validator",
+      subhead: "Latency-optimized execution on HIP-3 markets",
+      stats: [
+        { value: "~500ms", label: "order-to-fill latency" },
+        { value: "47%", label: "lower taker fees" },
+        { value: "2–4wk", label: "initial test window" },
       ],
     },
     authors: [


### PR DESCRIPTION
Adds the second memo at `/validator` — a Hyperliquid full validator strategy overview — and the diagram support it needed.

## Diagrams

Authored inline in the markdown as a ```flow block, so placement stays with the content:

    ```flow
    { "nodes": [{ "id": "order", "label": "Order", "col": 0 }, ...],
      "edges": [{ "source": "order", "target": "routing" }] }
    ```

Nodes take grid `col`/`row` rather than pixels, so every diagram on the site lines up the same way and memos carry no layout math. Styling comes entirely from the existing theme tokens — cream-and-ink in light mode, warm charcoal in dark — with no second palette. Labels reuse the uppercase eyebrow treatment already used in the header and index.

## Implementation notes

- **React Flow's viewport is not used.** Both `fitView` and `defaultViewport` no-op here: `nodesInitialized` never becomes true for custom nodes, which left the graph pinned to the top-left corner. The canvas size and node coordinates are computed directly and rendered at zoom 1. If pan/zoom is ever wanted, that root cause needs solving first.
- **Lazy loaded.** React Flow is ~55 kB, and every memo shares the `/[slug]` route bundle, so the component is dynamically imported. Confirmed via the network log that it does not load on `/dexos`.
- **Attribution hidden.** `proOptions.hideAttribution` is set at the author's explicit request; note that xyflow licenses this option to Pro subscribers.

## Verification

Build compiles clean (only the pre-existing `skiper26.tsx` unused-var warning) and prerenders `/validator` and `/api/og/validator`. In a real browser against the production build:

- Light and dark both render correctly and follow the theme toggle
- Mobile scrolls sideways (584 px of content in a 327 px column), matching how the site already handles wide tables
- No new console errors

There is one **pre-existing** error unrelated to this PR: `<circle> attribute r: Expected length, "undefined"` from `theme-toggle.tsx`, which also fires on `/dexos` where there is no diagram. Left alone here.

The second commit is an unrelated one-line chore to gitignore `.gstack/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)